### PR TITLE
Append underscores to temporary variable prefixes

### DIFF
--- a/src/ninetoothed/jit.py
+++ b/src/ninetoothed/jit.py
@@ -851,7 +851,7 @@ class _Inliner(ast.NodeTransformer):
             return names
 
         def _make_temporary():
-            prefix = naming.auto_generate(f"temporary_{self._count}")
+            prefix = f"{naming.auto_generate(f'temporary_{self._count}')}_"
             self._count += 1
 
             return prefix


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/voltjia/ninetoothed
configfile: pyproject.toml
plugins: cov-6.0.0
collected 17 items

tests/test_add.py .                                                      [  5%]
tests/test_addmm.py .F                                                   [ 17%]
tests/test_attention.py .                                                [ 23%]
tests/test_conv2d.py .                                                   [ 29%]
tests/test_matmul.py ..                                                  [ 41%]
tests/test_max_pool2d.py ..                                              [ 52%]
tests/test_naming.py .......                                             [ 94%]
tests/test_softmax.py .                                                  [100%]

=================================== FAILURES ===================================
______________________________ TestCUDA.test_fp8 _______________________________

self = <tests.test_addmm.TestCUDA object at 0x7f261f4f3650>

    @skip_if_float8_e5m2_not_supported
    def test_fp8(self):
        input = type(self).input.to(torch.float8_e5m2)
        mat1 = type(self).mat1.to(torch.float8_e5m2)
        mat2 = type(self).mat2.T.to(torch.float8_e5m2)
        beta = type(self).beta
        alpha = type(self).alpha
    
        # TODO: The current application function inlining feature
        # causes some precision issues. Consider reducing `atol` and
        # `rtol` of this test in the future.
>       assert torch.allclose(
            addmm(input, mat1, mat2, beta=beta, alpha=alpha),
            torch.addmm(
                input.to(torch.float16),
                mat1.to(torch.float16),
                mat2.to(torch.float16),
                beta=beta,
                alpha=alpha,
            ),
            atol=0.5,
            rtol=0.5,
        )
E       AssertionError: assert False
E        +  where False = <built-in method allclose of type object at 0x7f270921df60>(tensor([[ 12.9688,   2.6387,  -4.3633,  ...,   7.7461,  10.1328,  13.4766],\n        [  4.8008,  23.3906,  12.6094,  .....      [ 14.3125,  17.1719,  -4.0508,  ...,  -9.4219,  -1.4580,   1.1299]],\n       device='cuda:0', dtype=torch.float16), tensor([[ 12.9609,   2.6387,  -4.3633,  ...,   7.7500,  10.1328,  13.4766],\n        [  4.8008,  23.3906,  12.6172,  .....      [ 14.3125,  17.1719,  -4.0547,  ...,  -9.4219,  -1.4609,   1.1309]],\n       device='cuda:0', dtype=torch.float16), atol=0.5, rtol=0.5)
E        +    where <built-in method allclose of type object at 0x7f270921df60> = torch.allclose
E        +    and   tensor([[ 12.9688,   2.6387,  -4.3633,  ...,   7.7461,  10.1328,  13.4766],\n        [  4.8008,  23.3906,  12.6094,  .....      [ 14.3125,  17.1719,  -4.0508,  ...,  -9.4219,  -1.4580,   1.1299]],\n       device='cuda:0', dtype=torch.float16) = addmm(tensor([[-0.8750, -0.4375, -2.5000,  ..., -0.3125,  1.5000,  0.6250],\n        [-1.0000, -0.3750,  1.0000,  ..., -1.250...        [ 0.4375,  1.5000, -0.1094,  ...,  1.7500, -1.0000,  0.3750]],\n       device='cuda:0', dtype=torch.float8_e5m2), tensor([[ 2.5000e+00, -7.5000e-01, -5.0000e-01,  ..., -2.5000e+00,\n         -9.3750e-02, -1.0000e+00],\n        [ 1.000...000e+00,  2.4414e-03,  ...,  7.5000e-01,\n          1.5000e+00, -2.5000e-01]], device='cuda:0', dtype=torch.float8_e5m2), tensor([[-0.3750,  0.8750, -1.0000,  ..., -2.0000, -1.7500,  0.1562],\n        [ 0.6250, -0.6250,  0.3750,  ...,  0.750...        [-0.1094,  0.2500, -0.8750,  ..., -0.8750, -0.6250, -0.3750]],\n       device='cuda:0', dtype=torch.float8_e5m2), beta=0.789961716734192, alpha=0.5060792074943063)
E        +    and   tensor([[ 12.9609,   2.6387,  -4.3633,  ...,   7.7500,  10.1328,  13.4766],\n        [  4.8008,  23.3906,  12.6172,  .....      [ 14.3125,  17.1719,  -4.0547,  ...,  -9.4219,  -1.4609,   1.1309]],\n       device='cuda:0', dtype=torch.float16) = <built-in method addmm of type object at 0x7f270921df60>(tensor([[-0.8750, -0.4375, -2.5000,  ..., -0.3125,  1.5000,  0.6250],\n        [-1.0000, -0.3750,  1.0000,  ..., -1.250...0],\n        [ 0.4375,  1.5000, -0.1094,  ...,  1.7500, -1.0000,  0.3750]],\n       device='cuda:0', dtype=torch.float16), tensor([[ 2.5000e+00, -7.5000e-01, -5.0000e-01,  ..., -2.5000e+00,\n         -9.3750e-02, -1.0000e+00],\n        [ 1.000...-1.0000e+00,  2.4414e-03,  ...,  7.5000e-01,\n          1.5000e+00, -2.5000e-01]], device='cuda:0', dtype=torch.float16), tensor([[-0.3750,  0.8750, -1.0000,  ..., -2.0000, -1.7500,  0.1562],\n        [ 0.6250, -0.6250,  0.3750,  ...,  0.750...0],\n        [-0.1094,  0.2500, -0.8750,  ..., -0.8750, -0.6250, -0.3750]],\n       device='cuda:0', dtype=torch.float16), beta=0.789961716734192, alpha=0.5060792074943063)
E        +      where <built-in method addmm of type object at 0x7f270921df60> = torch.addmm
E        +      and   tensor([[-0.8750, -0.4375, -2.5000,  ..., -0.3125,  1.5000,  0.6250],\n        [-1.0000, -0.3750,  1.0000,  ..., -1.250...0],\n        [ 0.4375,  1.5000, -0.1094,  ...,  1.7500, -1.0000,  0.3750]],\n       device='cuda:0', dtype=torch.float16) = <built-in method to of Tensor object at 0x7f261df89d10>(torch.float16)
E        +        where <built-in method to of Tensor object at 0x7f261df89d10> = tensor([[-0.8750, -0.4375, -2.5000,  ..., -0.3125,  1.5000,  0.6250],\n        [-1.0000, -0.3750,  1.0000,  ..., -1.250...        [ 0.4375,  1.5000, -0.1094,  ...,  1.7500, -1.0000,  0.3750]],\n       device='cuda:0', dtype=torch.float8_e5m2).to
E        +        and   torch.float16 = torch.float16
E        +      and   tensor([[ 2.5000e+00, -7.5000e-01, -5.0000e-01,  ..., -2.5000e+00,\n         -9.3750e-02, -1.0000e+00],\n        [ 1.000...-1.0000e+00,  2.4414e-03,  ...,  7.5000e-01,\n          1.5000e+00, -2.5000e-01]], device='cuda:0', dtype=torch.float16) = <built-in method to of Tensor object at 0x7f261df89db0>(torch.float16)
E        +        where <built-in method to of Tensor object at 0x7f261df89db0> = tensor([[ 2.5000e+00, -7.5000e-01, -5.0000e-01,  ..., -2.5000e+00,\n         -9.3750e-02, -1.0000e+00],\n        [ 1.000...000e+00,  2.4414e-03,  ...,  7.5000e-01,\n          1.5000e+00, -2.5000e-01]], device='cuda:0', dtype=torch.float8_e5m2).to
E        +        and   torch.float16 = torch.float16
E        +      and   tensor([[-0.3750,  0.8750, -1.0000,  ..., -2.0000, -1.7500,  0.1562],\n        [ 0.6250, -0.6250,  0.3750,  ...,  0.750...0],\n        [-0.1094,  0.2500, -0.8750,  ..., -0.8750, -0.6250, -0.3750]],\n       device='cuda:0', dtype=torch.float16) = <built-in method to of Tensor object at 0x7f26272c8be0>(torch.float16)
E        +        where <built-in method to of Tensor object at 0x7f26272c8be0> = tensor([[-0.3750,  0.8750, -1.0000,  ..., -2.0000, -1.7500,  0.1562],\n        [ 0.6250, -0.6250,  0.3750,  ...,  0.750...        [-0.1094,  0.2500, -0.8750,  ..., -0.8750, -0.6250, -0.3750]],\n       device='cuda:0', dtype=torch.float8_e5m2).to
E        +        and   torch.float16 = torch.float16

tests/test_addmm.py:80: AssertionError
=========================== short test summary info ============================
FAILED tests/test_addmm.py::TestCUDA::test_fp8 - AssertionError: assert False
=================== 1 failed, 16 passed in 229.72s (0:03:49) ===================
```

The failure above is most likely caused by #37 and should not affect the merge of this pull request.