### PR TITLE
Add persistent caching

### DIFF
--- a/src/ninetoothed/jit.py
+++ b/src/ninetoothed/jit.py
@@ -184,6 +184,9 @@ class CodeGenerator(ast.NodeTransformer):
             if naming.is_constexpr(name)
         }
 
+        non_meta_names = sorted(non_meta_names)
+        meta_names = sorted(meta_names)
+
         node.args = [
             ast.arg(arg=name)
             if not naming.is_constexpr(name)


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/voltjia/ninetoothed
configfile: pyproject.toml
plugins: cov-6.0.0
collected 17 items

tests/test_add.py .                                                      [  5%]
tests/test_addmm.py ..                                                   [ 17%]
tests/test_attention.py .                                                [ 23%]
tests/test_conv2d.py .                                                   [ 29%]
tests/test_matmul.py ..                                                  [ 41%]
tests/test_max_pool2d.py ..                                              [ 52%]
tests/test_naming.py .......                                             [ 94%]
tests/test_softmax.py .                                                  [100%]

======================== 17 passed in 161.56s (0:02:41) ========================
```
