### PR TITLE
Ensure newline at end of generated source code

### DIFF
--- a/src/ninetoothed/generation.py
+++ b/src/ninetoothed/generation.py
@@ -82,6 +82,7 @@ class CodeGenerator(ast.NodeTransformer):
         dependencies = _find_dependencies(func)
         source = "\n\n".join((unparsed, dependencies)).strip()
         source = source.replace(func.__name__, kernel_name)
+        source += "\n"
 
         if prettify:
             for original, simplified in name_collector.simplified_names.items():


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/voltjia/ninetoothed
configfile: pyproject.toml
plugins: cov-5.0.0
collected 17 items

tests/test_add.py .                                                      [  5%]
tests/test_addmm.py ..                                                   [ 17%]
tests/test_attention.py .                                                [ 23%]
tests/test_conv2d.py .                                                   [ 29%]
tests/test_matmul.py ..                                                  [ 41%]
tests/test_max_pool2d.py ..                                              [ 52%]
tests/test_naming.py .......                                             [ 94%]
tests/test_softmax.py .                                                  [100%]

============================= 17 passed in 30.44s ==============================
```
