### PR TITLE
Fix `new_stride` computation in `Tensor.tile`

### DIFF
--- a/src/ninetoothed/tensor.py
+++ b/src/ninetoothed/tensor.py
@@ -146,7 +146,7 @@ class Tensor:
             )
             outer_shape.append(new_size)
 
-            new_stride = self_stride * stride // spacing
+            new_stride = self_stride * stride
             outer_strides.append(new_stride)
 
             inner_shape.append(tile_size)


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/voltjia/ninetoothed
configfile: pyproject.toml
plugins: cov-5.0.0
collected 19 items

tests/test_add.py .                                                      [  5%]
tests/test_addmm.py ..                                                   [ 15%]
tests/test_aot.py ..                                                     [ 26%]
tests/test_attention.py .                                                [ 31%]
tests/test_conv2d.py .                                                   [ 36%]
tests/test_matmul.py ..                                                  [ 47%]
tests/test_max_pool2d.py ..                                              [ 57%]
tests/test_naming.py .......                                             [ 94%]
tests/test_softmax.py .                                                  [100%]

============================= 19 passed in 35.53s ==============================
```
