### PR TITLE
Fix typo in `test_addmm.py`

### DIFF
--- a/tests/test_addmm.py
+++ b/tests/test_addmm.py
@@ -12,11 +12,11 @@ from tests.skippers import skip_if_cuda_not_available, skip_if_float8_e5m2_not_s
 def arrangement(input, mat1, mat2, beta, alpha, output):
     _, _, input_arranged = matmul.arrangement(mat1, mat2, input)
 
-    mat1_arrange, mat2_arranged, output_arranged = matmul.arrangement(
+    mat1_arranged, mat2_arranged, output_arranged = matmul.arrangement(
         mat1, mat2, output
     )
 
-    return input_arranged, mat1_arrange, mat2_arranged, beta, alpha, output_arranged
+    return input_arranged, mat1_arranged, mat2_arranged, beta, alpha, output_arranged
 
 
 def application(input, mat1, mat2, beta, alpha, output):


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/voltjia/ninetoothed
configfile: pyproject.toml
plugins: cov-6.0.0
collected 19 items

tests/test_add.py .                                                      [  5%]
tests/test_addmm.py ..                                                   [ 15%]
tests/test_aot.py ..                                                     [ 26%]
tests/test_attention.py .                                                [ 31%]
tests/test_conv2d.py .                                                   [ 36%]
tests/test_matmul.py ..                                                  [ 47%]
tests/test_max_pool2d.py ..                                              [ 57%]
tests/test_naming.py .......                                             [ 94%]
tests/test_softmax.py .                                                  [100%]

============================= 19 passed in 49.39s ==============================
```
