### PR TITLE
Support libdevice

### DIFF
--- a/src/ninetoothed/generation.py
+++ b/src/ninetoothed/generation.py
@@ -19,6 +19,7 @@ import uuid
 import sympy
 import triton
 import triton.language as tl
+from triton.language.extra import libdevice
 
 import ninetoothed.naming as naming
 from ninetoothed.cudaifier import Cudaifier
@@ -978,6 +979,9 @@ class _Inliner(ast.NodeTransformer):
         func_def = _find_function_definition(source)
 
         if func_def is None:
+            return None, []
+
+        if inspect.getmodule(func) is libdevice:
             return None, []
 
         collector = _ImportCollector()

--- a/src/ninetoothed/language.py
+++ b/src/ninetoothed/language.py
@@ -1,6 +1,10 @@
 import ast
 
+from triton.language.extra import libdevice
+
 from ninetoothed.symbol import Symbol
+
+__all__ = ["libdevice"]
 
 LANGUAGE = "ninetoothed.language"
 

--- a/tests/test_pow.py
+++ b/tests/test_pow.py
@@ -1,0 +1,50 @@
+import torch
+from triton.language.extra import libdevice
+
+import ninetoothed
+from ninetoothed import Tensor, block_size
+from tests.skippers import skip_if_cuda_not_available
+
+
+def arrangement(input, exponent, output, BLOCK_SIZE=block_size()):
+    return (
+        input.tile((BLOCK_SIZE,)),
+        exponent.tile((BLOCK_SIZE,)),
+        output.tile((BLOCK_SIZE,)),
+    )
+
+
+def application(input, exponent, output):
+    output = libdevice.pow(input, exponent)  # noqa: F841
+
+
+def pow(input, exponent):
+    output = torch.empty_like(input)
+
+    pow_kernel = ninetoothed.make(
+        arrangement, application, (Tensor(1), Tensor(1), Tensor(1))
+    )
+
+    pow_kernel(input, exponent, output)
+
+    return output
+
+
+@skip_if_cuda_not_available
+class TestCUDA:
+    @classmethod
+    def setup_class(cls):
+        torch.manual_seed(0)
+
+        size = 44925
+
+        cls.input = torch.randn(size, device="cuda")
+        cls.exponent = torch.randn(size, device="cuda")
+
+    def test_fp32(self):
+        input = type(self).input.to(torch.float32)
+        exponent = type(self).exponent.to(torch.float32)
+
+        assert torch.allclose(
+            pow(input, exponent), torch.pow(input, exponent), equal_nan=True
+        )

--- a/tests/test_pow.py
+++ b/tests/test_pow.py
@@ -1,8 +1,8 @@
 import torch
-from triton.language.extra import libdevice
 
 import ninetoothed
 from ninetoothed import Tensor, block_size
+from ninetoothed.language import libdevice
 from tests.skippers import skip_if_cuda_not_available
 
 


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/voltjia/ninetoothed
configfile: pyproject.toml
plugins: cov-6.0.0
collected 20 items

tests/test_add.py .                                                      [  5%]
tests/test_addmm.py ..                                                   [ 15%]
tests/test_aot.py ..                                                     [ 25%]
tests/test_attention.py .                                                [ 30%]
tests/test_conv2d.py .                                                   [ 35%]
tests/test_matmul.py ..                                                  [ 45%]
tests/test_max_pool2d.py ..                                              [ 55%]
tests/test_naming.py .......                                             [ 90%]
tests/test_pow.py .                                                      [ 95%]
tests/test_softmax.py .                                                  [100%]

============================= 20 passed in 43.93s ==============================
```
