### PR TITLE
Support accessing `dtype` in application functions

### DIFF
--- a/src/ninetoothed/generation.py
+++ b/src/ninetoothed/generation.py
@@ -254,6 +254,9 @@ class CodeGenerator(ast.NodeTransformer):
         if isinstance(value, Tensor):
             attr = getattr(value, node.attr)
 
+            if node.attr == "dtype" and attr is None:
+                return Symbol(f"{value.source.pointer_string()}.type.element_ty").node
+
             if isinstance(attr, Tensor):
                 return attr
 

--- a/src/ninetoothed/generation.py
+++ b/src/ninetoothed/generation.py
@@ -243,13 +243,21 @@ class CodeGenerator(ast.NodeTransformer):
         return node
 
     def visit_Attribute(self, node):
-        if self._in_context(node.value):
-            value = self._context[node.value.id]
+        value = node.value
 
-            if isinstance(value, Tensor):
-                inner = value.dtype
+        if isinstance(value, ast.Attribute):
+            value = self.visit_Attribute(value)
 
-                return Symbol(getattr(inner, node.attr)).node
+        if self._in_context(value):
+            value = self._context[value.id].dtype
+
+        if isinstance(value, Tensor):
+            attr = getattr(value, node.attr)
+
+            if isinstance(attr, Tensor):
+                return attr
+
+            return Symbol(attr).node
 
         self.generic_visit(node)
 


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/voltjia/ninetoothed
configfile: pyproject.toml
plugins: cov-6.0.0
collected 20 items

tests/test_add.py .                                                      [  5%]
tests/test_addmm.py ..                                                   [ 15%]
tests/test_aot.py ..                                                     [ 25%]
tests/test_attention.py .                                                [ 30%]
tests/test_conv2d.py .                                                   [ 35%]
tests/test_matmul.py ..                                                  [ 45%]
tests/test_max_pool2d.py ..                                              [ 55%]
tests/test_naming.py .......                                             [ 90%]
tests/test_pow.py .                                                      [ 95%]
tests/test_softmax.py .                                                  [100%]

============================= 20 passed in 43.78s ==============================
```
