### PR TITLE
Broaden AOT support

### DIFF
--- a/src/ninetoothed/aot.py
+++ b/src/ninetoothed/aot.py
@@ -105,6 +105,10 @@ typedef struct {
     uint64_t *shape;
     int64_t *strides;
 } NineToothedTensor;
+
+typedef void *NineToothedStream;
+
+typedef int NineToothedResult;
 """
 
 _HEADER_PATH = CACHE_DIR / "ninetoothed.h"
@@ -135,9 +139,9 @@ class _Unparser:
         return f"return {self._generic_unparse(call)};"
 
     def _unparse_FunctionDef(self, node):
-        params = ["CUstream stream"]
+        params = ["NineToothedStream stream"]
         params += [f"NineToothedTensor {arg.arg}" for arg in node.args.args]
-        header = f"CUresult {node.name}({', '.join(params)})"
+        header = f"NineToothedResult {node.name}({', '.join(params)})"
 
         self.header = header
 

--- a/src/ninetoothed/aot.py
+++ b/src/ninetoothed/aot.py
@@ -31,7 +31,7 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
 
     _HEADER_PATH.parent.mkdir(exist_ok=True)
 
-    if not _HEADER_PATH.exists():
+    if not _HEADER_PATH.exists() or _HEADER_PATH.read_text() != _HEADER_CONTENT:
         _HEADER_PATH.write_text(_HEADER_CONTENT)
 
     code_generator = CodeGenerator()

--- a/src/ninetoothed/aot.py
+++ b/src/ninetoothed/aot.py
@@ -101,7 +101,7 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
 _HEADER_CONTENT = """#include <stdint.h>
 
 typedef struct {
-    uintptr_t data;
+    void *data;
     uint64_t *shape;
     int64_t *strides;
 } NineToothedTensor;

--- a/src/ninetoothed/aot.py
+++ b/src/ninetoothed/aot.py
@@ -98,7 +98,10 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
     return output_contents
 
 
-_HEADER_CONTENT = """#include <stdint.h>
+_HEADER_CONTENT = """#ifndef NINETOOTHED_H
+#define NINETOOTHED_H
+
+#include <stdint.h>
 
 typedef struct {
     void *data;
@@ -109,6 +112,8 @@ typedef struct {
 typedef void *NineToothedStream;
 
 typedef int NineToothedResult;
+
+#endif // NINETOOTHED_H
 """
 
 _HEADER_PATH = CACHE_DIR / "ninetoothed.h"

--- a/src/ninetoothed/aot.py
+++ b/src/ninetoothed/aot.py
@@ -91,7 +91,7 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
 
     c_header_file_name = f"{kernel_name}.{signature_hash}.h"
     c_header_file = output_contents[c_header_file_name]
-    c_header_file = f"{c_header_file}\n{unparser.header};\n"
+    c_header_file = f'{c_header_file}\n#ifdef __cplusplus\nextern "C" {unparser.header};\n#else\n{unparser.header};\n#endif\n'
     c_header_file = c_header_file.replace("<stdint.h>", f'"{_HEADER_PATH}"')
     output_contents[c_header_file_name] = c_header_file
 


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/voltjia/ninetoothed
configfile: pyproject.toml
plugins: cov-6.0.0
collected 21 items

tests/test_add.py .                                                      [  4%]
tests/test_addmm.py ..                                                   [ 14%]
tests/test_aot.py ..                                                     [ 23%]
tests/test_attention.py ..                                               [ 33%]
tests/test_conv2d.py .                                                   [ 38%]
tests/test_matmul.py ..                                                  [ 47%]
tests/test_max_pool2d.py ..                                              [ 57%]
tests/test_naming.py .......                                             [ 90%]
tests/test_pow.py .                                                      [ 95%]
tests/test_softmax.py .                                                  [100%]

============================= 21 passed in 42.19s ==============================
```
