### PR TITLE
Add support for the `offsets` method

### DIFF
--- a/tests/test_dropout.py
+++ b/tests/test_dropout.py
@@ -1,0 +1,54 @@
+import random
+
+import torch
+
+import ninetoothed
+import ninetoothed.language as ntl
+from ninetoothed import Tensor, block_size
+from tests.skippers import skip_if_cuda_not_available
+
+
+def arrangement(input, p, seed, output, BLOCK_SIZE=block_size()):
+    return input.tile((BLOCK_SIZE,)), p, seed, output.tile((BLOCK_SIZE,))
+
+
+def application(input, p, seed, output):
+    output = ntl.where(ntl.rand(seed, input.offsets()) > p, input / (1 - p), 0)  # noqa: F841
+
+
+def dropout(input, p=0.5):
+    seed = random.randrange(0, 2**31)
+    output = torch.empty_like(input)
+
+    tensors = (Tensor(1), Tensor(0), Tensor(0), Tensor(1))
+    dropout_kernel = ninetoothed.make(arrangement, application, tensors)
+
+    dropout_kernel(input, p, seed, output)
+
+    return output
+
+
+@skip_if_cuda_not_available
+class TestCUDA:
+    @classmethod
+    def setup_class(cls):
+        random.seed(0)
+        torch.manual_seed(0)
+
+        size = 349
+
+        cls.input = torch.randn(size, device="cuda")
+
+    def test_fp16(self):
+        input = type(self).input.to(torch.float16)
+        p = 0.3
+
+        output = dropout(input, p=p)
+
+        assert input.shape == output.shape
+
+        non_zero_ratio = output.nonzero().numel() / input.numel()
+
+        assert abs(non_zero_ratio - (1 - p)) < 0.05
+
+        assert torch.allclose(output[output != 0], input[output != 0] / (1 - p))


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/voltjia/ninetoothed
configfile: pyproject.toml
plugins: cov-6.0.0
collected 24 items

tests/test_add.py .                                                      [  4%]
tests/test_addmm.py ..                                                   [ 12%]
tests/test_aot.py ..                                                     [ 20%]
tests/test_attention.py ....                                             [ 37%]
tests/test_conv2d.py .                                                   [ 41%]
tests/test_dropout.py .                                                  [ 45%]
tests/test_matmul.py ..                                                  [ 54%]
tests/test_max_pool2d.py ..                                              [ 62%]
tests/test_naming.py .......                                             [ 91%]
tests/test_pow.py .                                                      [ 95%]
tests/test_softmax.py .                                                  [100%]

======================== 24 passed in 260.96s (0:04:20) ========================
```
