### PR TITLE
Handle scalars in AOT compilation

### DIFF
--- a/tests/test_addmm.py
+++ b/tests/test_addmm.py
@@ -9,11 +9,23 @@ from ninetoothed import Tensor
 from tests.skippers import skip_if_cuda_not_available, skip_if_float8_e5m2_not_supported
 
 
-def arrangement(input, mat1, mat2, beta, alpha, output):
-    _, _, input_arranged = matmul.arrangement(mat1, mat2, input)
+def arrangement(
+    input,
+    mat1,
+    mat2,
+    beta,
+    alpha,
+    output,
+    BLOCK_SIZE_M=matmul.BLOCK_SIZE_M,
+    BLOCK_SIZE_N=matmul.BLOCK_SIZE_N,
+    BLOCK_SIZE_K=matmul.BLOCK_SIZE_K,
+):
+    _, _, input_arranged = matmul.arrangement(
+        mat1, mat2, input, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K
+    )
 
     mat1_arranged, mat2_arranged, output_arranged = matmul.arrangement(
-        mat1, mat2, output
+        mat1, mat2, output, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K
     )
 
     return input_arranged, mat1_arranged, mat2_arranged, beta, alpha, output_arranged


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/huangjiacheng/ninetoothed
configfile: pyproject.toml
plugins: cov-6.0.0
collected 25 items

tests/test_add.py .                                                      [  4%]
tests/test_addmm.py ..                                                   [ 12%]
tests/test_aot.py ...                                                    [ 24%]
tests/test_attention.py ....                                             [ 40%]
tests/test_conv2d.py .                                                   [ 44%]
tests/test_dropout.py .                                                  [ 48%]
tests/test_matmul.py ..                                                  [ 56%]
tests/test_max_pool2d.py ..                                              [ 64%]
tests/test_naming.py .......                                             [ 92%]
tests/test_pow.py .                                                      [ 96%]
tests/test_softmax.py .                                                  [100%]

======================== 25 passed in 344.41s (0:05:44) ========================
```
