### PR TITLE
Add support for constexpr zero-dimensional tensors

### DIFF
--- a/src/ninetoothed/generation.py
+++ b/src/ninetoothed/generation.py
@@ -500,16 +500,19 @@ class CodeGenerator(ast.NodeTransformer):
             naming.remove_prefixes(param) for param in next_power_of_2_params
         ]
 
+        arg_names = [naming.remove_prefixes(arg.source.name) for arg in self._args]
+
+        arg_names += [
+            param
+            for param in non_next_power_of_2_constexpr_params_without_prefixes
+            if not Tensor.size_pattern().fullmatch(param) and param not in arg_names
+        ]
+
         launch = ast.FunctionDef(
             name=self.launch_func_name,
             args=ast.arguments(
                 posonlyargs=[],
-                args=[ast.arg(arg=arg.source.name) for arg in self._args]
-                + [
-                    ast.arg(arg=param)
-                    for param in non_next_power_of_2_constexpr_params_without_prefixes
-                    if not Tensor.size_pattern().fullmatch(param)
-                ],
+                args=[ast.arg(arg=name) for name in arg_names],
                 kwonlyargs=[],
                 defaults=[],
             ),

--- a/src/ninetoothed/tensor.py
+++ b/src/ninetoothed/tensor.py
@@ -32,6 +32,7 @@ class Tensor:
         strides=None,
         other=None,
         shape_options=None,
+        constexpr=None,
         name=None,
         source=None,
         source_dims=None,
@@ -73,6 +74,16 @@ class Tensor:
                 self.strides = self._calculate_default_strides(shape)
 
         self.other = other
+
+        if constexpr and self.ndim != 0:
+            raise ValueError(
+                "`constexpr` can only be set for zero-dimensional tensors."
+            )
+
+        self.constexpr = constexpr
+
+        if self.constexpr:
+            self.name = naming.make_constexpr(self.name)
 
         if source is not None:
             self.source = source


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/huangjiacheng/ninetoothed
configfile: pyproject.toml
plugins: cov-6.0.0
collected 25 items

tests/test_add.py .                                                      [  4%]
tests/test_addmm.py ..                                                   [ 12%]
tests/test_aot.py ...                                                    [ 24%]
tests/test_attention.py ....                                             [ 40%]
tests/test_conv2d.py .                                                   [ 44%]
tests/test_dropout.py .                                                  [ 48%]
tests/test_matmul.py ..                                                  [ 56%]
tests/test_max_pool2d.py ..                                              [ 64%]
tests/test_naming.py .......                                             [ 92%]
tests/test_pow.py .                                                      [ 96%]
tests/test_softmax.py .                                                  [100%]

======================== 25 passed in 208.78s (0:03:28) ========================
```
