### PR TITLE
Generate `*.type.element_ty` as long as `dtype` is not `Tensor`

### DIFF
--- a/src/ninetoothed/generation.py
+++ b/src/ninetoothed/generation.py
@@ -289,11 +289,11 @@ class CodeGenerator(ast.NodeTransformer):
         if isinstance(value, Tensor):
             attr = getattr(value, node.attr)
 
-            if node.attr == "dtype" and attr is None:
-                return Symbol(f"{value.source.pointer_string()}.type.element_ty").node
-
             if isinstance(attr, Tensor):
                 return attr
+
+            if node.attr == "dtype":
+                return Symbol(f"{value.source.pointer_string()}.type.element_ty").node
 
             return Symbol(attr).node
 


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/huangjiacheng/ninetoothed
configfile: pyproject.toml
plugins: cov-6.0.0
collected 25 items

tests/test_add.py .                                                      [  4%]
tests/test_addmm.py ..                                                   [ 12%]
tests/test_aot.py ...                                                    [ 24%]
tests/test_attention.py ....                                             [ 40%]
tests/test_conv2d.py .                                                   [ 44%]
tests/test_dropout.py .                                                  [ 48%]
tests/test_matmul.py ..                                                  [ 56%]
tests/test_max_pool2d.py ..                                              [ 64%]
tests/test_naming.py .......                                             [ 92%]
tests/test_pow.py .                                                      [ 96%]
tests/test_softmax.py .                                                  [100%]

======================== 25 passed in 298.25s (0:04:58) ========================
```
