### PR TITLE
Fix auto-tuning generation

### DIFF
--- a/src/ninetoothed/aot.py
+++ b/src/ninetoothed/aot.py
@@ -9,11 +9,25 @@ import ninetoothed.naming as naming
 from ninetoothed.dtype import int64
 from ninetoothed.generation import CACHE_DIR, CodeGenerator
 from ninetoothed.tensor import Tensor
+from ninetoothed.utils import calculate_default_configs
 
 
 def aot(
-    func, caller="cuda", kernel_name=None, output_dir=None, num_warps=4, num_stages=3
+    func,
+    caller="cuda",
+    kernel_name=None,
+    output_dir=None,
+    num_warps=None,
+    num_stages=None,
 ):
+    default_num_warps, default_num_stages = calculate_default_configs()
+
+    if num_warps is None:
+        num_warps = default_num_warps
+
+    if num_stages is None:
+        num_stages = default_num_stages
+
     output_dir = pathlib.Path(output_dir)
 
     output_contents = _aot(func, caller, kernel_name, num_warps, num_stages)

--- a/src/ninetoothed/generation.py
+++ b/src/ninetoothed/generation.py
@@ -459,7 +459,7 @@ class CodeGenerator(ast.NodeTransformer):
         if self._max_num_configs is not None and len(configs) > self._max_num_configs:
             configs = random.sample(configs, k=self._max_num_configs)
 
-        if not configs:
+        if len(configs) <= 1:
             return None
 
         return ast.Call(

--- a/src/ninetoothed/generation.py
+++ b/src/ninetoothed/generation.py
@@ -555,7 +555,18 @@ class CodeGenerator(ast.NodeTransformer):
                             ctx=ast.Load(),
                         ),
                         args=[ast.Name(id=param, ctx=ast.Load()) for param in params],
-                        keywords=[],
+                        keywords=[
+                            ast.keyword(
+                                arg="num_warps",
+                                value=ast.Constant(value=self._num_wraps),
+                            ),
+                            ast.keyword(
+                                arg="num_stages",
+                                value=ast.Constant(value=self._num_stages),
+                            ),
+                        ]
+                        if self._autotune is None
+                        else [],
                     )
                 )
             ],

--- a/src/ninetoothed/generation.py
+++ b/src/ninetoothed/generation.py
@@ -396,6 +396,14 @@ class CodeGenerator(ast.NodeTransformer):
             ):
                 block_size_configs.append(config)
 
+        if not block_size_configs:
+            if meta:
+                raise ValueError(
+                    "Failed to generate auto-tuning. Please check the upper and lower bounds of the symbols."
+                )
+            else:
+                block_size_configs.append({})
+
         if isinstance(self._num_wraps, collections.abc.Iterable):
             num_warps_configs = self._num_wraps
         else:

--- a/src/ninetoothed/jit.py
+++ b/src/ninetoothed/jit.py
@@ -2,6 +2,7 @@ import importlib
 import sys
 
 from ninetoothed.generation import CodeGenerator
+from ninetoothed.utils import calculate_default_configs
 
 
 def jit(
@@ -31,6 +32,14 @@ def jit(
         The ``_prettify`` parameter is experimental, which might break
         the generated code.
     """
+
+    default_num_warps, default_num_stages = calculate_default_configs()
+
+    if num_warps is None:
+        num_warps = default_num_warps
+
+    if num_stages is None:
+        num_stages = default_num_stages
 
     def wrapper(func):
         return JIT(

--- a/src/ninetoothed/make.py
+++ b/src/ninetoothed/make.py
@@ -2,7 +2,6 @@ import inspect
 
 from ninetoothed.aot import aot
 from ninetoothed.jit import jit
-from ninetoothed.utils import calculate_default_configs
 
 
 def make(
@@ -30,14 +29,6 @@ def make(
         configurations to use.
     :return: A handle to the compute kernel.
     """
-
-    default_num_warps, default_num_stages = calculate_default_configs()
-
-    if num_warps is None:
-        num_warps = default_num_warps
-
-    if num_stages is None:
-        num_stages = default_num_stages
 
     params = inspect.signature(application).parameters
     types = arrangement(*tensors)

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -1,0 +1,52 @@
+import functools
+
+import pytest
+
+import ninetoothed
+import tests.test_matmul as matmul
+from ninetoothed import Tensor
+from tests.skippers import skip_if_cuda_not_available
+
+
+@skip_if_cuda_not_available
+@pytest.mark.parametrize("num_stages", (None, 3, (1, 3)))
+@pytest.mark.parametrize("num_warps", (None, 4, (4, 8)))
+@pytest.mark.parametrize("block_size_k", (ninetoothed.block_size(), 64))
+@pytest.mark.parametrize("block_size_n", (ninetoothed.block_size(), 64))
+@pytest.mark.parametrize("block_size_m", (ninetoothed.block_size(), 64))
+def test_auto_tuning_generation(
+    block_size_m, block_size_n, block_size_k, num_warps, num_stages
+):
+    auto_tuning_should_be_disabled = (
+        isinstance(block_size_m, int)
+        and isinstance(block_size_n, int)
+        and isinstance(block_size_k, int)
+        and not isinstance(num_warps, tuple)
+        and not isinstance(num_stages, tuple)
+    )
+
+    arrangement = functools.partial(
+        matmul.arrangement,
+        BLOCK_SIZE_M=block_size_m,
+        BLOCK_SIZE_N=block_size_n,
+        BLOCK_SIZE_K=block_size_k,
+    )
+
+    application = matmul.application
+
+    tensors = (Tensor(2), Tensor(2), Tensor(2))
+
+    kernel = ninetoothed.make(
+        arrangement, application, tensors, num_warps=num_warps, num_stages=num_stages
+    )
+
+    source_file = kernel._source
+
+    with open(source_file) as f:
+        contents = f.read()
+
+        if auto_tuning_should_be_disabled:
+            assert "application_with_auto_tuning" not in contents
+            assert "num_warps=" in contents and "num_stages=" in contents
+        else:
+            assert "application_with_auto_tuning" in contents


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/voltjia/ninetoothed
configfile: pyproject.toml
plugins: anyio-4.9.0, cov-6.0.0
collected 102 items

tests/test_add.py .                                                      [  0%]
tests/test_addmm.py ..                                                   [  2%]
tests/test_aot.py ....                                                   [  6%]
tests/test_attention.py ........                                         [ 14%]
tests/test_conv2d.py .                                                   [ 15%]
tests/test_dropout.py .                                                  [ 16%]
tests/test_generation.py ............................................... [ 62%]
.........................                                                [ 87%]
tests/test_matmul.py ..                                                  [ 89%]
tests/test_max_pool2d.py ..                                              [ 91%]
tests/test_naming.py .......                                             [ 98%]
tests/test_pow.py .                                                      [ 99%]
tests/test_softmax.py .                                                  [100%]

============================= 102 passed in 50.85s =============================
```
