### PR TITLE
Add `bfloat16` to `dtype.py` and `__init__.py`

### DIFF
--- a/src/ninetoothed/__init__.py
+++ b/src/ninetoothed/__init__.py
@@ -1,4 +1,5 @@
 from ninetoothed.dtype import (
+    bfloat16,
     float16,
     float32,
     float64,
@@ -19,6 +20,7 @@ from ninetoothed.tensor import Tensor
 __all__ = [
     "Symbol",
     "Tensor",
+    "bfloat16",
     "block_size",
     "float16",
     "float32",

--- a/src/ninetoothed/dtype.py
+++ b/src/ninetoothed/dtype.py
@@ -9,5 +9,6 @@ uint32 = "u32"
 uint64 = "u64"
 
 float16 = "fp16"
+bfloat16 = "bf16"
 float32 = "fp32"
 float64 = "fp64"


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/huangjiacheng/ninetoothed
configfile: pyproject.toml
plugins: cov-6.0.0
collected 103 items

tests/test_add.py .                                                      [  0%]
tests/test_addmm.py ..                                                   [  2%]
tests/test_aot.py .....                                                  [  7%]
tests/test_attention.py ........                                         [ 15%]
tests/test_conv2d.py .                                                   [ 16%]
tests/test_dropout.py .                                                  [ 17%]
tests/test_generation.py ............................................... [ 63%]
.........................                                                [ 87%]
tests/test_matmul.py ..                                                  [ 89%]
tests/test_max_pool2d.py ..                                              [ 91%]
tests/test_naming.py .......                                             [ 98%]
tests/test_pow.py .                                                      [ 99%]
tests/test_softmax.py .                                                  [100%]

======================= 103 passed in 212.23s (0:03:32) ========================
```
