### PR TITLE
Remove `vecadd-tiling.png` and `matmul-tiling.png`

### DIFF
--- a/docs/source/_static/matmul-tiling.png
+++ b/docs/source/_static/matmul-tiling.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f4436ac3d9a7b1362efdbd33cd14ff9be34ceef89d596d4554a4727dd0ef57d5
-size 224240

--- a/docs/source/_static/vecadd-tiling.png
+++ b/docs/source/_static/vecadd-tiling.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f2d6725fb932a4d96d1c1e7a4c730e2685d00c94d8677f63512d98182de638a1
-size 44416


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.4.1, pluggy-1.6.0
rootdir: /home/huang/ninetoothed
configfile: pyproject.toml
plugins: jaxtyping-0.3.2, typeguard-4.4.4, cov-6.2.1, anyio-4.9.0
collected 104 items

tests/test_add.py .                                                      [  0%]
tests/test_addmm.py ..                                                   [  2%]
tests/test_aot.py .....                                                  [  7%]
tests/test_attention.py ........                                         [ 15%]
tests/test_conv2d.py .                                                   [ 16%]
tests/test_debugging.py .                                                [ 17%]
tests/test_dropout.py .                                                  [ 18%]
tests/test_generation.py ............................................... [ 63%]
.........................                                                [ 87%]
tests/test_matmul.py ..                                                  [ 89%]
tests/test_max_pool2d.py ..                                              [ 91%]
tests/test_naming.py .......                                             [ 98%]
tests/test_pow.py .                                                      [ 99%]
tests/test_softmax.py .                                                  [100%]

======================== 104 passed in 65.00s (0:01:04) ========================
```
