### PR TITLE
Add `shape_options={"constexpr": True}` to `tensors` construction in `simulate_arrangement`

### DIFF
--- a/src/ninetoothed/debugging.py
+++ b/src/ninetoothed/debugging.py
@@ -55,7 +55,12 @@ def simulate_arrangement(arrangement, tensors, device=None):
         source_tensors.append(source_tensor)
         target_tensors.append(target_tensor)
 
-    tensors = arrangement(*(Tensor(tensor.ndim, other=-1) for tensor in tensors))
+    tensors = arrangement(
+        *(
+            Tensor(tensor.ndim, other=-1, shape_options={"constexpr": True})
+            for tensor in tensors
+        )
+    )
     debug_tensors = tuple(_generate_debug_tensor(tensor) for tensor in tensors)
 
     application_source = _generate_debug_application_source(tensors, debug_tensors)


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/voltjia/ninetoothed
configfile: pyproject.toml
plugins: jaxtyping-0.3.2, anyio-4.9.0, cov-6.0.0
collected 104 items

tests/test_add.py .                                                      [  0%]
tests/test_addmm.py ..                                                   [  2%]
tests/test_aot.py .....                                                  [  7%]
tests/test_attention.py ........                                         [ 15%]
tests/test_conv2d.py .                                                   [ 16%]
tests/test_debugging.py .                                                [ 17%]
tests/test_dropout.py .                                                  [ 18%]
tests/test_generation.py ............................................... [ 63%]
.........................                                                [ 87%]
tests/test_matmul.py ..                                                  [ 89%]
tests/test_max_pool2d.py ..                                              [ 91%]
tests/test_naming.py .......                                             [ 98%]
tests/test_pow.py .                                                      [ 99%]
tests/test_softmax.py .                                                  [100%]

============================= 104 passed in 53.34s =============================
```
