### PR TITLE
Add `functools.wraps` to `Tensor._meta_operation` to preserve metadata

### DIFF
--- a/src/ninetoothed/tensor.py
+++ b/src/ninetoothed/tensor.py
@@ -1,4 +1,5 @@
 import copy
+import functools
 import itertools
 import math
 import re
@@ -112,6 +113,7 @@ class Tensor:
 
     @staticmethod
     def _meta_operation(func):
+        @functools.wraps(func)
         def wrapper(self, *args, **kwargs):
             if self.source is self:
                 return func(copy.deepcopy(self), *args, **kwargs)


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.4.1, pluggy-1.6.0
rootdir: /home/huang/ninetoothed
configfile: pyproject.toml
plugins: jaxtyping-0.3.2, typeguard-4.4.4, cov-6.2.1, anyio-4.9.0
collected 104 items

tests/test_add.py .                                                      [  0%]
tests/test_addmm.py ..                                                   [  2%]
tests/test_aot.py .....                                                  [  7%]
tests/test_attention.py ........                                         [ 15%]
tests/test_conv2d.py .                                                   [ 16%]
tests/test_debugging.py .                                                [ 17%]
tests/test_dropout.py .                                                  [ 18%]
tests/test_generation.py ............................................... [ 63%]
.........................                                                [ 87%]
tests/test_matmul.py ..                                                  [ 89%]
tests/test_max_pool2d.py ..                                              [ 91%]
tests/test_naming.py .......                                             [ 98%]
tests/test_pow.py .                                                      [ 99%]
tests/test_softmax.py .                                                  [100%]

======================== 104 passed in 61.88s (0:01:01) ========================
```
