### PR TITLE
Clear `Tensor._inputs` after generation in `CodeGenerator._generate_offsets`

### DIFF
--- a/src/ninetoothed/generation.py
+++ b/src/ninetoothed/generation.py
@@ -741,6 +741,13 @@ class CodeGenerator(ast.NodeTransformer):
         for dim, offset in enumerate(tensor.source._outputs[0]):
             offsets[dim] += offset
 
+        curr = tensor
+
+        while isinstance(curr, type(tensor)):
+            curr._inputs.clear()
+
+            curr = curr.dtype
+
         return offsets
 
     @staticmethod


### PR DESCRIPTION
`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/voltjia/ninetoothed
configfile: pyproject.toml
plugins: jaxtyping-0.3.2, anyio-4.9.0, cov-6.0.0
collected 104 items

tests/test_add.py .                                                      [  0%]
tests/test_addmm.py ..                                                   [  2%]
tests/test_aot.py .....                                                  [  7%]
tests/test_attention.py ........                                         [ 15%]
tests/test_conv2d.py .                                                   [ 16%]
tests/test_debugging.py .                                                [ 17%]
tests/test_dropout.py .                                                  [ 18%]
tests/test_generation.py ............................................... [ 63%]
.........................                                                [ 87%]
tests/test_matmul.py ..                                                  [ 89%]
tests/test_max_pool2d.py ..                                              [ 91%]
tests/test_naming.py .......                                             [ 98%]
tests/test_pow.py .                                                      [ 99%]
tests/test_softmax.py .                                                  [100%]

============================= 104 passed in 51.78s =============================
```
