### PR TITLE
Add auto-tuning support for AOT compilation

### DIFF
--- a/src/ninetoothed/aot.py
+++ b/src/ninetoothed/aot.py
@@ -454,6 +454,8 @@ def _compile_library(kernel_name, output_dir):
         "-shared",
         "-arch",
         "native",
+        "--threads",
+        "0",
         "-Xcompiler",
         "-fPIC",
         # TODO: Remove the following 2 lines after the return value issue is resolved.

--- a/src/ninetoothed/aot.py
+++ b/src/ninetoothed/aot.py
@@ -454,6 +454,9 @@ def _compile_library(kernel_name, output_dir):
         "-shared",
         "-Xcompiler",
         "-fPIC",
+        # TODO: Remove the following 2 lines after the return value issue is resolved.
+        "-Xcompiler",
+        "-Wno-return-type",
         "-lcuda",
         "-o",
         output_dir / f"{kernel_name}.so",

--- a/src/ninetoothed/aot.py
+++ b/src/ninetoothed/aot.py
@@ -452,6 +452,8 @@ def _compile_library(kernel_name, output_dir):
     command = [
         "nvcc",
         "-shared",
+        "-arch",
+        "native",
         "-Xcompiler",
         "-fPIC",
         # TODO: Remove the following 2 lines after the return value issue is resolved.

--- a/src/ninetoothed/aot.py
+++ b/src/ninetoothed/aot.py
@@ -169,7 +169,11 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
 
 _INDENTATION = "    "
 
-_MACRO_MAPPING = {True: ("NINETOOTHED_TRUE", 1), False: ("NINETOOTHED_FALSE", 0)}
+_MACRO_MAPPING = {
+    True: ("NINETOOTHED_TRUE", 1),
+    False: ("NINETOOTHED_FALSE", 0),
+    None: ("NINETOOTHED_NONE", 0),
+}
 
 _DTYPE_MAPPING = {
     ninetoothed.dtype.int8: "NINETOOTHED_INT8",

--- a/src/ninetoothed/aot.py
+++ b/src/ninetoothed/aot.py
@@ -375,6 +375,13 @@ class _ArgumentTensor(ctypes.Structure):
         return arg_tensor
 
 
+class _KernelLaunchError(RuntimeError):
+    def __init__(self, error_code):
+        self._message = f"Kernel launch failed with error code: {error_code}."
+
+        super().__init__(self._message)
+
+
 def _compile(path, name, signature, grid, num_warps, num_stages):
     with tempfile.TemporaryDirectory() as temp_dir:
         output_dir = pathlib.Path(temp_dir)
@@ -443,7 +450,7 @@ def _generate_launch_func(kernel_name, output_dir):
         )
 
         if result != 0:
-            raise RuntimeError(f"Kernel launch failed with error code: {result}.")
+            raise _KernelLaunchError(result)
 
     return _run_launch_func
 

--- a/src/ninetoothed/aot.py
+++ b/src/ninetoothed/aot.py
@@ -199,6 +199,10 @@ _DATA_TYPE_BODY_CONTENT = ",\n    ".join(_DTYPE_MAPPING.values())
 
 _TEMPLATES_DIR = pathlib.Path(__file__).parent / "templates"
 
+_AUTO_TUNING_CACHE_CONTENT = (
+    (_TEMPLATES_DIR / "auto_tuning_cache.h").read_text().strip()
+)
+
 _THREAD_SAFE_UNORDERED_MAP_CONTENT = (
     (_TEMPLATES_DIR / "thread_safe_unordered_map.h").read_text().strip()
 )
@@ -225,6 +229,8 @@ typedef void *NineToothedStream;
 typedef int NineToothedResult;
 
 #ifdef __cplusplus
+{_AUTO_TUNING_CACHE_CONTENT}
+
 {_THREAD_SAFE_UNORDERED_MAP_CONTENT}
 #endif
 

--- a/src/ninetoothed/aot.py
+++ b/src/ninetoothed/aot.py
@@ -157,7 +157,7 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
         + "};\n"
         + textwrap.indent(c_source_file[kernel_end:], _INDENTATION)
         + "}\n"
-        + f"\nstatic ThreadSafeUnorderedMap<unsigned long long, {kernel_name_with_hash}::Kernel> kernels;\n"
+        + f"\nstatic ninetoothed::ThreadSafeUnorderedMap<unsigned long long, {kernel_name_with_hash}::Kernel> kernels;\n"
         + f'\nextern "C" {launch_func_unparsed}\n'
     )
     cpp_source_file_name = f"{kernel_name}.{signature_hash}.cpp"
@@ -197,40 +197,11 @@ _MACRO_CONTENT = "\n\n".join(
 
 _DATA_TYPE_BODY_CONTENT = ",\n    ".join(_DTYPE_MAPPING.values())
 
-_THREAD_SAFE_UNORDERED_MAP_CONTENT = """#include <mutex>
-#include <shared_mutex>
-#include <unordered_map>
+_TEMPLATES_DIR = pathlib.Path(__file__).parent / "templates"
 
-template<typename Key, typename Value>
-class ThreadSafeUnorderedMap {
-public:
-    Value& operator[](const Key& key) {
-        {
-            std::shared_lock lock{mutex};
-
-            auto iter = map.find(key);
-
-            if (iter != map.end()) {
-                return iter->second;
-            }
-        }
-
-        std::unique_lock lock{mutex};
-
-        auto iter = map.find(key);
-
-        if (iter == map.end()) {
-            iter = map.emplace(key, Value{}).first;
-        }
-
-        return iter->second;
-    }
-
-private:
-    std::unordered_map<Key, Value> map;
-
-    mutable std::shared_mutex mutex;
-};"""
+_THREAD_SAFE_UNORDERED_MAP_CONTENT = (
+    (_TEMPLATES_DIR / "thread_safe_unordered_map.h").read_text().strip()
+)
 
 _HEADER_CONTENT = f"""#ifndef NINETOOTHED_H
 #define NINETOOTHED_H

--- a/src/ninetoothed/auto_tuner.py
+++ b/src/ninetoothed/auto_tuner.py
@@ -4,6 +4,7 @@ import os
 
 import triton
 
+from ninetoothed.aot import _KernelLaunchError
 from ninetoothed.generation import CACHE_DIR
 
 
@@ -74,7 +75,10 @@ class AutoTuner:
         if arg_key in data:
             return data[arg_key]
 
-        timing = triton.testing.do_bench(lambda: func(*args, **kwargs))
+        try:
+            timing = triton.testing.do_bench(lambda: func(*args, **kwargs))
+        except _KernelLaunchError:
+            timing = float("inf")
 
         data[arg_key] = timing
 

--- a/src/ninetoothed/build.py
+++ b/src/ninetoothed/build.py
@@ -289,17 +289,9 @@ def _auto_tune(
             meta_args_to_timing.items(), key=lambda item: item[1]
         )[0][0]
 
-        int_configs = []
+        int_configs = tuple(_arg_to_int(arg) for arg in config_)
 
-        for arg in config_:
-            if arg in _DTYPE_MAPPING:
-                arg = tuple(_DTYPE_MAPPING.keys()).index(arg)
-            elif isinstance(arg, enum.Enum):
-                arg = arg.value
-
-            int_configs.append(arg)
-
-        config_to_best_meta_arguments[tuple(int_configs)] = best_meta_arguments
+        config_to_best_meta_arguments[int_configs] = best_meta_arguments
 
     with open(output_dir / f"{kernel_name}.csv", "w") as f:
         csv.writer(f).writerows(
@@ -431,3 +423,13 @@ def _generate_condition(combination):
 
 def _generate_suffix(values):
     return "_".join(f"{value}" for value in values)
+
+
+def _arg_to_int(arg):
+    if arg in _DTYPE_MAPPING:
+        return tuple(_DTYPE_MAPPING.keys()).index(arg)
+
+    if isinstance(arg, enum.Enum):
+        return arg.value
+
+    return arg

--- a/src/ninetoothed/build.py
+++ b/src/ninetoothed/build.py
@@ -6,7 +6,6 @@ import inspect
 import itertools
 import multiprocessing
 import pathlib
-import textwrap
 
 import ninetoothed
 from ninetoothed.aot import (
@@ -185,33 +184,21 @@ def _generate_kernel_with_auto_tuning(
 ):
     num_non_meta_premake_params = len(tuple(config_to_best_meta_arguments.keys())[0])
 
+    config_param_names = non_tensor_param_names[:num_non_meta_premake_params]
     meta_param_names = non_tensor_param_names[num_non_meta_premake_params:]
     meta_param_types = tuple("int" for _ in meta_param_names)
 
-    meta_param_decl_stmts = textwrap.indent(
-        _generate_declaration_statements(meta_param_types, meta_param_names),
-        _INDENTATION,
+    csv_path = output_dir / f"{kernel_name}.csv"
+    config_args = ", ".join(f"static_cast<int>({name})" for name in config_param_names)
+    cache_line = (
+        f'{_INDENTATION}static ninetoothed::AutoTuningCache cache{{"{csv_path}"}};'
     )
-
-    meta_param_assignment_branches = []
-
-    for config, best_meta_args in config_to_best_meta_arguments.items():
-        condition = _generate_condition(
-            {name: value for name, value in zip(non_tensor_param_names, config)}
-        )
-
-        assignments = textwrap.indent(
-            _generate_assignment_statements(meta_param_names, best_meta_args),
-            _INDENTATION,
-        )
-
-        meta_param_assignment_branches.append(
-            textwrap.indent(f"if ({condition}) {{\n{assignments}\n}}", _INDENTATION)
-        )
-
-    meta_param_initialization = f"{meta_param_decl_stmts}\n" + "\n".join(
-        meta_param_assignment_branches
+    lookup_line = f"{_INDENTATION}auto meta{{cache.lookup({{{config_args}}})}};"
+    meta_assignments = "\n".join(
+        f"{_INDENTATION}auto {name}{{meta[{i}]}};"
+        for i, name in enumerate(meta_param_names)
     )
+    meta_param_initialization = f"{cache_line}\n{lookup_line}\n{meta_assignments}"
 
     meta_param_decl_exprs = _generate_declaration_expressions(
         meta_param_types, meta_param_names

--- a/src/ninetoothed/build.py
+++ b/src/ninetoothed/build.py
@@ -273,12 +273,13 @@ def _auto_tune(
         )
 
         meta_args_to_timing = {}
+        func_timings = auto_tuner._timings[key]
 
         for meta_args in all_meta_arguments_:
             arg_key = auto_tuner._make_arg_key((*config_, *meta_args), {})
 
-            for key, timing in auto_tuner._timings.items():
-                if arg_key not in key:
+            for full_arg_key, timing in func_timings.items():
+                if not full_arg_key.endswith(arg_key):
                     continue
 
                 meta_args_to_timing[meta_args] = timing

--- a/src/ninetoothed/build.py
+++ b/src/ninetoothed/build.py
@@ -370,11 +370,7 @@ def _make(premake, config, caller, kernel_name, output_dir):
     combination |= compilation_configs
 
     for name, value in combination.items():
-        if isinstance(value, bool) or value is None:
-            combination[name] = _MACRO_MAPPING[value][0]
-
-        if value in _DTYPE_MAPPING:
-            combination[name] = _DTYPE_MAPPING[value]
+        combination[name] = _arg_to_int(value)
 
     kernel_name_ = f"{kernel_name}_{_generate_suffix(combination.values())}"
 
@@ -426,6 +422,9 @@ def _generate_suffix(values):
 
 
 def _arg_to_int(arg):
+    if isinstance(arg, bool) or arg is None:
+        return _MACRO_MAPPING[arg][1]
+
     if arg in _DTYPE_MAPPING:
         return tuple(_DTYPE_MAPPING.keys()).index(arg)
 

--- a/src/ninetoothed/build.py
+++ b/src/ninetoothed/build.py
@@ -108,7 +108,7 @@ def build(
     for kernel_name_, param_names_, combination in zip(
         kernel_names, all_param_names, combinations
     ):
-        header = output_dir / f"{kernel_name_}.h"
+        header = f"{kernel_name_}.h"
         launch = f"""    if ({_generate_condition(combination)})
         return launch_{kernel_name_}({", ".join((param_names[0],) + param_names_)});"""
 

--- a/src/ninetoothed/build.py
+++ b/src/ninetoothed/build.py
@@ -378,7 +378,7 @@ def _make(premake, config, caller, kernel_name, output_dir):
     combination |= compilation_configs
 
     for name, value in combination.items():
-        if isinstance(value, bool):
+        if isinstance(value, bool) or value is None:
             combination[name] = _MACRO_MAPPING[value][0]
 
         if value in _DTYPE_MAPPING:

--- a/src/ninetoothed/build.py
+++ b/src/ninetoothed/build.py
@@ -1,5 +1,6 @@
 import concurrent.futures
 import csv
+import enum
 import functools
 import inspect
 import itertools
@@ -288,14 +289,17 @@ def _auto_tune(
             meta_args_to_timing.items(), key=lambda item: item[1]
         )[0][0]
 
-        config_ = tuple(
-            arg
-            if arg not in _DTYPE_MAPPING
-            else tuple(_DTYPE_MAPPING.keys()).index(arg)
-            for arg in config_
-        )
+        int_configs = []
 
-        config_to_best_meta_arguments[config_] = best_meta_arguments
+        for arg in config_:
+            if arg in _DTYPE_MAPPING:
+                arg = tuple(_DTYPE_MAPPING.keys()).index(arg)
+            elif isinstance(arg, enum.Enum):
+                arg = arg.value
+
+            int_configs.append(arg)
+
+        config_to_best_meta_arguments[tuple(int_configs)] = best_meta_arguments
 
     with open(output_dir / f"{kernel_name}.csv", "w") as f:
         csv.writer(f).writerows(

--- a/src/ninetoothed/build.py
+++ b/src/ninetoothed/build.py
@@ -237,13 +237,6 @@ def _generate_kernel_with_auto_tuning(
 def _auto_tune(
     kernel, configs, all_tensors, meta_parameters, *, caller, kernel_name, output_dir
 ):
-    key = str(output_dir / kernel_name)
-
-    auto_tuner = AutoTuner(funcs=(kernel,), keys=(key,))
-
-    for config, tensors in zip(configs, all_tensors):
-        _warm_up(auto_tuner, config, tensors, caller=caller)
-
     config_to_all_meta_arguments = {}
 
     for config in configs:
@@ -261,6 +254,19 @@ def _auto_tune(
             config_to_all_meta_arguments[config_] = []
 
         config_to_all_meta_arguments[config_].append(meta_args)
+
+    csv_path = output_dir / f"{kernel_name}.csv"
+    cached = _read_auto_tuning_cache(csv_path)
+
+    if cached is not None:
+        return cached
+
+    key = str(output_dir / kernel_name)
+
+    auto_tuner = AutoTuner(funcs=(kernel,), keys=(key,))
+
+    for config, tensors in zip(configs, all_tensors):
+        _warm_up(auto_tuner, config, tensors, caller=caller)
 
     config_to_best_meta_arguments = {}
 
@@ -294,10 +300,7 @@ def _auto_tune(
 
         config_to_best_meta_arguments[int_configs] = best_meta_arguments
 
-    with open(output_dir / f"{kernel_name}.csv", "w") as f:
-        csv.writer(f).writerows(
-            itertools.chain.from_iterable(config_to_best_meta_arguments.items())
-        )
+    _write_auto_tuning_cache(csv_path, config_to_best_meta_arguments)
 
     return config_to_best_meta_arguments
 
@@ -392,6 +395,31 @@ def _make(premake, config, caller, kernel_name, output_dir):
     )
 
     return kernel_name_, param_names, combination, config, tensors
+
+
+def _read_auto_tuning_cache(path):
+    if not path.exists():
+        return None
+
+    config_to_best_meta_arguments = {}
+
+    with open(path) as f:
+        rows = list(csv.reader(f))
+
+    for i in range(0, len(rows), 2):
+        config = tuple(int(value) for value in rows[i])
+        meta_args = tuple(int(value) for value in rows[i + 1])
+
+        config_to_best_meta_arguments[config] = meta_args
+
+    return config_to_best_meta_arguments
+
+
+def _write_auto_tuning_cache(path, config_to_best_meta_arguments):
+    with open(path, "w") as f:
+        csv.writer(f).writerows(
+            itertools.chain.from_iterable(config_to_best_meta_arguments.items())
+        )
 
 
 def _generate_declaration_statements(types, names):

--- a/src/ninetoothed/build.py
+++ b/src/ninetoothed/build.py
@@ -1,19 +1,33 @@
 import concurrent.futures
+import csv
 import functools
 import inspect
+import itertools
 import multiprocessing
 import pathlib
+import textwrap
 
 import ninetoothed
 from ninetoothed.aot import (
     _DTYPE_MAPPING,
     _HEADER_PATH,
+    _INDENTATION,
     _MACRO_MAPPING,
     _generate_launch_func,
 )
+from ninetoothed.auto_tuner import AutoTuner
+from ninetoothed.tensor import Symbol
 
 
-def build(premake, configs, *, caller=None, kernel_name=None, output_dir=None):
+def build(
+    premake,
+    configs,
+    *,
+    meta_parameters=None,
+    caller=None,
+    kernel_name=None,
+    output_dir=None,
+):
     """Build a kernel from a ``premake`` function and ``configs``.
 
     :param premake: A callable that returns the ``arrangement``,
@@ -24,6 +38,8 @@ def build(premake, configs, *, caller=None, kernel_name=None, output_dir=None):
         ``args`` and ``kwargs`` are passed to ``premake``, and
         ``compilation_configs`` contains compilation configurations for
         ``ninetoothed.make`` (e.g., ``num_warps`` and ``num_stages``).
+    :param meta_parameters: An iterable of meta-parameters that should
+        be auto-tuned.
     :param caller: Who will call the compute kernel.
     :param kernel_name: The name for the generated kernel.
     :param output_dir: The directory to store the generated files.
@@ -37,6 +53,7 @@ def build(premake, configs, *, caller=None, kernel_name=None, output_dir=None):
     kernel_names = []
     all_param_names = []
     combinations = []
+    all_tensors = []
 
     with concurrent.futures.ProcessPoolExecutor(
         mp_context=multiprocessing.get_context("spawn")
@@ -55,12 +72,16 @@ def build(premake, configs, *, caller=None, kernel_name=None, output_dir=None):
 
             futures.append(future)
 
+        configs = []
+
         for future in concurrent.futures.as_completed(futures):
-            kernel_name_, param_names, combination = future.result()
+            kernel_name_, param_names, combination, config, tensors = future.result()
 
             kernel_names.append(kernel_name_)
             all_param_names.append(param_names)
             combinations.append(combination)
+            configs.append(config)
+            all_tensors.append(tensors)
 
     tensor_param_names = tuple(
         functools.reduce(
@@ -79,9 +100,7 @@ def build(premake, configs, *, caller=None, kernel_name=None, output_dir=None):
     param_names = ("stream",) + tensor_param_names + non_tensor_param_names
     param_types = ("NineToothedStream",) + tensor_param_types + non_tensor_param_types
 
-    param_decls = ", ".join(
-        f"{type} {param}" for param, type in zip(param_names, param_types)
-    )
+    param_decls = _generate_declaration_expressions(param_types, param_names)
 
     headers = []
     launches = []
@@ -120,7 +139,222 @@ def build(premake, configs, *, caller=None, kernel_name=None, output_dir=None):
     (output_dir / source_file_name).write_text(source_content)
     (output_dir / header_file_name).write_text(header_content)
 
+    kernel = _generate_launch_func(kernel_name=kernel_name, output_dir=output_dir)
+
+    if meta_parameters is not None:
+        config_to_best_meta_arguments = _auto_tune(
+            kernel,
+            configs,
+            all_tensors,
+            meta_parameters,
+            caller=caller,
+            kernel_name=kernel_name,
+            output_dir=output_dir,
+        )
+
+        return _generate_kernel_with_auto_tuning(
+            config_to_best_meta_arguments,
+            non_tensor_param_names,
+            kernel_name=kernel_name,
+            output_dir=output_dir,
+        )
+
+    return kernel
+
+
+_DEFAULT_SIZES = tuple(2**i for i in range(10))
+
+
+class _MetaTensor:
+    def __init__(self, shape, dtype):
+        self.shape = []
+
+        for size in shape:
+            if isinstance(size, Symbol):
+                self.shape.append(None)
+            else:
+                self.shape.append(size)
+
+        self.dtype = dtype
+
+
+def _generate_kernel_with_auto_tuning(
+    config_to_best_meta_arguments, non_tensor_param_names, *, kernel_name, output_dir
+):
+    num_non_meta_premake_params = len(tuple(config_to_best_meta_arguments.keys())[0])
+
+    meta_param_names = non_tensor_param_names[num_non_meta_premake_params:]
+    meta_param_types = tuple("int" for _ in meta_param_names)
+
+    meta_param_decl_stmts = textwrap.indent(
+        _generate_declaration_statements(meta_param_types, meta_param_names),
+        _INDENTATION,
+    )
+
+    meta_param_assignment_branches = []
+
+    for config, best_meta_args in config_to_best_meta_arguments.items():
+        condition = _generate_condition(
+            {name: value for name, value in zip(non_tensor_param_names, config)}
+        )
+
+        assignments = textwrap.indent(
+            _generate_assignment_statements(meta_param_names, best_meta_args),
+            _INDENTATION,
+        )
+
+        meta_param_assignment_branches.append(
+            textwrap.indent(f"if ({condition}) {{\n{assignments}\n}}", _INDENTATION)
+        )
+
+    meta_param_initialization = f"{meta_param_decl_stmts}\n" + "\n".join(
+        meta_param_assignment_branches
+    )
+
+    meta_param_decl_exprs = _generate_declaration_expressions(
+        meta_param_types, meta_param_names
+    )
+
+    source_file_name = f"{kernel_name}.cpp"
+    header_file_name = f"{kernel_name}.h"
+
+    source_path = output_dir / source_file_name
+    header_path = output_dir / header_file_name
+
+    source_content = source_path.read_text().replace(
+        f", {meta_param_decl_exprs}) {{", f") {{\n{meta_param_initialization}"
+    )
+    header_content = header_path.read_text().replace(f", {meta_param_decl_exprs}", "")
+
+    source_path.write_text(source_content)
+    header_path.write_text(header_content)
+
     return _generate_launch_func(kernel_name=kernel_name, output_dir=output_dir)
+
+
+def _auto_tune(
+    kernel, configs, all_tensors, meta_parameters, *, caller, kernel_name, output_dir
+):
+    key = str(output_dir / kernel_name)
+
+    auto_tuner = AutoTuner(funcs=(kernel,), keys=(key,))
+
+    for config, tensors in zip(configs, all_tensors):
+        _warm_up(auto_tuner, config, tensors, caller=caller)
+
+    config_to_all_meta_arguments = {}
+
+    for config in configs:
+        args, kwargs, compilation_configs = config
+
+        meta_args = {
+            param: kwargs[param] for param in meta_parameters if param in kwargs
+        } | compilation_configs
+
+        kwargs_ = {key: value for key, value in kwargs.items() if key not in meta_args}
+
+        config_ = (args, tuple(kwargs_.items()))
+
+        if config_ not in config_to_all_meta_arguments:
+            config_to_all_meta_arguments[config_] = []
+
+        config_to_all_meta_arguments[config_].append(meta_args)
+
+    config_to_best_meta_arguments = {}
+
+    for config, all_meta_arguments in config_to_all_meta_arguments.items():
+        args, kwargs_items = config
+
+        config_ = (*args, *(item[1] for item in kwargs_items))
+        all_meta_arguments_ = tuple(
+            tuple(meta_args.values()) for meta_args in all_meta_arguments
+        )
+
+        meta_args_to_timing = {}
+
+        for meta_args in all_meta_arguments_:
+            arg_key = auto_tuner._make_arg_key((*config_, *meta_args), {})
+
+            for key, timing in auto_tuner._timings.items():
+                if arg_key not in key:
+                    continue
+
+                meta_args_to_timing[meta_args] = timing
+
+                break
+
+        best_meta_arguments = sorted(
+            meta_args_to_timing.items(), key=lambda item: item[1]
+        )[0][0]
+
+        config_ = tuple(
+            arg
+            if arg not in _DTYPE_MAPPING
+            else tuple(_DTYPE_MAPPING.keys()).index(arg)
+            for arg in config_
+        )
+
+        config_to_best_meta_arguments[config_] = best_meta_arguments
+
+    with open(output_dir / f"{kernel_name}.csv", "w") as f:
+        csv.writer(f).writerows(
+            itertools.chain.from_iterable(config_to_best_meta_arguments.items())
+        )
+
+    return config_to_best_meta_arguments
+
+
+def _warm_up(kernel, config, meta_tensors, *, caller):
+    import torch
+
+    dtype_mapping = {
+        ninetoothed.int8: torch.int8,
+        ninetoothed.int16: torch.int16,
+        ninetoothed.int32: torch.int32,
+        ninetoothed.int64: torch.int64,
+        ninetoothed.uint8: torch.uint8,
+        ninetoothed.uint16: torch.uint16,
+        ninetoothed.uint32: torch.uint32,
+        ninetoothed.uint64: torch.uint64,
+        ninetoothed.float16: torch.float16,
+        ninetoothed.bfloat16: torch.bfloat16,
+        ninetoothed.float32: torch.float32,
+        ninetoothed.float64: torch.float64,
+    }
+
+    args, kwargs, compilation_configs = config
+
+    all_shapes = []
+
+    for meta_tensor in meta_tensors:
+        all_sizes = []
+
+        for size in meta_tensor.shape:
+            if size is None:
+                all_sizes.append(_DEFAULT_SIZES)
+            else:
+                all_sizes.append((size,))
+
+        shapes = tuple(itertools.product(*all_sizes))
+
+        all_shapes.append(shapes)
+
+    for shapes in tuple(itertools.product(*all_shapes)):
+        tensors = []
+
+        for meta_tensor, shape in zip(meta_tensors, shapes):
+            dtype = dtype_mapping[meta_tensor.dtype]
+
+            if len(shape) == 0:
+                device = None
+            else:
+                device = caller
+
+            tensor = torch.empty(shape, dtype=dtype, device=device)
+
+            tensors.append(tensor)
+
+        kernel(*tensors, *args, *kwargs.values(), *compilation_configs.values())
 
 
 def _make(premake, config, caller, kernel_name, output_dir):
@@ -156,8 +390,31 @@ def _make(premake, config, caller, kernel_name, output_dir):
 
     application_signature = inspect.signature(application)
     param_names = tuple(application_signature.parameters.keys())
+    tensors = tuple(
+        _MetaTensor(shape=tensor.shape, dtype=tensor.dtype) for tensor in tensors
+    )
 
-    return kernel_name_, param_names, combination
+    return kernel_name_, param_names, combination, config, tensors
+
+
+def _generate_declaration_statements(types, names):
+    return "\n".join(
+        f"{_generate_declaration(type, name)};" for type, name in zip(types, names)
+    )
+
+
+def _generate_assignment_statements(names, values):
+    return "\n".join(f"{name} = {value};" for name, value in zip(names, values))
+
+
+def _generate_declaration_expressions(types, names):
+    return ", ".join(
+        _generate_declaration(type, name) for type, name in zip(types, names)
+    )
+
+
+def _generate_declaration(type, name):
+    return f"{type} {name}"
 
 
 def _generate_condition(combination):

--- a/src/ninetoothed/build.py
+++ b/src/ninetoothed/build.py
@@ -34,10 +34,9 @@ def build(premake, configs, *, caller=None, kernel_name=None, output_dir=None):
 
     output_dir = pathlib.Path(output_dir)
 
-    headers = []
+    kernel_names = []
     all_param_names = []
     combinations = []
-    launches = []
 
     with concurrent.futures.ProcessPoolExecutor(
         mp_context=multiprocessing.get_context("spawn")
@@ -57,36 +56,50 @@ def build(premake, configs, *, caller=None, kernel_name=None, output_dir=None):
             futures.append(future)
 
         for future in concurrent.futures.as_completed(futures):
-            header, param_names, combination, launch = future.result()
+            kernel_name_, param_names, combination = future.result()
 
-            headers.append(header)
+            kernel_names.append(kernel_name_)
             all_param_names.append(param_names)
             combinations.append(combination)
-            launches.append(launch)
 
-    includes = "\n".join(f'#include "{header}"' for header in headers)
-
-    param_names = list(
+    tensor_param_names = tuple(
         functools.reduce(
             lambda x, y: dict.fromkeys(x) | dict.fromkeys(y),
             sorted(all_param_names, key=len, reverse=True),
             {},
         )
     )
-    param_types = [
-        "NineToothedStream",
-    ] + ["NineToothedTensor" for _ in range(len(param_names) - 1)]
+    tensor_param_types = tuple("NineToothedTensor" for _ in tensor_param_names)
 
-    for param_name in functools.reduce(lambda x, y: x | y, combinations, {}):
-        param_names.append(param_name)
-        param_types.append("int")
+    non_tensor_param_names = tuple(
+        functools.reduce(lambda x, y: x | y, combinations, {})
+    )
+    non_tensor_param_types = tuple("int" for _ in non_tensor_param_names)
+
+    param_names = ("stream",) + tensor_param_names + non_tensor_param_names
+    param_types = ("NineToothedStream",) + tensor_param_types + non_tensor_param_types
 
     param_decls = ", ".join(
         f"{type} {param}" for param, type in zip(param_names, param_types)
     )
 
+    headers = []
+    launches = []
+
+    for kernel_name_, param_names_, combination in zip(
+        kernel_names, all_param_names, combinations
+    ):
+        header = output_dir / f"{kernel_name_}.h"
+        launch = f"""    if ({_generate_condition(combination)})
+        return launch_{kernel_name_}({", ".join((param_names[0],) + param_names_)});"""
+
+        headers.append(header)
+        launches.append(launch)
+
     source_file_name = f"{kernel_name}.cpp"
     header_file_name = f"{kernel_name}.h"
+
+    includes = "\n".join(f'#include "{header}"' for header in headers)
 
     func_sig = f"NineToothedResult launch_{kernel_name}({param_decls})"
 
@@ -141,13 +154,10 @@ def _make(premake, config, caller, kernel_name, output_dir):
         **compilation_configs,
     )
 
-    header = output_dir / f"{kernel_name_}.h"
     application_signature = inspect.signature(application)
-    param_names = ("stream",) + tuple(application_signature.parameters.keys())
-    launch = f"""    if ({_generate_condition(combination)})
-        return launch_{kernel_name_}({", ".join(param_names)});"""
+    param_names = tuple(application_signature.parameters.keys())
 
-    return header, param_names, combination, launch
+    return kernel_name_, param_names, combination
 
 
 def _generate_condition(combination):

--- a/src/ninetoothed/build.py
+++ b/src/ninetoothed/build.py
@@ -14,6 +14,7 @@ from ninetoothed.aot import (
     _INDENTATION,
     _MACRO_MAPPING,
     _generate_launch_func,
+    _KernelLaunchError,
 )
 from ninetoothed.auto_tuner import AutoTuner
 from ninetoothed.tensor import Symbol
@@ -354,7 +355,10 @@ def _warm_up(kernel, config, meta_tensors, *, caller):
 
             tensors.append(tensor)
 
-        kernel(*tensors, *args, *kwargs.values(), *compilation_configs.values())
+        try:
+            kernel(*tensors, *args, *kwargs.values(), *compilation_configs.values())
+        except _KernelLaunchError:
+            pass
 
 
 def _make(premake, config, caller, kernel_name, output_dir):

--- a/src/ninetoothed/templates/auto_tuning_cache.h
+++ b/src/ninetoothed/templates/auto_tuning_cache.h
@@ -1,0 +1,59 @@
+#include <fstream>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace ninetoothed {
+
+class AutoTuningCache {
+public:
+    AutoTuningCache(const std::string& path) : path{path} {}
+
+    std::vector<int> lookup(const std::vector<int>& config) {
+        if (!loaded) {
+            load();
+        }
+
+        auto iter = cache.find(config);
+
+        if (iter != cache.end()) {
+            return iter->second;
+        }
+
+        return {};
+    }
+
+private:
+    void load() {
+        std::ifstream file{path};
+        std::string config_line;
+        std::string meta_line;
+
+        while (std::getline(file, config_line) && std::getline(file, meta_line)) {
+            cache[parse(config_line)] = parse(meta_line);
+        }
+
+        loaded = true;
+    }
+
+    static std::vector<int> parse(const std::string& line) {
+        std::vector<int> values;
+        std::stringstream ss{line};
+        std::string token;
+
+        while (std::getline(ss, token, ',')) {
+            values.push_back(std::stoi(token));
+        }
+
+        return values;
+    }
+
+    std::string path;
+
+    bool loaded{false};
+
+    std::map<std::vector<int>, std::vector<int>> cache;
+};
+
+}

--- a/src/ninetoothed/templates/thread_safe_unordered_map.h
+++ b/src/ninetoothed/templates/thread_safe_unordered_map.h
@@ -1,0 +1,38 @@
+#include <mutex>
+#include <shared_mutex>
+#include <unordered_map>
+
+namespace ninetoothed {
+
+template<typename Key, typename Value>
+class ThreadSafeUnorderedMap {
+public:
+    Value& operator[](const Key& key) {
+        {
+            std::shared_lock lock{mutex};
+
+            auto iter = map.find(key);
+
+            if (iter != map.end()) {
+                return iter->second;
+            }
+        }
+
+        std::unique_lock lock{mutex};
+
+        auto iter = map.find(key);
+
+        if (iter == map.end()) {
+            iter = map.emplace(key, Value{}).first;
+        }
+
+        return iter->second;
+    }
+
+private:
+    std::unordered_map<Key, Value> map;
+
+    mutable std::shared_mutex mutex;
+};
+
+}

--- a/src/ninetoothed/tensor.py
+++ b/src/ninetoothed/tensor.py
@@ -49,24 +49,31 @@ class Tensor:
         else:
             self.name = naming.auto_generate(f"tensor_{type(self).num_instances}")
 
-        if ndim is not None:
-            if shape_options is None:
-                shape_options = tuple({} for _ in range(ndim))
+        assert ndim is not None or shape is not None, (
+            "Either `ndim` or `shape` must be provided."
+        )
 
-            if isinstance(shape_options, dict):
-                shape_options = tuple(shape_options for _ in range(ndim))
+        if ndim is None:
+            ndim = len(shape)
 
-            shape_options = tuple(
-                size_options if size_options is not None else {}
-                for size_options in shape_options
-            )
+        if shape is None:
+            shape = tuple(None for _ in range(ndim))
 
-            self.shape = (
-                Symbol(self.size_string(i), **size_options)
-                for i, size_options in zip(range(ndim), shape_options)
-            )
-        else:
-            self.shape = shape
+        if shape_options is None:
+            shape_options = tuple({} for _ in range(ndim))
+
+        if isinstance(shape_options, dict):
+            shape_options = tuple(shape_options for _ in range(ndim))
+
+        shape_options = tuple(
+            size_options if size_options is not None else {}
+            for size_options in shape_options
+        )
+
+        self.shape = (
+            size if size is not None else Symbol(self.size_string(i), **size_options)
+            for i, (size, size_options) in enumerate(zip(shape, shape_options))
+        )
 
         self.other = other
 

--- a/tests/test_aot.py
+++ b/tests/test_aot.py
@@ -239,9 +239,20 @@ def test_conv2d(
     rtol,
     atol,
 ):
-    premake = functools.partial(
-        conv2d.premake, dtype=ninetoothed_dtype, constexpr_shapes=constexpr_shapes
-    )
+    if constexpr_shapes:
+        sizes = {"n": n, "c": c, "h": h, "w": w, "k": k, "r": r, "s": s}
+    else:
+        sizes = {
+            "n": None,
+            "c": None,
+            "h": None,
+            "w": None,
+            "k": None,
+            "r": None,
+            "s": None,
+        }
+
+    premake = functools.partial(conv2d.premake, **sizes, dtype=ninetoothed_dtype)
 
     caller = device
     kernel_name = f"conv2d{_generate_kernel_name_suffix()}"
@@ -280,7 +291,7 @@ def test_conv2d(
     output = torch.empty(n, k, p, q, dtype=dtype, device=device)
 
     if test_build:
-        config = (ninetoothed_dtype, constexpr_shapes) + tuple(configs[0][1].values())
+        config = (*sizes.values(), ninetoothed_dtype) + tuple(configs[0][1].values())
     else:
         config = ()
 

--- a/tests/test_aot_auto_tuning.py
+++ b/tests/test_aot_auto_tuning.py
@@ -53,6 +53,7 @@ def test_auto_tuning(size, dtype, device, ninetoothed_dtype, rtol, atol):
     kernel_name = "add"
     output_dir = ninetoothed.generation.CACHE_DIR / "test_auto_tuning"
 
+    shutil.rmtree(output_dir, ignore_errors=True)
     output_dir.mkdir()
 
     configs = (

--- a/tests/test_aot_auto_tuning.py
+++ b/tests/test_aot_auto_tuning.py
@@ -1,0 +1,106 @@
+import functools
+import shutil
+
+import pytest
+import torch
+
+import ninetoothed
+import ninetoothed.generation
+from ninetoothed import Tensor
+from tests.utils import get_available_devices
+
+
+def arrangement(input, other, alpha, output, block_size=None):
+    if block_size is None:
+        block_size = ninetoothed.block_size()
+
+    input_arranged = input.tile((block_size,))
+    other_arranged = other.tile((block_size,))
+    alpha_arranged = alpha
+    output_arranged = output.tile((block_size,))
+
+    return input_arranged, other_arranged, alpha_arranged, output_arranged
+
+
+def application(input, other, alpha, output):
+    output = input + alpha * other  # noqa: F841
+
+
+def premake(size=None, dtype=None, block_size=None):
+    arrangement_ = functools.partial(arrangement, block_size=block_size)
+
+    tensors = (
+        Tensor(shape=(size,), dtype=dtype),
+        Tensor(shape=(size,), dtype=dtype),
+        Tensor(0, dtype=ninetoothed.float64),
+        Tensor(shape=(size,), dtype=dtype),
+    )
+
+    return arrangement_, application, tensors
+
+
+@pytest.mark.parametrize("device", get_available_devices())
+@pytest.mark.parametrize(
+    "dtype, ninetoothed_dtype, rtol, atol",
+    (
+        (torch.float32, ninetoothed.float32, 1e-5, 1e-5),
+        (torch.float16, ninetoothed.float16, 1e-3, 1e-3),
+    ),
+)
+@pytest.mark.parametrize("size", (20260128, 1127))
+def test_auto_tuning(size, dtype, device, ninetoothed_dtype, rtol, atol):
+    caller = device
+    kernel_name = "add"
+    output_dir = ninetoothed.generation.CACHE_DIR / "test_auto_tuning"
+
+    output_dir.mkdir()
+
+    configs = (
+        ((), {"size": 20260128, "dtype": ninetoothed.float16, "block_size": 256}, {}),
+        ((), {"size": 20260128, "dtype": ninetoothed.float16, "block_size": 1024}, {}),
+        ((), {"size": 20260128, "dtype": ninetoothed.float32, "block_size": 512}, {}),
+        ((), {"size": 20260128, "dtype": ninetoothed.float32, "block_size": 1024}, {}),
+        (
+            (),
+            {"size": 1127, "dtype": ninetoothed.float16, "block_size": 64},
+            {"num_warps": 4},
+        ),
+        (
+            (),
+            {"size": 1127, "dtype": ninetoothed.float16, "block_size": 64},
+            {"num_warps": 8},
+        ),
+        (
+            (),
+            {"size": 1127, "dtype": ninetoothed.float16, "block_size": 256},
+            {"num_warps": 4, "num_stages": 1},
+        ),
+        (
+            (),
+            {"size": 1127, "dtype": ninetoothed.float16, "block_size": 256},
+            {"num_warps": 8, "num_stages": 1},
+        ),
+        ((), {"size": 1127, "dtype": ninetoothed.float32, "block_size": 512}, {}),
+    )
+
+    kernel = ninetoothed.build(
+        premake,
+        configs,
+        meta_parameters=("block_size",),
+        caller=caller,
+        kernel_name=kernel_name,
+        output_dir=output_dir,
+    )
+
+    input = torch.randn((size,), dtype=dtype, device=device)
+    other = torch.randn((size,), dtype=dtype, device=device)
+    alpha = torch.randn((), dtype=torch.float64)
+    output = torch.empty_like(input)
+
+    kernel(input, other, alpha, output, size, ninetoothed_dtype)
+
+    shutil.rmtree(output_dir)
+
+    expected = torch.add(input, other, alpha=alpha)
+
+    assert torch.allclose(output, expected, rtol=rtol, atol=atol)

--- a/tests/test_conv2d.py
+++ b/tests/test_conv2d.py
@@ -49,17 +49,18 @@ def arrangement(
 
 
 def premake(
+    n=None,
+    c=None,
+    h=None,
+    w=None,
+    k=None,
+    r=None,
+    s=None,
     dtype=None,
-    constexpr_shapes=False,
     block_size_m=64,
     block_size_n=64,
     block_size_k=64,
 ):
-    if constexpr_shapes:
-        shape_options = {"constexpr": True}
-    else:
-        shape_options = None
-
     arrangement_ = functools.partial(
         arrangement,
         BLOCK_SIZE_M=block_size_m,
@@ -67,9 +68,22 @@ def premake(
         BLOCK_SIZE_K=block_size_k,
     )
     application = matmul.application
-    tensors = tuple(
-        Tensor(4, dtype=dtype, shape_options=shape_options) for _ in range(3)
-    )
+
+    if h is not None and r is not None:
+        p = h - r + 1
+    else:
+        p = None
+
+    if w is not None and s is not None:
+        q = w - s + 1
+    else:
+        q = None
+
+    input = Tensor(shape=(n, c, h, w), dtype=dtype)
+    filter = Tensor(shape=(k, c, r, s), dtype=dtype)
+    output = Tensor(shape=(n, k, p, q), dtype=dtype)
+
+    tensors = (input, filter, output)
 
     return arrangement_, application, tensors
 


### PR DESCRIPTION
## Summary
- Add `ninetoothed.build` for multi-config AOT kernel compilation with optional auto-tuning of meta-parameters (e.g., `block_size`, `num_warps`).
- Compile multiple kernel configurations in parallel using `ProcessPoolExecutor` and generate a unified C++ dispatch function.
- Auto-tune meta-parameters by benchmarking all configs and persist results in a CSV cache, usable from both Python (skip re-tuning on rebuild) and C++ (runtime lookup via `ninetoothed::AutoTuningCache`).
- Allow partial shape initialization in `Tensor` (mix of concrete sizes and symbolic `None` dimensions).
- Extract C++ class templates into standalone header files under `src/ninetoothed/templates/`.

## Testing

`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.20, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/huangjiacheng/ninetoothed
configfile: pyproject.toml
plugins: cov-7.1.0, anyio-4.13.0, xdist-3.8.0
collected 213 items

tests/test_add.py .                                                      [  0%]
tests/test_addmm.py ..                                                   [  1%]
tests/test_aot.py .........                                              [  5%]
tests/test_aot_auto_tuning.py ....                                       [  7%]
tests/test_attention.py ........                                         [ 11%]
tests/test_auto_tuner.py ....                                            [ 13%]
tests/test_clone.py ....                                                 [ 15%]
tests/test_conv2d.py ....                                                [ 16%]
tests/test_data_ptr.py .                                                 [ 17%]
tests/test_debugging.py .                                                [ 17%]
tests/test_dropout.py .                                                  [ 18%]
tests/test_eval.py ........                                              [ 22%]
tests/test_expand.py .                                                   [ 22%]
tests/test_generation.py ............................................... [ 44%]
.............................                                            [ 58%]
tests/test_getitem.py ..........                                         [ 62%]
tests/test_ipynb.py .                                                    [ 63%]
tests/test_jagged.py ................                                    [ 70%]
tests/test_matmul.py ..                                                  [ 71%]
tests/test_max_pool2d.py ..                                              [ 72%]
tests/test_naming.py .......                                             [ 76%]
tests/test_pad.py ................................................       [ 98%]
tests/test_pow.py .                                                      [ 99%]
tests/test_softmax.py .                                                  [ 99%]
tests/test_unsqueeze.py .                                                [100%]

======================= 213 passed in 163.73s (0:02:43) ========================
```
