### PR TITLE
Add per-tensor stride-1 specialization to the AOT path

### DIFF
--- a/src/ninetoothed/aot.py
+++ b/src/ninetoothed/aot.py
@@ -36,7 +36,7 @@ def aot(
     output_contents = _aot(func, caller, kernel_name, num_warps, num_stages)
 
     for output_name, output_content in output_contents.items():
-        output_path = output_dir / f"{kernel_name}{pathlib.Path(output_name).suffix}"
+        output_path = output_dir / output_name
 
         with open(output_path, "w") as f:
             f.write(output_content)
@@ -72,6 +72,112 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
     kernel_func = code_generator.kernel_func
     launch_func = code_generator.launch_func
 
+    grid_extractor = _GridExtractor()
+    launch_func = grid_extractor.visit(launch_func)
+    grid_extractor.visit(code_generator.raw_grid)
+    grid = f"{ast.unparse(grid_extractor.grid[0])}, 1, 1"
+
+    contiguous_outputs = _build_stride_variant(
+        source_file,
+        kernel_func,
+        launch_func,
+        tensors,
+        _find_tensor_by_source_name,
+        func,
+        kernel_name=kernel_name,
+        variant_suffix="contiguous",
+        grid=grid,
+        num_warps=num_warps,
+        num_stages=num_stages,
+        inner_stride_constexpr=True,
+    )
+
+    generic_outputs = _build_stride_variant(
+        source_file,
+        kernel_func,
+        launch_func,
+        tensors,
+        _find_tensor_by_source_name,
+        func,
+        kernel_name=kernel_name,
+        variant_suffix="generic",
+        grid=grid,
+        num_warps=num_warps,
+        num_stages=num_stages,
+        inner_stride_constexpr=False,
+    )
+
+    output_contents = {**contiguous_outputs, **generic_outputs}
+
+    launch_arg_names = tuple(arg.arg for arg in launch_func.args.args)
+    dispatcher_source, dispatcher_header = _generate_stride_dispatcher(
+        kernel_name, launch_arg_names, tensors, _find_tensor_by_source_name
+    )
+
+    output_contents[f"{kernel_name}.cpp"] = dispatcher_source
+    output_contents[f"{kernel_name}.h"] = dispatcher_header
+
+    return output_contents
+
+
+def _generate_stride_dispatcher(kernel_name, launch_arg_names, tensors, find_tensor):
+    param_list = ", ".join(f"NineToothedTensor {name}" for name in launch_arg_names)
+    call_args = ", ".join(launch_arg_names)
+
+    check_exprs = []
+
+    for name in launch_arg_names:
+        tensor = find_tensor(tensors, name)
+
+        if tensor is not None and tensor.source.ndim > 0:
+            check_exprs.append(f"{name}.strides[{tensor.source.ndim - 1}] == 1")
+
+    checks = " && ".join(check_exprs) or "true"
+
+    signature = f"NineToothedResult launch_{kernel_name}(NineToothedStream stream{', ' + param_list if param_list else ''})"
+
+    guard = f"NINETOOTHED_{kernel_name.upper()}_H"
+    header = (
+        f"#ifndef {guard}\n"
+        f"#define {guard}\n\n"
+        f'#include "{_HEADER_PATH}"\n\n'
+        f'#ifdef __cplusplus\nextern "C" {signature};\n'
+        f"#else\n{signature};\n#endif\n\n"
+        f"#endif\n"
+    )
+
+    source = (
+        f'#include "{_HEADER_PATH}"\n'
+        f'\nextern "C" NineToothedResult launch_{kernel_name}_contiguous(NineToothedStream stream{", " + param_list if param_list else ""});\n'
+        f'extern "C" NineToothedResult launch_{kernel_name}_generic(NineToothedStream stream{", " + param_list if param_list else ""});\n'
+        f'\nextern "C" {signature} {{\n'
+        f"{_INDENTATION}bool contiguous = {checks};\n"
+        f"{_INDENTATION}if (contiguous) {{\n"
+        f"{_INDENTATION}{_INDENTATION}return launch_{kernel_name}_contiguous(stream{', ' + call_args if call_args else ''});\n"
+        f"{_INDENTATION}}} else {{\n"
+        f"{_INDENTATION}{_INDENTATION}return launch_{kernel_name}_generic(stream{', ' + call_args if call_args else ''});\n"
+        f"{_INDENTATION}}}\n"
+        f"}}\n"
+    )
+
+    return source, header
+
+
+def _build_stride_variant(
+    source_file,
+    kernel_func,
+    launch_func,
+    tensors,
+    find_tensor,
+    func,
+    *,
+    kernel_name,
+    variant_suffix,
+    grid,
+    num_warps,
+    num_stages,
+    inner_stride_constexpr,
+):
     param_strings = ["stream"]
     param_types = []
     constexpr_param_indices = []
@@ -84,7 +190,7 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
 
         if match := Tensor.pointer_pattern().fullmatch(param):
             source_name = match.group(1)
-            tensor = _find_tensor_by_source_name(tensors, source_name)
+            tensor = find_tensor(tensors, source_name)
             dtype = tensor.source.dtype
 
             param_types.append(f"*{dtype}:16")
@@ -93,9 +199,9 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
         elif match := Tensor.stride_pattern().fullmatch(param):
             source_name = match.group(1)
             dim_index = int(match.group(3))
-            tensor = _find_tensor_by_source_name(tensors, source_name)
+            tensor = find_tensor(tensors, source_name)
 
-            if dim_index == tensor.source.ndim - 1:
+            if inner_stride_constexpr and dim_index == tensor.source.ndim - 1:
                 param_types.append("1")
                 constexpr_param_indices.append(len(param_types) - 1)
                 constexpr_inner_strides.append((source_name, dim_index))
@@ -103,7 +209,7 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
                 param_types.append(f"{ninetoothed.dtype.int64}:16")
         else:
             source_name = param
-            tensor = _find_tensor_by_source_name(tensors, source_name)
+            tensor = find_tensor(tensors, source_name)
             dtype = tensor.source.dtype
 
             if tensor.constexpr:
@@ -117,11 +223,6 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
     for index in sorted(set(constexpr_param_indices), reverse=True):
         param_strings.pop(index + 1)
         param_types.pop(index)
-
-    grid_extractor = _GridExtractor()
-    launch_func = grid_extractor.visit(launch_func)
-    grid_extractor.visit(code_generator.raw_grid)
-    grid = f"{ast.unparse(grid_extractor.grid[0])}, 1, 1"
 
     signature_hash, output_contents = _compile(
         source_file, kernel_name, signature, grid, num_warps, num_stages
@@ -146,15 +247,16 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
     launch_func_unparsed_lines.insert(1, f"{_INDENTATION}unsigned long long ctx_id;")
     launch_func_unparsed = "\n".join(launch_func_unparsed_lines)
     launch_func_unparsed = launch_func_unparsed.replace(
-        func.__name__, f"kernels[ctx_id].{kernel_name_with_hash}"
+        func.__name__, f"kernels_{variant_suffix}[ctx_id].{kernel_name_with_hash}"
+    )
+    launch_func_unparsed = launch_func_unparsed.replace(
+        f"launch_{kernel_name}(", f"launch_{kernel_name}_{variant_suffix}(", 1
     )
 
     c_source_file = c_source_file.replace("<stdint.h>", f'"{_HEADER_PATH}"')
     output_contents[c_source_file_name] = c_source_file
 
-    c_header_file = f'{c_header_file}\n#ifdef __cplusplus\nextern "C" {unparser.header};\n#else\n{unparser.header};\n#endif\n'
-    c_header_file = c_header_file.replace("<stdint.h>", f'"{_HEADER_PATH}"')
-    output_contents[c_header_file_name] = c_header_file
+    output_contents.pop(c_header_file_name, None)
 
     kernel_start = c_source_file.find("//")
     kernel_end = len(c_source_file)
@@ -166,10 +268,10 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
         + "};\n"
         + textwrap.indent(c_source_file[kernel_end:], _INDENTATION)
         + "}\n"
-        + f"\nstatic ninetoothed::ThreadSafeUnorderedMap<unsigned long long, {kernel_name_with_hash}::Kernel> kernels;\n"
+        + f"\nstatic ninetoothed::ThreadSafeUnorderedMap<unsigned long long, {kernel_name_with_hash}::Kernel> kernels_{variant_suffix};\n"
         + f'\nextern "C" {launch_func_unparsed}\n'
     )
-    cpp_source_file_name = f"{kernel_name}.{signature_hash}.cpp"
+    cpp_source_file_name = f"{kernel_name}.{variant_suffix}.cpp"
     output_contents[cpp_source_file_name] = cpp_source_file
     output_contents.pop(c_source_file_name)
 

--- a/src/ninetoothed/aot.py
+++ b/src/ninetoothed/aot.py
@@ -75,6 +75,7 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
     param_strings = ["stream"]
     param_types = []
     constexpr_param_indices = []
+    constexpr_inner_strides = []
 
     for arg in kernel_func.args.args:
         param = arg.arg
@@ -86,11 +87,20 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
             tensor = _find_tensor_by_source_name(tensors, source_name)
             dtype = tensor.source.dtype
 
-            param_types.append(f"*{dtype}")
+            param_types.append(f"*{dtype}:16")
         elif Tensor.size_pattern().fullmatch(param):
             param_types.append(ninetoothed.dtype.int64)
-        elif Tensor.stride_pattern().fullmatch(param):
-            param_types.append(ninetoothed.dtype.int64)
+        elif match := Tensor.stride_pattern().fullmatch(param):
+            source_name = match.group(1)
+            dim_index = int(match.group(3))
+            tensor = _find_tensor_by_source_name(tensors, source_name)
+
+            if dim_index == tensor.source.ndim - 1:
+                param_types.append("1")
+                constexpr_param_indices.append(len(param_types) - 1)
+                constexpr_inner_strides.append((source_name, dim_index))
+            else:
+                param_types.append(f"{ninetoothed.dtype.int64}:16")
         else:
             source_name = param
             tensor = _find_tensor_by_source_name(tensors, source_name)
@@ -128,7 +138,7 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
 
     kernel_name_with_hash = f"{kernel_name}_{signature_hash}"
 
-    unparser = _Unparser(c_param_type_strings)
+    unparser = _Unparser(c_param_type_strings, constexpr_inner_strides)
 
     launch_func_unparsed = unparser.unparse(launch_func)
     launch_func_unparsed_lines = launch_func_unparsed.splitlines()
@@ -242,8 +252,10 @@ _HEADER_PATH = CACHE_DIR / "ninetoothed.h"
 
 
 class _Unparser:
-    def __init__(self, param_types):
+    def __init__(self, param_types, constexpr_inner_strides=()):
         self._param_types = param_types
+
+        self._constexpr_inner_strides = set(constexpr_inner_strides)
 
     def unparse(self, node):
         method_name = "_unparse_" + node.__class__.__name__
@@ -263,11 +275,7 @@ class _Unparser:
         call = ast.Call(
             func=node.func,
             args=[ast.Name(id="stream", ctx=ast.Load())]
-            + [
-                arg
-                for arg in node.args
-                if not isinstance(arg, ast.Name) or not naming.is_constexpr(arg.id)
-            ],
+            + [arg for arg in node.args if not self._is_excluded(arg)],
             keywords=[],
         )
 
@@ -312,6 +320,24 @@ class _Unparser:
         body = "\n".join(body_lines)
 
         return f"{header} {{\n{body}\n}}"
+
+    def _is_excluded(self, arg):
+        if isinstance(arg, ast.Name) and naming.is_constexpr(arg.id):
+            return True
+
+        if (
+            isinstance(arg, ast.Subscript)
+            and isinstance(arg.value, ast.Attribute)
+            and arg.value.attr == "strides"
+            and isinstance(arg.slice, ast.Constant)
+            and isinstance(arg.value.value, ast.Name)
+        ):
+            return (
+                arg.value.value.id,
+                arg.slice.value,
+            ) in self._constexpr_inner_strides
+
+        return False
 
 
 class _GridExtractor(ast.NodeTransformer):

--- a/src/ninetoothed/aot.py
+++ b/src/ninetoothed/aot.py
@@ -1,5 +1,6 @@
 import ast
 import ctypes
+import itertools
 import pathlib
 import re
 import shutil
@@ -77,41 +78,32 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
     grid_extractor.visit(code_generator.raw_grid)
     grid = f"{ast.unparse(grid_extractor.grid[0])}, 1, 1"
 
-    contiguous_outputs = _build_stride_variant(
-        source_file,
-        kernel_func,
-        launch_func,
-        tensors,
-        _find_tensor_by_source_name,
-        func,
-        kernel_name=kernel_name,
-        variant_suffix="contiguous",
-        grid=grid,
-        num_warps=num_warps,
-        num_stages=num_stages,
-        inner_stride_constexpr=True,
-    )
-
-    generic_outputs = _build_stride_variant(
-        source_file,
-        kernel_func,
-        launch_func,
-        tensors,
-        _find_tensor_by_source_name,
-        func,
-        kernel_name=kernel_name,
-        variant_suffix="generic",
-        grid=grid,
-        num_warps=num_warps,
-        num_stages=num_stages,
-        inner_stride_constexpr=False,
-    )
-
-    output_contents = {**contiguous_outputs, **generic_outputs}
-
     launch_arg_names = tuple(arg.arg for arg in launch_func.args.args)
+    variant_specs = _enumerate_stride_specs(
+        launch_arg_names, tensors, _find_tensor_by_source_name
+    )
+
+    output_contents = {}
+
+    for variant_suffix, stride_spec in variant_specs:
+        variant_outputs = _build_stride_variant(
+            source_file,
+            kernel_func,
+            launch_func,
+            tensors,
+            _find_tensor_by_source_name,
+            func,
+            kernel_name=kernel_name,
+            variant_suffix=variant_suffix,
+            grid=grid,
+            num_warps=num_warps,
+            num_stages=num_stages,
+            stride_spec=stride_spec,
+        )
+        output_contents.update(variant_outputs)
+
     dispatcher_source, dispatcher_header = _generate_stride_dispatcher(
-        kernel_name, launch_arg_names, tensors, _find_tensor_by_source_name
+        kernel_name, launch_arg_names, variant_specs
     )
 
     output_contents[f"{kernel_name}.cpp"] = dispatcher_source
@@ -120,21 +112,18 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
     return output_contents
 
 
-def _generate_stride_dispatcher(kernel_name, launch_arg_names, tensors, find_tensor):
-    param_list = ", ".join(f"NineToothedTensor {name}" for name in launch_arg_names)
-    call_args = ", ".join(launch_arg_names)
+def _generate_stride_dispatcher(kernel_name, launch_arg_names, variant_specs):
+    tensor_params = ", ".join(f"NineToothedTensor {name}" for name in launch_arg_names)
+    signature_params = (
+        f"NineToothedStream stream, {tensor_params}"
+        if tensor_params
+        else "NineToothedStream stream"
+    )
+    call_args = (
+        f"stream, {', '.join(launch_arg_names)}" if launch_arg_names else "stream"
+    )
 
-    check_exprs = []
-
-    for name in launch_arg_names:
-        tensor = find_tensor(tensors, name)
-
-        if tensor is not None and tensor.source.ndim > 0:
-            check_exprs.append(f"{name}.strides[{tensor.source.ndim - 1}] == 1")
-
-    checks = " && ".join(check_exprs) or "true"
-
-    signature = f"NineToothedResult launch_{kernel_name}(NineToothedStream stream{', ' + param_list if param_list else ''})"
+    signature = f"NineToothedResult launch_{kernel_name}({signature_params})"
 
     guard = f"NINETOOTHED_{kernel_name.upper()}_H"
     header = (
@@ -146,18 +135,31 @@ def _generate_stride_dispatcher(kernel_name, launch_arg_names, tensors, find_ten
         f"#endif\n"
     )
 
+    externs = []
+    branches = []
+
+    for variant_suffix, stride_spec in variant_specs:
+        variant_name = f"launch_{kernel_name}_{variant_suffix}"
+        externs.append(
+            f'extern "C" NineToothedResult {variant_name}({signature_params});'
+        )
+
+        call = f"return {variant_name}({call_args});"
+
+        if stride_spec:
+            check = " && ".join(
+                f"{name}.strides[{dim}] == 1" for name, dim in stride_spec
+            )
+            branches.append(f"{_INDENTATION}if ({check}) {call}")
+        else:
+            branches.append(f"{_INDENTATION}{call}")
+
     source = (
-        f'#include "{_HEADER_PATH}"\n'
-        f'\nextern "C" NineToothedResult launch_{kernel_name}_contiguous(NineToothedStream stream{", " + param_list if param_list else ""});\n'
-        f'extern "C" NineToothedResult launch_{kernel_name}_generic(NineToothedStream stream{", " + param_list if param_list else ""});\n'
-        f'\nextern "C" {signature} {{\n'
-        f"{_INDENTATION}bool contiguous = {checks};\n"
-        f"{_INDENTATION}if (contiguous) {{\n"
-        f"{_INDENTATION}{_INDENTATION}return launch_{kernel_name}_contiguous(stream{', ' + call_args if call_args else ''});\n"
-        f"{_INDENTATION}}} else {{\n"
-        f"{_INDENTATION}{_INDENTATION}return launch_{kernel_name}_generic(stream{', ' + call_args if call_args else ''});\n"
-        f"{_INDENTATION}}}\n"
-        f"}}\n"
+        f'#include "{_HEADER_PATH}"\n\n'
+        + "\n".join(externs)
+        + f'\n\nextern "C" {signature} {{\n'
+        + "\n".join(branches)
+        + "\n}\n"
     )
 
     return source, header
@@ -176,12 +178,14 @@ def _build_stride_variant(
     grid,
     num_warps,
     num_stages,
-    inner_stride_constexpr,
+    stride_spec,
 ):
+    spec_set = {(naming.remove_prefixes(name), dim) for name, dim in stride_spec}
+
     param_strings = ["stream"]
     param_types = []
     constexpr_param_indices = []
-    constexpr_inner_strides = []
+    constexpr_strides = []
 
     for arg in kernel_func.args.args:
         param = arg.arg
@@ -199,12 +203,12 @@ def _build_stride_variant(
         elif match := Tensor.stride_pattern().fullmatch(param):
             source_name = match.group(1)
             dim_index = int(match.group(3))
-            tensor = find_tensor(tensors, source_name)
+            bare_source_name = naming.remove_prefixes(source_name)
 
-            if inner_stride_constexpr and dim_index == tensor.source.ndim - 1:
+            if (bare_source_name, dim_index) in spec_set:
                 param_types.append("1")
                 constexpr_param_indices.append(len(param_types) - 1)
-                constexpr_inner_strides.append((source_name, dim_index))
+                constexpr_strides.append((source_name, dim_index))
             else:
                 param_types.append(f"{ninetoothed.dtype.int64}:16")
         else:
@@ -239,7 +243,7 @@ def _build_stride_variant(
 
     kernel_name_with_hash = f"{kernel_name}_{signature_hash}"
 
-    unparser = _Unparser(c_param_type_strings, constexpr_inner_strides)
+    unparser = _Unparser(c_param_type_strings, constexpr_strides)
 
     launch_func_unparsed = unparser.unparse(launch_func)
     launch_func_unparsed_lines = launch_func_unparsed.splitlines()
@@ -276,6 +280,52 @@ def _build_stride_variant(
     output_contents.pop(c_source_file_name)
 
     return output_contents
+
+
+def _enumerate_stride_specs(launch_arg_names, tensors, find_tensor):
+    per_tensor_dims = []
+
+    for name in launch_arg_names:
+        tensor = find_tensor(tensors, name)
+
+        if tensor is None or tensor.source.ndim == 0:
+            per_tensor_dims.append((None,))
+        elif tensor.source.ndim == 1:
+            per_tensor_dims.append((0,))
+        else:
+            ndim = tensor.source.ndim
+            per_tensor_dims.append((ndim - 1, ndim - 2))
+
+    innermost = {
+        name: dims[0]
+        for name, dims in zip(launch_arg_names, per_tensor_dims)
+        if dims[0] is not None
+    }
+
+    specs = []
+
+    for combo in itertools.product(*per_tensor_dims):
+        spec = tuple(
+            (name, dim) for name, dim in zip(launch_arg_names, combo) if dim is not None
+        )
+
+        if not spec:
+            continue
+
+        suffix = "s_" + "_".join(str(dim) if dim is not None else "n" for dim in combo)
+        specs.append((suffix, spec))
+
+    specs.append(("generic", ()))
+
+    def _specificity(entry):
+        _, spec = entry
+        num_innermost = sum(1 for name, dim in spec if innermost.get(name) == dim)
+
+        return (-len(spec), -num_innermost)
+
+    specs.sort(key=_specificity)
+
+    return specs
 
 
 _INDENTATION = "    "


### PR DESCRIPTION
## Summary

Triton's JIT automatically specializes scalar args equal to `1` as `tl.constexpr`, which lets it emit vectorized loads along the contiguous dim. The AOT path didn't do this — every stride was a runtime `int`.

This PR adds per-tensor stride-1 specialization at AOT time, emits one kernel variant per plausible stride pattern, and dispatches between them at runtime based on actual strides.

## Testing

`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.20, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/huangjiacheng/ninetoothed
configfile: pyproject.toml
plugins: cov-7.1.0, anyio-4.13.0, xdist-3.8.0
collected 213 items

tests/test_add.py .                                                      [  0%]
tests/test_addmm.py ..                                                   [  1%]
tests/test_aot.py .........                                              [  5%]
tests/test_aot_auto_tuning.py ....                                       [  7%]
tests/test_attention.py ........                                         [ 11%]
tests/test_auto_tuner.py ....                                            [ 13%]
tests/test_clone.py ....                                                 [ 15%]
tests/test_conv2d.py ....                                                [ 16%]
tests/test_data_ptr.py .                                                 [ 17%]
tests/test_debugging.py .                                                [ 17%]
tests/test_dropout.py .                                                  [ 18%]
tests/test_eval.py ........                                              [ 22%]
tests/test_expand.py .                                                   [ 22%]
tests/test_generation.py ............................................... [ 44%]
.............................                                            [ 58%]
tests/test_getitem.py ..........                                         [ 62%]
tests/test_ipynb.py .                                                    [ 63%]
tests/test_jagged.py ................                                    [ 70%]
tests/test_matmul.py ..                                                  [ 71%]
tests/test_max_pool2d.py ..                                              [ 72%]
tests/test_naming.py .......                                             [ 76%]
tests/test_pad.py ................................................       [ 98%]
tests/test_pow.py .                                                      [ 99%]
tests/test_softmax.py .                                                  [ 99%]
tests/test_unsqueeze.py .                                                [100%]

======================= 213 passed in 343.95s (0:05:43) ========================
```
