### PR TITLE
Add runtime re-auto-tuning for `ninetoothed.build`

### DIFF
--- a/src/ninetoothed/build.py
+++ b/src/ninetoothed/build.py
@@ -6,6 +6,7 @@ import inspect
 import itertools
 import multiprocessing
 import pathlib
+import textwrap
 
 import ninetoothed
 from ninetoothed.aot import (
@@ -300,23 +301,33 @@ class _MetaTensor:
 def _generate_kernel_with_auto_tuning(
     config_to_best_meta_arguments, non_tensor_param_names, *, kernel_name, output_dir
 ):
-    num_non_meta_premake_params = len(tuple(config_to_best_meta_arguments.keys())[0])
+    num_non_meta_premake_params = len(next(iter(config_to_best_meta_arguments)))
 
     config_param_names = non_tensor_param_names[:num_non_meta_premake_params]
     meta_param_names = non_tensor_param_names[num_non_meta_premake_params:]
     meta_param_types = tuple("int" for _ in meta_param_names)
 
-    csv_path = output_dir / f"{kernel_name}.csv"
-    config_args = ", ".join(f"static_cast<int>({name})" for name in config_param_names)
-    cache_line = (
-        f'{_INDENTATION}static ninetoothed::AutoTuningCache cache{{"{csv_path}"}};'
+    declarations = _generate_declaration_statements(meta_param_types, meta_param_names)
+
+    branches = tuple(
+        _generate_dispatch_branch(
+            dict(zip(config_param_names, config)),
+            dict(zip(meta_param_names, meta_arguments)),
+        )
+        for config, meta_arguments in config_to_best_meta_arguments.items()
     )
-    lookup_line = f"{_INDENTATION}auto meta{{cache.lookup({{{config_args}}})}};"
-    meta_assignments = "\n".join(
-        f"{_INDENTATION}auto {name}{{meta[{i}]}};"
-        for i, name in enumerate(meta_param_names)
+
+    dispatch = "\nelse ".join(branches)
+
+    if config_param_names:
+        csv_path = output_dir / f"{kernel_name}.csv"
+        dispatch += "\nelse " + _generate_dispatch_fallback(
+            config_param_names, meta_param_names, csv_path
+        )
+
+    meta_param_initialization = textwrap.indent(
+        f"{declarations}\n{dispatch}", _INDENTATION
     )
-    meta_param_initialization = f"{cache_line}\n{lookup_line}\n{meta_assignments}"
 
     meta_param_decl_exprs = _generate_declaration_expressions(
         meta_param_types, meta_param_names
@@ -606,6 +617,34 @@ def _generate_declaration(type, name):
 
 def _generate_condition(combination):
     return " && ".join(f"{param} == {value}" for param, value in combination.items())
+
+
+def _generate_dispatch_branch(config, meta_arguments):
+    body = textwrap.indent(
+        _generate_assignment_statements(meta_arguments.keys(), meta_arguments.values()),
+        _INDENTATION,
+    )
+
+    if not config:
+        return f"{{\n{body}\n}}"
+
+    return f"if ({_generate_condition(config)}) {{\n{body}\n}}"
+
+
+def _generate_dispatch_fallback(config_param_names, meta_param_names, csv_path):
+    config_arguments = ", ".join(
+        f"static_cast<int>({name})" for name in config_param_names
+    )
+    meta_arguments = tuple(f"meta_arguments[{i}]" for i in range(len(meta_param_names)))
+    body = "\n".join(
+        (
+            f'static ninetoothed::AutoTuningCache cache{{"{csv_path}"}};',
+            f"auto meta_arguments{{cache.lookup({{{config_arguments}}})}};",
+            _generate_assignment_statements(meta_param_names, meta_arguments),
+        )
+    )
+
+    return f"{{\n{textwrap.indent(body, _INDENTATION)}\n}}"
 
 
 def _generate_suffix(values):

--- a/src/ninetoothed/build.py
+++ b/src/ninetoothed/build.py
@@ -523,12 +523,9 @@ def _read_auto_tuning_cache(path):
     with open(path) as f:
         rows = tuple(csv.reader(f))
 
-    for i in range(0, len(rows), 2):
+    for i in range(2, len(rows), 2):
         config = tuple(int(value) for value in rows[i] if value)
         meta_args = tuple(int(value) for value in rows[i + 1])
-
-        if not config:
-            continue
 
         config_to_best_meta_arguments[config] = meta_args
 

--- a/src/ninetoothed/build.py
+++ b/src/ninetoothed/build.py
@@ -287,6 +287,7 @@ def _auto_tune(
 
         config_to_best_meta_arguments[int_configs] = best_meta_arguments
 
+    _normalize_meta_arguments(config_to_best_meta_arguments, configs, meta_parameters)
     _write_auto_tuning_cache(csv_path, config_to_best_meta_arguments)
 
     return config_to_best_meta_arguments
@@ -391,11 +392,14 @@ def _read_auto_tuning_cache(path):
     config_to_best_meta_arguments = {}
 
     with open(path) as f:
-        rows = list(csv.reader(f))
+        rows = tuple(csv.reader(f))
 
     for i in range(0, len(rows), 2):
-        config = tuple(int(value) for value in rows[i])
+        config = tuple(int(value) for value in rows[i] if value)
         meta_args = tuple(int(value) for value in rows[i + 1])
+
+        if not config:
+            continue
 
         config_to_best_meta_arguments[config] = meta_args
 
@@ -403,10 +407,63 @@ def _read_auto_tuning_cache(path):
 
 
 def _write_auto_tuning_cache(path, config_to_best_meta_arguments):
+    default_meta = next(iter(config_to_best_meta_arguments.values()))
+
     with open(path, "w") as f:
-        csv.writer(f).writerows(
-            itertools.chain.from_iterable(config_to_best_meta_arguments.items())
-        )
+        writer = csv.writer(f)
+
+        writer.writerow(())
+        writer.writerow(default_meta)
+
+        for config, meta in config_to_best_meta_arguments.items():
+            writer.writerow(config)
+            writer.writerow(meta)
+
+
+def _append_auto_tuning_cache(path, new_entries):
+    with open(path, "a") as f:
+        writer = csv.writer(f)
+
+        for config, meta in new_entries.items():
+            writer.writerow(config)
+            writer.writerow(meta)
+
+
+def _normalize_meta_arguments(config_to_best_meta_arguments, configs, meta_parameters):
+    from ninetoothed.utils import calculate_default_configs
+
+    default_num_warps, default_num_stages = calculate_default_configs()
+    compilation_defaults = {
+        "num_warps": default_num_warps,
+        "num_stages": default_num_stages,
+    }
+
+    all_meta_names = {}
+
+    for config in configs:
+        _, kwargs, compilation_configs = config
+
+        meta_args = {
+            param: kwargs[param] for param in meta_parameters if param in kwargs
+        } | compilation_configs
+
+        for key in meta_args:
+            all_meta_names[key] = None
+
+    expected_len = len(all_meta_names)
+    meta_names = tuple(all_meta_names.keys())
+
+    for int_configs, meta_values in config_to_best_meta_arguments.items():
+        if len(meta_values) >= expected_len:
+            continue
+
+        padded = list(meta_values)
+
+        for i in range(len(meta_values), expected_len):
+            name = meta_names[i]
+            padded.append(compilation_defaults.get(name, 0))
+
+        config_to_best_meta_arguments[int_configs] = tuple(padded)
 
 
 def _generate_declaration_statements(types, names):

--- a/src/ninetoothed/build.py
+++ b/src/ninetoothed/build.py
@@ -143,8 +143,10 @@ def build(
     kernel = _generate_launch_func(kernel_name=kernel_name, output_dir=output_dir)
 
     if meta_parameters is not None:
+        kernel_before_auto_tuning = kernel
+
         config_to_best_meta_arguments = _auto_tune(
-            kernel,
+            kernel_before_auto_tuning,
             configs,
             all_tensors,
             meta_parameters,
@@ -153,9 +155,19 @@ def build(
             output_dir=output_dir,
         )
 
-        return _generate_kernel_with_auto_tuning(
+        kernel_after_auto_tuning = _generate_kernel_with_auto_tuning(
             config_to_best_meta_arguments,
             non_tensor_param_names,
+            kernel_name=kernel_name,
+            output_dir=output_dir,
+        )
+
+        return _AutoTunedKernel(
+            kernel_after_auto_tuning=kernel_after_auto_tuning,
+            kernel_before_auto_tuning=kernel_before_auto_tuning,
+            configs=configs,
+            meta_parameters=meta_parameters,
+            config_to_best_meta_arguments=config_to_best_meta_arguments,
             kernel_name=kernel_name,
             output_dir=output_dir,
         )
@@ -164,6 +176,112 @@ def build(
 
 
 _DEFAULT_SIZES = tuple(2**i for i in range(10))
+
+_DEFAULT_RE_TUNE_AFTER = 16
+
+
+class _AutoTunedKernel:
+    def __init__(
+        self,
+        kernel_after_auto_tuning,
+        kernel_before_auto_tuning,
+        configs,
+        meta_parameters,
+        config_to_best_meta_arguments,
+        kernel_name,
+        output_dir,
+        re_tune_after=_DEFAULT_RE_TUNE_AFTER,
+    ):
+        self._kernel_after_auto_tuning = kernel_after_auto_tuning
+
+        self._kernel_before_auto_tuning = kernel_before_auto_tuning
+
+        self._kernel_name = kernel_name
+
+        self._output_dir = output_dir
+
+        self._re_tune_after = re_tune_after
+
+        self._num_non_meta_premake_params = len(
+            next(iter(config_to_best_meta_arguments.keys()))
+        )
+
+        meta_values = set()
+
+        for _, kwargs, compilation_configs in configs:
+            meta = {
+                param: kwargs[param] for param in meta_parameters if param in kwargs
+            } | compilation_configs
+
+            meta_values.add(tuple(_arg_to_int(value) for value in meta.values()))
+
+        self._all_meta_values = tuple(meta_values)
+
+        self._known_configs = set(config_to_best_meta_arguments.keys())
+
+        self._new_inputs = []
+
+    def __call__(self, *args, **kwargs):
+        _, _, config_key = self._split_args(args)
+
+        if config_key not in self._known_configs:
+            self._new_inputs.append((args, kwargs))
+
+            if len(self._new_inputs) >= self._re_tune_after:
+                self._re_tune()
+
+        return self._kernel_after_auto_tuning(*args, **kwargs)
+
+    def _re_tune(self):
+        import triton
+
+        csv_path = self._output_dir / f"{self._kernel_name}.csv"
+
+        new_entries = {}
+        seen_config_keys = set()
+
+        for args, _ in self._new_inputs:
+            tensor_args, config_args, config_key = self._split_args(args)
+
+            if config_key in seen_config_keys or config_key in self._known_configs:
+                continue
+
+            seen_config_keys.add(config_key)
+
+            best_time = float("inf")
+            best_meta = self._all_meta_values[0]
+
+            for meta_values in self._all_meta_values:
+                try:
+                    timing = triton.testing.do_bench(
+                        lambda meta_values=meta_values: self._kernel_before_auto_tuning(
+                            *tensor_args, *config_args, *meta_values
+                        )
+                    )
+                except Exception:
+                    timing = float("inf")
+
+                if timing < best_time:
+                    best_time = timing
+                    best_meta = meta_values
+
+            new_entries[config_key] = best_meta
+
+        if new_entries:
+            _append_auto_tuning_cache(csv_path, new_entries)
+            self._known_configs.update(new_entries.keys())
+
+        self._new_inputs.clear()
+
+    def _split_args(self, args):
+        if self._num_non_meta_premake_params <= 0:
+            return args, (), ()
+
+        tensor_args = args[: -self._num_non_meta_premake_params]
+        config_args = args[-self._num_non_meta_premake_params :]
+        config_key = tuple(_arg_to_int(arg) for arg in config_args)
+
+        return tensor_args, config_args, config_key
 
 
 class _MetaTensor:

--- a/src/ninetoothed/build.py
+++ b/src/ninetoothed/build.py
@@ -176,7 +176,11 @@ def build(
     return kernel
 
 
-_DEFAULT_SIZES = tuple(2**i for i in range(10))
+# TODO: Revisit this value with broader benchmarks. Short experiments on
+# `add` and `silu` showed that very small sizes (e.g., 64) produce
+# unreliable auto-tuning picks, while 256, 1024, and 4096 are all within
+# noise for the cases tested.
+_DEFAULT_SIZES = (256,)
 
 _DEFAULT_RE_TUNE_AFTER = 16
 

--- a/src/ninetoothed/templates/auto_tuning_cache.h
+++ b/src/ninetoothed/templates/auto_tuning_cache.h
@@ -11,9 +11,7 @@ public:
     AutoTuningCache(const std::string& path) : path{path} {}
 
     std::vector<int> lookup(const std::vector<int>& config) {
-        if (!loaded) {
-            load();
-        }
+        load();
 
         auto iter = cache.find(config);
 
@@ -21,20 +19,24 @@ public:
             return iter->second;
         }
 
-        return {};
+        return default_meta;
     }
 
 private:
     void load() {
+        cache.clear();
+
         std::ifstream file{path};
         std::string config_line;
         std::string meta_line;
 
+        if (std::getline(file, config_line) && std::getline(file, meta_line)) {
+            default_meta = parse(meta_line);
+        }
+
         while (std::getline(file, config_line) && std::getline(file, meta_line)) {
             cache[parse(config_line)] = parse(meta_line);
         }
-
-        loaded = true;
     }
 
     static std::vector<int> parse(const std::string& line) {
@@ -43,17 +45,33 @@ private:
         std::string token;
 
         while (std::getline(ss, token, ',')) {
-            values.push_back(std::stoi(token));
+            auto trimmed = trim(token);
+
+            if (!trimmed.empty()) {
+                values.push_back(std::stoi(trimmed));
+            }
         }
 
         return values;
     }
 
+    static std::string trim(const std::string& s) {
+        auto start = s.find_first_not_of(" \t\r\n");
+
+        if (start == std::string::npos) {
+            return "";
+        }
+
+        auto end = s.find_last_not_of(" \t\r\n");
+
+        return s.substr(start, end - start + 1);
+    }
+
     std::string path;
 
-    bool loaded{false};
-
     std::map<std::vector<int>, std::vector<int>> cache;
+
+    std::vector<int> default_meta;
 };
 
 }

--- a/src/ninetoothed/templates/auto_tuning_cache.h
+++ b/src/ninetoothed/templates/auto_tuning_cache.h
@@ -1,3 +1,4 @@
+#include <filesystem>
 #include <fstream>
 #include <map>
 #include <sstream>
@@ -24,6 +25,14 @@ public:
 
 private:
     void load() {
+        auto mtime = std::filesystem::last_write_time(path);
+
+        if (mtime == last_mtime) {
+            return;
+        }
+
+        last_mtime = mtime;
+
         cache.clear();
 
         std::ifstream file{path};
@@ -72,6 +81,8 @@ private:
     std::map<std::vector<int>, std::vector<int>> cache;
 
     std::vector<int> default_meta;
+
+    std::filesystem::file_time_type last_mtime;
 };
 
 }


### PR DESCRIPTION
## Summary

Extends the AOT auto-tuning cache so kernels can adapt to input shapes that weren't known at build time:

- **Fallback entry** — the cache stores a default meta-argument set (row 1 of the CSV, keyed by an empty config). When a runtime config isn't found, the C++ cache returns the fallback instead of failing.
- **`_AutoTunedKernel` wrapper** — tracks unseen config keys at call time and, after `re_tune_after` misses, benchmarks the meta-parameter variants for each new key and appends the best entries to the CSV.
- **Cache reload on change** — the C++ cache watches the CSV's modification time and reloads on the next lookup, so runtime-appended entries take effect without restarting the process.
- **Compile-time dispatch** — for configurations already in the cache at build time, the dispatcher emits a direct `if` chain instead of going through the CSV lookup, avoiding the map-lookup overhead for known shapes.
- **Warm-up simplification** — build-time auto-tuning now fills symbolic dimensions with a single default size (`256`) instead of sweeping ten powers of two, avoiding combinatorial blow-up when multiple tensors have symbolic shapes. A `TODO` records that this value was chosen from a limited sweep and should be revisited with broader benchmarks.
- **Cache hygiene** — preserve empty-config entries when reading, normalize meta arguments to a fixed order, and write the default entry on build.

## Testing

`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.20, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/huangjiacheng/ninetoothed
configfile: pyproject.toml
plugins: cov-7.1.0, anyio-4.13.0, xdist-3.8.0
collected 213 items

tests/test_add.py .                                                      [  0%]
tests/test_addmm.py ..                                                   [  1%]
tests/test_aot.py .........                                              [  5%]
tests/test_aot_auto_tuning.py ....                                       [  7%]
tests/test_attention.py ........                                         [ 11%]
tests/test_auto_tuner.py ....                                            [ 13%]
tests/test_clone.py ....                                                 [ 15%]
tests/test_conv2d.py ....                                                [ 16%]
tests/test_data_ptr.py .                                                 [ 17%]
tests/test_debugging.py .                                                [ 17%]
tests/test_dropout.py .                                                  [ 18%]
tests/test_eval.py ........                                              [ 22%]
tests/test_expand.py .                                                   [ 22%]
tests/test_generation.py ............................................... [ 44%]
.............................                                            [ 58%]
tests/test_getitem.py ..........                                         [ 62%]
tests/test_ipynb.py .                                                    [ 63%]
tests/test_jagged.py ................                                    [ 70%]
tests/test_matmul.py ..                                                  [ 71%]
tests/test_max_pool2d.py ..                                              [ 72%]
tests/test_naming.py .......                                             [ 76%]
tests/test_pad.py ................................................       [ 98%]
tests/test_pow.py .                                                      [ 99%]
tests/test_softmax.py .                                                  [ 99%]
tests/test_unsqueeze.py .                                                [100%]

======================= 213 passed in 347.72s (0:05:47) ========================
```
