### PR TITLE
Improve `ninetoothed.build` ergonomics

### DIFF
--- a/src/ninetoothed/build.py
+++ b/src/ninetoothed/build.py
@@ -16,6 +16,7 @@ from ninetoothed.aot import (
     _MACRO_MAPPING,
     _generate_launch_func,
     _KernelLaunchError,
+    _load_launch_func,
 )
 from ninetoothed.auto_tuner import AutoTuner
 from ninetoothed.tensor import Symbol
@@ -51,6 +52,13 @@ def build(
         caller = "cuda"
 
     output_dir = pathlib.Path(output_dir)
+
+    cached = _load_cached(
+        configs, meta_parameters, kernel_name=kernel_name, output_dir=output_dir
+    )
+
+    if cached is not None:
+        return cached
 
     kernel_names = []
     all_param_names = []
@@ -516,6 +524,34 @@ def _make(premake, config, caller, kernel_name, output_dir):
     )
 
     return kernel_name_, param_names, combination, config, tensors
+
+
+def _load_cached(configs, meta_parameters, *, kernel_name, output_dir):
+    so_path = output_dir / f"{kernel_name}.so"
+
+    if not so_path.exists():
+        return None
+
+    if meta_parameters is None:
+        return _load_launch_func(kernel_name=kernel_name, output_dir=output_dir)
+
+    csv_path = output_dir / f"{kernel_name}.csv"
+    config_to_best_meta_arguments = _read_auto_tuning_cache(csv_path)
+
+    if not config_to_best_meta_arguments:
+        return None
+
+    kernel = _load_launch_func(kernel_name=kernel_name, output_dir=output_dir)
+
+    return _AutoTunedKernel(
+        kernel_after_auto_tuning=kernel,
+        kernel_before_auto_tuning=kernel,
+        configs=configs,
+        meta_parameters=meta_parameters,
+        config_to_best_meta_arguments=config_to_best_meta_arguments,
+        kernel_name=kernel_name,
+        output_dir=output_dir,
+    )
 
 
 def _read_auto_tuning_cache(path):

--- a/src/ninetoothed/build.py
+++ b/src/ninetoothed/build.py
@@ -30,6 +30,7 @@ def build(
     caller=None,
     kernel_name=None,
     output_dir=None,
+    lazy=False,
 ):
     """Build a kernel from a ``premake`` function and ``configs``.
 
@@ -46,6 +47,10 @@ def build(
     :param caller: Who will call the compute kernel.
     :param kernel_name: The name for the generated kernel.
     :param output_dir: The directory to store the generated files.
+    :param lazy: If ``True``, defer the actual build until the returned
+        kernel is first called. Use this when ``build`` is invoked at
+        module import time and its ``ProcessPoolExecutor`` would
+        otherwise deadlock on the Python import lock.
     """
 
     if caller is None:
@@ -59,6 +64,18 @@ def build(
 
     if cached is not None:
         return cached
+
+    if lazy:
+        return _LazyKernel(
+            lambda: build(
+                premake,
+                configs,
+                meta_parameters=meta_parameters,
+                caller=caller,
+                kernel_name=kernel_name,
+                output_dir=output_dir,
+            )
+        )
 
     kernel_names = []
     all_param_names = []
@@ -191,6 +208,21 @@ def build(
 _DEFAULT_SIZES = (256,)
 
 _DEFAULT_RE_TUNE_AFTER = 16
+
+
+class _LazyKernel:
+    __slots__ = ("_factory", "_kernel")
+
+    def __init__(self, factory):
+        self._factory = factory
+
+        self._kernel = None
+
+    def __call__(self, *args, **kwargs):
+        if self._kernel is None:
+            self._kernel = self._factory()
+
+        return self._kernel(*args, **kwargs)
 
 
 class _AutoTunedKernel:

--- a/src/ninetoothed/build.py
+++ b/src/ninetoothed/build.py
@@ -333,11 +333,15 @@ class _MetaTensor:
     def __init__(self, shape, dtype):
         self.shape = []
 
+        self.upper_bounds = []
+
         for size in shape:
             if isinstance(size, Symbol):
                 self.shape.append(None)
+                self.upper_bounds.append(getattr(size, "upper_bound", None))
             else:
                 self.shape.append(size)
+                self.upper_bounds.append(None)
 
         self.dtype = dtype
 
@@ -491,9 +495,18 @@ def _warm_up(kernel, config, meta_tensors, *, caller):
     for meta_tensor in meta_tensors:
         all_sizes = []
 
-        for size in meta_tensor.shape:
+        for size, upper_bound in zip(meta_tensor.shape, meta_tensor.upper_bounds):
             if size is None:
-                all_sizes.append(_DEFAULT_SIZES)
+                if upper_bound is not None:
+                    all_sizes.append(
+                        tuple(
+                            dict.fromkeys(
+                                min(upper_bound, size) for size in _DEFAULT_SIZES
+                            )
+                        )
+                    )
+                else:
+                    all_sizes.append(_DEFAULT_SIZES)
             else:
                 all_sizes.append((size,))
 


### PR DESCRIPTION
## Summary

Three ergonomic improvements to `ninetoothed.build`:

- **Skip rebuild when output artifacts already exist** — if the `{kernel_name}.so` is already present (and, for auto-tuned kernels, the CSV cache has entries), `build` now loads the existing artifacts via `_load_launch_func` instead of re-running the spawn-based build and auto-tuning pipeline. Makes repeated imports of a `build`-based kernel effectively free after the first build.
- **`lazy=True` option** — defers the actual build until the returned kernel is first called. This is needed when `build` is invoked at module import time: the `ProcessPoolExecutor` backing `build` would otherwise deadlock on the Python import lock. `_LazyKernel` holds a factory and calls it on the first `__call__`.
- **Cap warm-up size using per-dim `upper_bound` hints** — `_warm_up` now honors `Symbol.upper_bound` on symbolic shape dims when sizing the warm-up tensors. For each symbolic dim with an `upper_bound`, every value in `_DEFAULT_SIZES` is clamped to the bound and deduped (preserving order). Lets kernels declare "this dim is usually small" via `Tensor(shape=(None, ...), shape_options=({"upper_bound": 4}, ...))` without blowing up warm-up memory when another symbolic dim (like K or N) is large. Dims without an `upper_bound` fall back to `_DEFAULT_SIZES` unchanged, so the change is backward-compatible.

Together these let consumers write `kernel = ninetoothed.build(..., lazy=True)` at module level with symbolic-batch kernel specs, pay the build cost only on the first invocation, and only once across sessions thanks to the artifact cache.

## Testing

`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.20, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/huangjiacheng/ninetoothed
configfile: pyproject.toml
plugins: cov-7.1.0, anyio-4.13.0, xdist-3.8.0
collected 213 items

tests/test_add.py .                                                      [  0%]
tests/test_addmm.py ..                                                   [  1%]
tests/test_aot.py .........                                              [  5%]
tests/test_aot_auto_tuning.py ....                                       [  7%]
tests/test_attention.py ........                                         [ 11%]
tests/test_auto_tuner.py ....                                            [ 13%]
tests/test_clone.py ....                                                 [ 15%]
tests/test_conv2d.py ....                                                [ 16%]
tests/test_data_ptr.py .                                                 [ 17%]
tests/test_debugging.py .                                                [ 17%]
tests/test_dropout.py .                                                  [ 18%]
tests/test_eval.py ........                                              [ 22%]
tests/test_expand.py .                                                   [ 22%]
tests/test_generation.py ............................................... [ 44%]
.............................                                            [ 58%]
tests/test_getitem.py ..........                                         [ 62%]
tests/test_ipynb.py .                                                    [ 63%]
tests/test_jagged.py ................                                    [ 70%]
tests/test_matmul.py ..                                                  [ 71%]
tests/test_max_pool2d.py ..                                              [ 72%]
tests/test_naming.py .......                                             [ 76%]
tests/test_pad.py ................................................       [ 98%]
tests/test_pow.py .                                                      [ 99%]
tests/test_softmax.py .                                                  [ 99%]
tests/test_unsqueeze.py .                                                [100%]

======================= 213 passed in 300.12s (0:05:00) ========================
```
