### PR TITLE
Invalidate `ninetoothed.build` cache when inputs change

### DIFF
--- a/src/ninetoothed/build.py
+++ b/src/ninetoothed/build.py
@@ -2,6 +2,7 @@ import concurrent.futures
 import csv
 import enum
 import functools
+import hashlib
 import inspect
 import itertools
 import multiprocessing
@@ -58,8 +59,19 @@ def build(
 
     output_dir = pathlib.Path(output_dir)
 
+    configs = tuple(configs)
+
+    if meta_parameters is not None:
+        meta_parameters = tuple(meta_parameters)
+
+    fingerprint = _compute_fingerprint(premake, configs, meta_parameters, caller)
+
     cached = _load_cached(
-        configs, meta_parameters, kernel_name=kernel_name, output_dir=output_dir
+        configs,
+        meta_parameters,
+        kernel_name=kernel_name,
+        output_dir=output_dir,
+        fingerprint=fingerprint,
     )
 
     if cached is not None:
@@ -167,6 +179,8 @@ def build(
     (output_dir / header_file_name).write_text(header_content)
 
     kernel = _generate_launch_func(kernel_name=kernel_name, output_dir=output_dir)
+
+    _write_fingerprint(kernel_name, output_dir, fingerprint)
 
     if meta_parameters is not None:
         kernel_before_auto_tuning = kernel
@@ -571,10 +585,13 @@ def _make(premake, config, caller, kernel_name, output_dir):
     return kernel_name_, param_names, combination, config, tensors
 
 
-def _load_cached(configs, meta_parameters, *, kernel_name, output_dir):
+def _load_cached(configs, meta_parameters, *, kernel_name, output_dir, fingerprint):
     so_path = output_dir / f"{kernel_name}.so"
 
     if not so_path.exists():
+        return None
+
+    if not _fingerprint_matches(kernel_name, output_dir, fingerprint):
         return None
 
     if meta_parameters is None:
@@ -597,6 +614,52 @@ def _load_cached(configs, meta_parameters, *, kernel_name, output_dir):
         kernel_name=kernel_name,
         output_dir=output_dir,
     )
+
+
+def _compute_fingerprint(premake, configs, meta_parameters, caller):
+    hasher = hashlib.sha256()
+
+    target = premake.func if isinstance(premake, functools.partial) else premake
+
+    try:
+        hasher.update(inspect.getsource(target).encode())
+    except (TypeError, OSError):
+        hasher.update(repr(target).encode())
+
+    if isinstance(premake, functools.partial):
+        hasher.update(repr(premake.args).encode())
+        hasher.update(repr(sorted(premake.keywords.items())).encode())
+
+    hasher.update(repr(configs).encode())
+    hasher.update(repr(meta_parameters).encode())
+    hasher.update(repr(caller).encode())
+
+    package_dir = pathlib.Path(__file__).parent
+
+    for path in (package_dir / "build.py", package_dir / "aot.py"):
+        try:
+            hasher.update(path.read_bytes())
+        except OSError:
+            pass
+
+    return hasher.hexdigest()
+
+
+def _fingerprint_matches(kernel_name, output_dir, fingerprint):
+    path = _fingerprint_path(kernel_name, output_dir)
+
+    if not path.exists():
+        return False
+
+    return path.read_text().strip() == fingerprint
+
+
+def _write_fingerprint(kernel_name, output_dir, fingerprint):
+    _fingerprint_path(kernel_name, output_dir).write_text(fingerprint)
+
+
+def _fingerprint_path(kernel_name, output_dir):
+    return output_dir / f"{kernel_name}.fingerprint"
 
 
 def _read_auto_tuning_cache(path):


### PR DESCRIPTION
## Summary

`_load_cached` in `ninetoothed.build` previously returned the cached `.so` whenever it existed on disk, regardless of whether the source code, configs, or library internals had changed since it was produced. That let stale artifacts silently survive across `premake`, `configs`, or `ninetoothed` updates — e.g. two `tests/test_aot.py::test_conv2d` cases were failing with `_KernelLaunchError` because cached `.so` files from before the `test_aot.py` argument list grew were still being loaded.

## Changes

- Add `_compute_fingerprint(premake, configs, meta_parameters, caller)` that SHA-256s the `premake` source (with `functools.partial` args and keywords folded in), `configs`, `meta_parameters`, `caller`, and the contents of `build.py` and `aot.py`.
- Persist the fingerprint as `<kernel_name>.fingerprint` alongside the other build artifacts.
- `_load_cached` returns `None` when the fingerprint file is missing or its contents do not match.
- Normalize `configs` (and `meta_parameters` when set) to tuples up front so pre-iterating them for the fingerprint does not exhaust generators.

## Testing

## Testing

`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.16, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/huangjiacheng/ninetoothed
configfile: pyproject.toml
plugins: anyio-4.12.1, xdist-3.8.0, cov-7.0.0, typeguard-4.4.4
collected 213 items

tests/test_add.py .                                                      [  0%]
tests/test_addmm.py ..                                                   [  1%]
tests/test_aot.py .........                                              [  5%]
tests/test_aot_auto_tuning.py ....                                       [  7%]
tests/test_attention.py ........                                         [ 11%]
tests/test_auto_tuner.py ....                                            [ 13%]
tests/test_clone.py ....                                                 [ 15%]
tests/test_conv2d.py ....                                                [ 16%]
tests/test_data_ptr.py .                                                 [ 17%]
tests/test_debugging.py .                                                [ 17%]
tests/test_dropout.py .                                                  [ 18%]
tests/test_eval.py ........                                              [ 22%]
tests/test_expand.py .                                                   [ 22%]
tests/test_generation.py ............................................... [ 44%]
.............................                                            [ 58%]
tests/test_getitem.py ..........                                         [ 62%]
tests/test_ipynb.py .                                                    [ 63%]
tests/test_jagged.py ................                                    [ 70%]
tests/test_matmul.py ..                                                  [ 71%]
tests/test_max_pool2d.py ..                                              [ 72%]
tests/test_naming.py .......                                             [ 76%]
tests/test_pad.py ................................................       [ 98%]
tests/test_pow.py .                                                      [ 99%]
tests/test_softmax.py .                                                  [ 99%]
tests/test_unsqueeze.py .                                                [100%]

======================= 213 passed in 2781.93s (0:46:21) =======================
```
