### PR TITLE
Wrap scalar `int` as `NineToothedTensor` in launcher

### DIFF
--- a/src/ninetoothed/aot.py
+++ b/src/ninetoothed/aot.py
@@ -696,10 +696,30 @@ def _load_launch_func(kernel_name, output_dir):
     launch_func_name = f"launch_{kernel_name}"
     launch_func = getattr(library, launch_func_name)
 
+    def _num_tensor_args(kernel_name, output_dir):
+        header_path = pathlib.Path(output_dir) / f"{kernel_name}.h"
+        text = header_path.read_text()
+        pattern = (
+            rf"NineToothedResult\s+launch_{re.escape(kernel_name)}\s*\((.*?)\)\s*;"
+        )
+        match = re.search(pattern, text)
+
+        if match is None:
+            raise RuntimeError(
+                f"Could not find launch signature for `{kernel_name}` in `{header_path}`."
+            )
+
+        params = (param.strip() for param in match.group(1).split(","))
+
+        return sum(1 for param in params if param.startswith("NineToothedTensor "))
+
+    num_tensor_args = _num_tensor_args(kernel_name, output_dir)
+
     dtype_to_index = _DTYPE_TO_INDEX
     from_torch_tensor = _ArgumentTensor.from_torch_tensor
     from_scalar = _ArgumentTensor.from_scalar
     c_double = ctypes.c_double
+    c_int64 = ctypes.c_int64
     c_void_p = ctypes.c_void_p
     current_device = torch.cuda.current_device
     get_current_raw_stream = torch._C._cuda_getCurrentRawStream
@@ -709,12 +729,17 @@ def _load_launch_func(kernel_name, output_dir):
         arguments = [None] * len(args)
 
         for i, arg in enumerate(args):
-            if isinstance(arg, Tensor_cls):
-                arguments[i] = from_torch_tensor(arg)
+            if i < num_tensor_args:
+                if isinstance(arg, Tensor_cls):
+                    arguments[i] = from_torch_tensor(arg)
+                elif type(arg) is float:
+                    arguments[i] = from_scalar(arg, c_double)
+                elif type(arg) is int:
+                    arguments[i] = from_scalar(arg, c_int64)
+                else:
+                    arguments[i] = arg
             elif type(arg) is str:
                 arguments[i] = dtype_to_index[arg]
-            elif type(arg) is float:
-                arguments[i] = from_scalar(arg, c_double)
             else:
                 arguments[i] = arg
 


### PR DESCRIPTION
## Summary

- Treat positional `int` arguments at tensor-parameter positions as scalar tensors in the AOT launcher, mirroring the existing `float` handling (wrapped via `_ArgumentTensor.from_scalar` with `ctypes.c_int64`).
- Parse the generated `<kernel>.h` header to count `NineToothedTensor` parameters, so the scalar-to-tensor wrapping only applies to true tensor-arg slots; trailing arguments (e.g. dtype index strings) keep their prior conversion path.

## Testing

`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.16, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/huangjiacheng/ninetoothed
configfile: pyproject.toml
plugins: anyio-4.12.1, xdist-3.8.0, cov-7.0.0, typeguard-4.4.4
collected 213 items

tests/test_add.py .                                                      [  0%]
tests/test_addmm.py ..                                                   [  1%]
tests/test_aot.py .........                                              [  5%]
tests/test_aot_auto_tuning.py ....                                       [  7%]
tests/test_attention.py ........                                         [ 11%]
tests/test_auto_tuner.py ....                                            [ 13%]
tests/test_clone.py ....                                                 [ 15%]
tests/test_conv2d.py ....                                                [ 16%]
tests/test_data_ptr.py .                                                 [ 17%]
tests/test_debugging.py .                                                [ 17%]
tests/test_dropout.py .                                                  [ 18%]
tests/test_eval.py ........                                              [ 22%]
tests/test_expand.py .                                                   [ 22%]
tests/test_generation.py ............................................... [ 44%]
.............................                                            [ 58%]
tests/test_getitem.py ..........                                         [ 62%]
tests/test_ipynb.py .                                                    [ 63%]
tests/test_jagged.py ................                                    [ 70%]
tests/test_matmul.py ..                                                  [ 71%]
tests/test_max_pool2d.py ..                                              [ 72%]
tests/test_naming.py .......                                             [ 76%]
tests/test_pad.py ................................................       [ 98%]
tests/test_pow.py .                                                      [ 99%]
tests/test_softmax.py .                                                  [ 99%]
tests/test_unsqueeze.py .                                                [100%]

======================= 213 passed in 2813.42s (0:46:53) =======================
```
