### PR TITLE
Linearize AOT variant enumeration

### DIFF
--- a/src/ninetoothed/aot.py
+++ b/src/ninetoothed/aot.py
@@ -1,6 +1,5 @@
 import ast
 import ctypes
-import itertools
 import pathlib
 import re
 import shutil
@@ -310,11 +309,22 @@ def _enumerate_variant_specs(launch_arg_names, tensors, find_tensor):
             (name, dim) for name, dim in zip(launch_arg_names, combo) if dim is not None
         )
 
-    dim_specs = tuple(
-        _spec_from_combo(combo)
-        for combo in itertools.product(*per_tensor_dims)
-        if any(dim is not None for dim in combo)
-    ) + ((),)
+    base_combo = tuple(dims[0] for dims in per_tensor_dims)
+    combos = [base_combo] if any(dim is not None for dim in base_combo) else []
+
+    for i, dims in enumerate(per_tensor_dims):
+        if len(dims) <= 1:
+            continue
+
+        for alternative_dim in dims[1:]:
+            if alternative_dim is None:
+                continue
+
+            combo = list(base_combo)
+            combo[i] = alternative_dim
+            combos.append(tuple(combo))
+
+    dim_specs = tuple(_spec_from_combo(combo) for combo in combos) + ((),)
 
     specs = []
 


### PR DESCRIPTION
## Summary

Replaces the Cartesian-product-based variant enumeration (`itertools.product`, O(2^N) combos per dimension spec) with a linearized approach that generates only the base combination plus N single-alternative combinations (O(N)). Since total variants scale as dim_specs² (divisibility × contiguity cross-product), this reduces the overall variant count from O(4^N) to O(N²).

## Testing

`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.16, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/huangjiacheng/ninetoothed
configfile: pyproject.toml
plugins: anyio-4.12.1, xdist-3.8.0, cov-7.0.0, typeguard-4.4.4
collected 214 items

tests/test_add.py .                                                      [  0%]
tests/test_addmm.py ..                                                   [  1%]
tests/test_aot.py ..........                                             [  6%]
tests/test_aot_auto_tuning.py ....                                       [  7%]
tests/test_attention.py ........                                         [ 11%]
tests/test_auto_tuner.py ....                                            [ 13%]
tests/test_clone.py ....                                                 [ 15%]
tests/test_conv2d.py ....                                                [ 17%]
tests/test_data_ptr.py .                                                 [ 17%]
tests/test_debugging.py .                                                [ 18%]
tests/test_dropout.py .                                                  [ 18%]
tests/test_eval.py ........                                              [ 22%]
tests/test_expand.py .                                                   [ 22%]
tests/test_generation.py ............................................... [ 44%]
.............................                                            [ 58%]
tests/test_getitem.py ..........                                         [ 63%]
tests/test_ipynb.py .                                                    [ 63%]
tests/test_jagged.py ................                                    [ 71%]
tests/test_matmul.py ..                                                  [ 71%]
tests/test_max_pool2d.py ..                                              [ 72%]
tests/test_naming.py .......                                             [ 76%]
tests/test_pad.py ................................................       [ 98%]
tests/test_pow.py .                                                      [ 99%]
tests/test_softmax.py .                                                  [ 99%]
tests/test_unsqueeze.py .                                                [100%]

======================= 214 passed in 856.54s (0:14:16) ========================
```
