### PR TITLE
Fix AOT non-power-of-two innermost sizes

### DIFF
--- a/src/ninetoothed/generation.py
+++ b/src/ninetoothed/generation.py
@@ -780,6 +780,16 @@ class CodeGenerator(ast.NodeTransformer):
     @staticmethod
     def _generate_innermost_indices(tensor, use_power_of_2_sizes=True):
         class _NextPowerOfTwoMaker(ast.NodeTransformer):
+            def visit_Constant(self, node):
+                value = node.value
+
+                if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+                    return ast.copy_location(
+                        ast.Constant(value=1 << (value - 1).bit_length()), node
+                    )
+
+                return self.generic_visit(node)
+
             def visit_Name(self, node):
                 name = node.id
 

--- a/tests/test_aot.py
+++ b/tests/test_aot.py
@@ -343,6 +343,41 @@ def test_fp32_scalar(device):
     assert torch.allclose(output, expected)
 
 
+@pytest.mark.parametrize("device", get_available_devices())
+def test_aot_with_static_non_power_of_two_innermost_sizes(device):
+    def _arrangement(input, output):
+        return input.tile((3,)), output.tile((3,))
+
+    def _application(input, output):
+        output = input  # noqa: F841
+
+    tensors = (
+        Tensor(1, dtype=ninetoothed.float32),
+        Tensor(1, dtype=ninetoothed.float32),
+    )
+
+    kernel_name = (
+        f"static_non_power_of_two_innermost_sizes{_generate_kernel_name_suffix()}"
+    )
+    output_dir = ninetoothed.generation.CACHE_DIR
+
+    kernel = ninetoothed.make(
+        _arrangement,
+        _application,
+        tensors,
+        caller=device,
+        kernel_name=kernel_name,
+        output_dir=output_dir,
+    )
+
+    input = torch.randn((3,), dtype=torch.float32, device=device)
+    output = torch.empty_like(input)
+
+    kernel(input, output)
+
+    assert torch.allclose(input, output)
+
+
 def test_overflow_terms():
     terms = ninetoothed.aot._overflow_terms(("input", "scale"), (2, 0))
 


### PR DESCRIPTION
## Summary

- Add an AOT regression test for static non-power-of-two innermost sizes.
- Convert positive integer constants used for innermost indices to the next power of two during code generation.
- Preserve the original logical size in masks, so generated `tl.arange` extents are valid for Triton while tensor semantics stay unchanged.

## Testing

`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.10.16, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/huangjiacheng/ninetoothed
configfile: pyproject.toml
plugins: anyio-4.12.1, xdist-3.8.0, cov-7.0.0, typeguard-4.4.4
collected 216 items

tests/test_add.py .                                                      [  0%]
tests/test_addmm.py ..                                                   [  1%]
tests/test_aot.py ............                                           [  6%]
tests/test_aot_auto_tuning.py ....                                       [  8%]
tests/test_attention.py ........                                         [ 12%]
tests/test_auto_tuner.py ....                                            [ 14%]
tests/test_clone.py ....                                                 [ 16%]
tests/test_conv2d.py ....                                                [ 18%]
tests/test_data_ptr.py .                                                 [ 18%]
tests/test_debugging.py .                                                [ 18%]
tests/test_dropout.py .                                                  [ 19%]
tests/test_eval.py ........                                              [ 23%]
tests/test_expand.py .                                                   [ 23%]
tests/test_generation.py ............................................... [ 45%]
.............................                                            [ 58%]
tests/test_getitem.py ..........                                         [ 63%]
tests/test_ipynb.py .                                                    [ 63%]
tests/test_jagged.py ................                                    [ 71%]
tests/test_matmul.py ..                                                  [ 72%]
tests/test_max_pool2d.py ..                                              [ 73%]
tests/test_naming.py .......                                             [ 76%]
tests/test_pad.py ................................................       [ 98%]
tests/test_pow.py .                                                      [ 99%]
tests/test_softmax.py .                                                  [ 99%]
tests/test_unsqueeze.py .                                                [100%]

======================= 216 passed in 952.02s (0:15:52) ========================
```
