### PR TITLE
Run `pytest` on NVIDIA self-hosted runner

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,18 +2,15 @@ name: pytest
 on: [push, pull_request]
 jobs:
   pytest:
-    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, linux, x64, nvidia, ninetoothed]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -e .[all]
-          pip install -r requirements.txt
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -e .[all]
+          python3 -m pip install -r requirements.txt
       - name: Test with pytest
         run: |
-          pytest --doctest-modules --junitxml=junit/test-results.xml --cov=ninetoothed --cov-report=xml --cov-report=html
+          python3 -m pytest --doctest-modules --junitxml=junit/test-results.xml --cov=ninetoothed --cov-report=xml --cov-report=html


### PR DESCRIPTION
## Summary

This PR routes the `pytest` GitHub Actions workflow to the new NVIDIA self-hosted runner for trusted contexts. The runner is registered as `nvidia-0` with labels `nvidia`, `gpu`, `cuda`, and `ninetoothed`.

Changes:
- Move `pytest` from `ubuntu-latest` to `[self-hosted, linux, x64, nvidia, ninetoothed]`.
- Skip self-hosted `pytest` for fork PRs to avoid running untrusted code on the GPU host.
- Use the runner image’s `python3` environment instead of `actions/setup-python`, so CI can reuse the NVIDIA/PyTorch container environment.

Validation:
- Confirmed `nvidia-0` is online in GitHub Actions.
- Confirmed the remote runner container is running with `--restart unless-stopped`.
- Verified pytest passes on the self-hosted runner: https://github.com/InfiniTensor/ninetoothed/actions/runs/26500802071

## Testing

`pytest` output:

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.1.1, pluggy-1.6.0
rootdir: /home/runner/actions-runner/_work/ninetoothed/ninetoothed
configfile: pyproject.toml
plugins: cov-7.1.0, typeguard-4.4.4, anyio-4.12.0, hypothesis-6.130.8, shard-0.1.2, flakefinder-1.1.0, xdoctest-1.0.2, xdist-3.8.0, rerunfailures-16.1
collected 216 items
Running 216 items in this shard

tests/test_add.py .                                                      [  0%]
tests/test_addmm.py ..                                                   [  1%]
tests/test_aot.py ............                                           [  6%]
tests/test_aot_auto_tuning.py ....                                       [  8%]
tests/test_attention.py ........                                         [ 12%]
tests/test_auto_tuner.py ....                                            [ 14%]
tests/test_clone.py ....                                                 [ 16%]
tests/test_conv2d.py ....                                                [ 18%]
tests/test_data_ptr.py .                                                 [ 18%]
tests/test_debugging.py .                                                [ 18%]
tests/test_dropout.py .                                                  [ 19%]
tests/test_eval.py ........                                              [ 23%]
tests/test_expand.py .                                                   [ 23%]
tests/test_generation.py ............................................... [ 45%]
.............................                                            [ 58%]
tests/test_getitem.py ..........                                         [ 63%]
tests/test_ipynb.py .                                                    [ 63%]
tests/test_jagged.py ................                                    [ 71%]
tests/test_matmul.py ..                                                  [ 72%]
tests/test_max_pool2d.py ..                                              [ 73%]
tests/test_naming.py .......                                             [ 76%]
tests/test_pad.py ................................................       [ 98%]
tests/test_pow.py .                                                      [ 99%]
tests/test_softmax.py .                                                  [ 99%]
tests/test_unsqueeze.py .                                                [100%]

- generated xml file: /home/runner/actions-runner/_work/ninetoothed/ninetoothed/junit/test-results.xml -
================================ tests coverage ================================
_______________ coverage: platform linux, python 3.12.3-final-0 ________________

Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml
======================= 216 passed in 1968.77s (0:32:48) =======================
```
