### PR TITLE
Automate contributing rule checks

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -84,4 +84,19 @@ else
     exit 1
 fi
 
+if command -v python3 > /dev/null; then
+    python_cmd=python3
+elif command -v python > /dev/null; then
+    python_cmd=python
+else
+    echo "❌ Error: Python not found." >&2
+    exit 1
+fi
+
+echo "Running contributing style checks..." >&2
+if ! "$python_cmd" scripts/check_contributing_style.py; then
+    echo "❌ Error: Contributing style check failed." >&2
+    exit 1
+fi
+
 echo "✅ Code formatting completed." >&2

--- a/.github/workflows/contributing.yml
+++ b/.github/workflows/contributing.yml
@@ -1,0 +1,15 @@
+name: Contributing
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+jobs:
+  metadata:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check PR metadata
+        run: python3 scripts/check_contributing_metadata.py --event "$GITHUB_EVENT_PATH"

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -5,6 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Check contributing style
+        run: python3 scripts/check_contributing_style.py
       - uses: chartboost/ruff-action@v1
       - uses: chartboost/ruff-action@v1
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,19 @@ Run [Ruff](https://docs.astral.sh/ruff/) before every commit:
 ruff format && ruff check
 ```
 
-This is also enforced by the `commit-msg` hook.
+Run the project-specific contributing style checker for Python code:
+
+```bash
+python scripts/check_contributing_style.py
+```
+
+To apply mechanical blank-line fixes before checking:
+
+```bash
+python scripts/check_contributing_style.py --fix
+```
+
+Ruff and the project-specific contributing style checks are also enforced by the `commit-msg` hook.
 
 ### Additional Rules
 
@@ -132,10 +144,26 @@ Run the formatter:
 ruff format
 ```
 
+Run the project-specific contributing style checker:
+
+```bash
+python scripts/check_contributing_style.py
+```
+
+Apply project-specific blank-line fixes:
+
+```bash
+python scripts/check_contributing_style.py --fix
+```
+
 To run a full local CI check before pushing:
 
 ```bash
-ruff format && ruff check && pytest
+python scripts/check_contributing_style.py --fix
+ruff format
+ruff check
+python scripts/check_contributing_style.py
+pytest
 ```
 
 ## Version Release Process

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ We follow [GitHub flow](https://docs.github.com/en/get-started/using-github/gith
 
 ### Branch Naming
 
-Use kebab-case (lowercase letters, numbers, and hyphens) for branch names, with a maximum of 50 characters. This is enforced by the `pre-push` hook.
+Use kebab-case (lowercase letters, numbers, and hyphens) for branch names, with a maximum of 50 characters. This is enforced by the `pre-push` hook and the PR metadata workflow.
 
 - **Valid:** `develop-visualization`, `fix-123-memory-leak`, `add-conv2d-support`
 - **Invalid:** `Develop_Visualization`, `fix_memory_leak`, `myBranch`
@@ -68,7 +68,7 @@ The following rules apply to both commit messages and PR titles:
 - **Do not** end with punctuation (`.`, `!`, `?`, etc.).
 - **Use imperative mood** (e.g., "Add feature" not "Added feature").
 
-These rules are enforced by the `commit-msg` hook.
+Commit messages are enforced by the `commit-msg` hook. PR titles are enforced by the PR metadata workflow.
 
 **Valid examples:**
 
@@ -84,7 +84,7 @@ These rules are enforced by the `commit-msg` hook.
 
 ### Pull Request Requirements
 
-Before merging a PR, you must provide the `pytest` output in the PR description to confirm that all tests pass with your latest changes. The PR template includes a section for this. See [#30](https://github.com/InfiniTensor/ninetoothed/pull/30) for a reference example.
+Before merging a PR, you must provide the `pytest` output in the PR description to confirm that all tests pass with your latest changes. The PR template includes a section for this, and the PR metadata workflow checks that the section is filled in. See [#30](https://github.com/InfiniTensor/ninetoothed/pull/30) for a reference example.
 
 ## Code Style Guide
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,10 @@ src = [".", "src", "tests"]
 
 [tool.ruff.lint]
 select = ["E4", "E7", "E9", "F", "I"]
+extend-select = ["D2", "D3", "D4", "PT"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "pep257"
+
+[tool.ruff.format]
+docstring-code-format = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ src = [".", "src", "tests"]
 [tool.ruff.lint]
 select = ["E4", "E7", "E9", "F", "I"]
 extend-select = ["D2", "D3", "D4", "PT"]
+ignore = ["D401"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "pep257"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ src = [".", "src", "tests"]
 
 [tool.ruff.lint]
 select = ["E4", "E7", "E9", "F", "I"]
-extend-select = ["D2", "D3", "D4", "PT"]
+extend-select = ["D3", "D4"]
 ignore = ["D401"]
 
 [tool.ruff.lint.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ src = [".", "src", "tests"]
 [tool.ruff.lint]
 select = ["E4", "E7", "E9", "F", "I"]
 extend-select = ["D2", "D3", "D4"]
-ignore = ["D401"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "pep257"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ src = [".", "src", "tests"]
 
 [tool.ruff.lint]
 select = ["E4", "E7", "E9", "F", "I"]
-extend-select = ["D3", "D4"]
+extend-select = ["D2", "D3", "D4"]
 ignore = ["D401"]
 
 [tool.ruff.lint.pydocstyle]

--- a/scripts/check_contributing_metadata.py
+++ b/scripts/check_contributing_metadata.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -60,7 +59,9 @@ def parse_args() -> argparse.Namespace:
         help="Commit message file whose first line should be checked as a title.",
     )
     parser.add_argument("--skip-title", action="store_true", help="Skip title checks.")
-    parser.add_argument("--skip-branch", action="store_true", help="Skip branch checks.")
+    parser.add_argument(
+        "--skip-branch", action="store_true", help="Skip branch checks."
+    )
     parser.add_argument(
         "--skip-pytest-output",
         action="store_true",
@@ -134,7 +135,9 @@ def check_title_text(title: str | None, *, label: str) -> list[str]:
         return [f"METADATA001: The {label} cannot be empty."]
 
     if not normalized[0].isupper():
-        diagnostics.append(f"METADATA002: The {label} must start with an uppercase letter.")
+        diagnostics.append(
+            f"METADATA002: The {label} must start with an uppercase letter."
+        )
 
     if normalized[-1] in TRAILING_PUNCTUATION:
         diagnostics.append(f"METADATA003: The {label} must not end with punctuation.")
@@ -160,7 +163,9 @@ def check_branch_name(branch: str | None) -> list[str]:
         )
 
     if len(normalized) > 50:
-        diagnostics.append("METADATA007: The branch name must be 50 characters or shorter.")
+        diagnostics.append(
+            "METADATA007: The branch name must be 50 characters or shorter."
+        )
 
     return diagnostics
 
@@ -170,7 +175,9 @@ def check_pytest_output_block(body: str | None) -> list[str]:
     match = PYTEST_OUTPUT_PATTERN.search(normalized)
 
     if match is None:
-        return ["METADATA008: The PR description must include a `pytest` output code block."]
+        return [
+            "METADATA008: The PR description must include a `pytest` output code block."
+        ]
 
     if not match.group(1).strip():
         return ["METADATA009: The `pytest` output code block cannot be empty."]

--- a/scripts/check_contributing_metadata.py
+++ b/scripts/check_contributing_metadata.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Check contribution metadata rules from ``CONTRIBUTING.md``."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+BRANCH_PATTERN = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+TRAILING_PUNCTUATION = ".,;:!?"
+PAST_TENSE_PATTERN = re.compile(
+    r"\b(added|fixed|changed|modified|removed|updated|implemented|created|improved)\b",
+    re.IGNORECASE,
+)
+PYTEST_OUTPUT_PATTERN = re.compile(
+    r"`?pytest`?\s+output\s*:\s*```[a-zA-Z0-9_-]*\s*(.*?)```",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+@dataclass(frozen=True)
+class Metadata:
+    title: str | None = None
+    branch: str | None = None
+    body: str | None = None
+
+
+def main() -> int:
+    args = parse_args()
+    metadata = load_metadata(args)
+    diagnostics = check_metadata(
+        metadata,
+        check_title=not args.skip_title,
+        check_branch=not args.skip_branch,
+        check_pytest_output=not args.skip_pytest_output,
+    )
+
+    for diagnostic in diagnostics:
+        print(diagnostic)
+
+    return 1 if diagnostics else 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Check contribution metadata rules from CONTRIBUTING.md."
+    )
+    parser.add_argument("--event", type=Path, help="GitHub event JSON file.")
+    parser.add_argument("--title", help="Commit message subject or PR title.")
+    parser.add_argument("--branch", help="Branch name to validate.")
+    parser.add_argument("--body", help="PR body text.")
+    parser.add_argument("--body-file", type=Path, help="File containing the PR body.")
+    parser.add_argument(
+        "--commit-message-file",
+        type=Path,
+        help="Commit message file whose first line should be checked as a title.",
+    )
+    parser.add_argument("--skip-title", action="store_true", help="Skip title checks.")
+    parser.add_argument("--skip-branch", action="store_true", help="Skip branch checks.")
+    parser.add_argument(
+        "--skip-pytest-output",
+        action="store_true",
+        help="Skip PR body pytest output checks.",
+    )
+
+    return parser.parse_args()
+
+
+def load_metadata(args: argparse.Namespace) -> Metadata:
+    metadata = Metadata()
+
+    if args.event is not None:
+        metadata = metadata_from_event(args.event)
+
+    title = args.title if args.title is not None else metadata.title
+    branch = args.branch if args.branch is not None else metadata.branch
+    body = args.body if args.body is not None else metadata.body
+
+    if args.body_file is not None:
+        body = args.body_file.read_text(encoding="utf-8")
+
+    if args.commit_message_file is not None:
+        title = first_line(args.commit_message_file.read_text(encoding="utf-8"))
+
+    return Metadata(title=title, branch=branch, body=body)
+
+
+def metadata_from_event(path: Path) -> Metadata:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    pull_request = payload.get("pull_request") or {}
+    head = pull_request.get("head") or {}
+
+    return Metadata(
+        title=pull_request.get("title"),
+        branch=head.get("ref"),
+        body=pull_request.get("body") or "",
+    )
+
+
+def first_line(text: str) -> str:
+    return text.splitlines()[0] if text.splitlines() else ""
+
+
+def check_metadata(
+    metadata: Metadata,
+    *,
+    check_title: bool,
+    check_branch: bool,
+    check_pytest_output: bool,
+) -> list[str]:
+    diagnostics: list[str] = []
+
+    if check_title:
+        diagnostics.extend(check_title_text(metadata.title, label="title"))
+
+    if check_branch:
+        diagnostics.extend(check_branch_name(metadata.branch))
+
+    if check_pytest_output:
+        diagnostics.extend(check_pytest_output_block(metadata.body))
+
+    return diagnostics
+
+
+def check_title_text(title: str | None, *, label: str) -> list[str]:
+    diagnostics: list[str] = []
+    normalized = (title or "").strip()
+
+    if not normalized:
+        return [f"METADATA001: The {label} cannot be empty."]
+
+    if not normalized[0].isupper():
+        diagnostics.append(f"METADATA002: The {label} must start with an uppercase letter.")
+
+    if normalized[-1] in TRAILING_PUNCTUATION:
+        diagnostics.append(f"METADATA003: The {label} must not end with punctuation.")
+
+    if PAST_TENSE_PATTERN.search(normalized):
+        diagnostics.append(f"METADATA004: The {label} must use imperative mood.")
+
+    return diagnostics
+
+
+def check_branch_name(branch: str | None) -> list[str]:
+    normalized = (branch or "").strip()
+
+    if not normalized:
+        return ["METADATA005: The branch name cannot be empty."]
+
+    diagnostics: list[str] = []
+
+    if not BRANCH_PATTERN.fullmatch(normalized):
+        diagnostics.append(
+            "METADATA006: The branch name must use kebab-case with lowercase letters, "
+            "numbers, and hyphens."
+        )
+
+    if len(normalized) > 50:
+        diagnostics.append("METADATA007: The branch name must be 50 characters or shorter.")
+
+    return diagnostics
+
+
+def check_pytest_output_block(body: str | None) -> list[str]:
+    normalized = body or ""
+    match = PYTEST_OUTPUT_PATTERN.search(normalized)
+
+    if match is None:
+        return ["METADATA008: The PR description must include a `pytest` output code block."]
+
+    if not match.group(1).strip():
+        return ["METADATA009: The `pytest` output code block cannot be empty."]
+
+    return []
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_contributing_style.py
+++ b/scripts/check_contributing_style.py
@@ -1,0 +1,624 @@
+#!/usr/bin/env python3
+"""Check project-specific Python style rules from ``CONTRIBUTING.md``."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import io
+import re
+import sys
+import tokenize
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_PATHS = ("src", "tests", "docs/source", "scripts")
+EXCLUDED_DIRS = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+    "htmlcov",
+    "venv",
+}
+SENTENCE_PUNCTUATION = ".!?:;"
+CONTROL_FLOW_STATEMENTS = (
+    ast.If,
+    ast.For,
+    ast.AsyncFor,
+    ast.While,
+    ast.With,
+    ast.AsyncWith,
+    ast.Try,
+    ast.Match,
+)
+EXCEPTION_NAMES = {
+    "AssertionError",
+    "AttributeError",
+    "EOFError",
+    "ImportError",
+    "IndexError",
+    "KeyError",
+    "LookupError",
+    "NameError",
+    "NotImplementedError",
+    "OSError",
+    "RuntimeError",
+    "StopIteration",
+    "SyntaxError",
+    "SystemError",
+    "TypeError",
+    "ValueError",
+}
+FRAMEWORK_MESSAGE_CALLS = {
+    "pytest.importorskip",
+    "pytest.skip",
+    "pytest.xfail",
+}
+CODE_QUOTE_PATTERN = re.compile(
+    r"(?<!`)['\"]([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)?(?:\(\))?)['\"]"
+)
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    path: Path
+    line: int
+    column: int
+    code: str
+    message: str
+
+
+@dataclass(frozen=True)
+class CommentLine:
+    line: int
+    column: int
+    text: str
+
+
+@dataclass(frozen=True)
+class Fixes:
+    insertions: frozenset[int]
+    deletions: frozenset[int]
+
+
+def main() -> int:
+    args = parse_args()
+    paths = tuple(Path(path) for path in args.paths)
+    files = tuple(discover_python_files(paths))
+    diagnostics: list[Diagnostic] = []
+    fixed_paths: list[Path] = []
+
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        path_diagnostics, fixed_text = check_file(path, text, fix=args.fix)
+        diagnostics.extend(path_diagnostics)
+
+        if args.fix and fixed_text is not None and fixed_text != text:
+            path.write_text(fixed_text, encoding="utf-8")
+            fixed_paths.append(path)
+
+    for diagnostic in diagnostics:
+        print(
+            f"{diagnostic.path}:{diagnostic.line}:{diagnostic.column + 1}: "
+            f"{diagnostic.code} {diagnostic.message}"
+        )
+
+    if args.fix and fixed_paths:
+        for path in fixed_paths:
+            print(f"Fixed {path}")
+
+    return 1 if diagnostics else 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Check project-specific Python style rules from CONTRIBUTING.md."
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=DEFAULT_PATHS,
+        help="Files or directories to check. Defaults to the Python source tree.",
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Apply mechanical blank-line fixes.",
+    )
+
+    return parser.parse_args()
+
+
+def discover_python_files(paths: tuple[Path, ...]) -> list[Path]:
+    files: list[Path] = []
+
+    for path in paths:
+        if not path.exists():
+            continue
+
+        if path.is_file():
+            if path.suffix == ".py":
+                files.append(path)
+
+            continue
+
+        for child in path.rglob("*.py"):
+            if any(part in EXCLUDED_DIRS for part in child.parts):
+                continue
+
+            files.append(child)
+
+    return sorted(dict.fromkeys(files))
+
+
+def check_file(path: Path, text: str, *, fix: bool) -> tuple[list[Diagnostic], str | None]:
+    diagnostics: list[Diagnostic] = []
+    lines = text.splitlines()
+
+    try:
+        tree = ast.parse(text, filename=str(path))
+    except SyntaxError as error:
+        diagnostics.append(
+            Diagnostic(
+                path=path,
+                line=error.lineno or 1,
+                column=error.offset or 0,
+                code="PY000",
+                message=error.msg,
+            )
+        )
+
+        return diagnostics, None
+
+    diagnostics.extend(check_comments(path, text))
+    diagnostics.extend(check_error_messages(path, tree))
+    blank_line_diagnostics, fixes = check_blank_lines(path, tree, lines)
+    diagnostics.extend(blank_line_diagnostics)
+
+    if fix:
+        fixed_text = apply_fixes(text, fixes)
+
+        if fixed_text != text:
+            fixed_diagnostics, _ = check_file(path, fixed_text, fix=False)
+            diagnostics = [
+                diagnostic
+                for diagnostic in fixed_diagnostics
+                if diagnostic.code.startswith(("C", "E", "PY"))
+            ]
+
+        return diagnostics, fixed_text
+
+    return diagnostics, None
+
+
+def check_comments(path: Path, text: str) -> list[Diagnostic]:
+    diagnostics: list[Diagnostic] = []
+    comments = collect_comment_lines(text)
+
+    for block in group_comment_blocks(comments):
+        if should_skip_comment_block(block):
+            continue
+
+        first = block[0]
+        normalized = normalize_comment_block(block)
+
+        if not normalized:
+            continue
+
+        sentence_error = validate_sentence(normalized)
+
+        if sentence_error is not None:
+            diagnostics.append(
+                Diagnostic(
+                    path=path,
+                    line=first.line,
+                    column=first.column,
+                    code="C001",
+                    message=sentence_error,
+                )
+            )
+
+        if CODE_QUOTE_PATTERN.search(normalized):
+            diagnostics.append(
+                Diagnostic(
+                    path=path,
+                    line=first.line,
+                    column=first.column,
+                    code="C002",
+                    message="Use Markdown backticks for code references in comments.",
+                )
+            )
+
+    return diagnostics
+
+
+def collect_comment_lines(text: str) -> list[CommentLine]:
+    comments: list[CommentLine] = []
+
+    try:
+        tokens = tokenize.generate_tokens(io.StringIO(text).readline)
+
+        for token in tokens:
+            if token.type != tokenize.COMMENT:
+                continue
+
+            comment_text = token.string.lstrip()[1:].strip()
+            comments.append(
+                CommentLine(
+                    line=token.start[0],
+                    column=token.start[1],
+                    text=comment_text,
+                )
+            )
+    except tokenize.TokenError:
+        return comments
+
+    return comments
+
+
+def group_comment_blocks(comments: list[CommentLine]) -> list[list[CommentLine]]:
+    blocks: list[list[CommentLine]] = []
+
+    for comment in comments:
+        if not blocks:
+            blocks.append([comment])
+
+            continue
+
+        previous = blocks[-1][-1]
+
+        if comment.line == previous.line + 1 and comment.column == previous.column:
+            blocks[-1].append(comment)
+
+            continue
+
+        blocks.append([comment])
+
+    return blocks
+
+
+def should_skip_comment_block(block: list[CommentLine]) -> bool:
+    meaningful = [line.text.strip() for line in block if line.text.strip()]
+
+    if not meaningful:
+        return True
+
+    return all(is_skippable_comment_line(line) for line in meaningful)
+
+
+def is_skippable_comment_line(text: str) -> bool:
+    lower = text.lower()
+
+    if text.startswith("!") or lower.startswith("-*- coding:"):
+        return True
+
+    if re.fullmatch(r"coding[:=]\s*[-\w.]+", lower):
+        return True
+
+    if lower.startswith(("noqa", "type:", "pragma:", "fmt:", "isort:", "pylint:", "flake8:")):
+        return True
+
+    if text.startswith(("http://", "https://")):
+        return True
+
+    return bool(re.fullmatch(r"-{2,}.*-{2,}", text) or re.fullmatch(r"[=#*-]{3,}", text))
+
+
+def normalize_comment_block(block: list[CommentLine]) -> str:
+    parts: list[str] = []
+
+    for line in block:
+        text = line.text.strip()
+
+        if not text or text.startswith(("http://", "https://")):
+            continue
+
+        if is_skippable_comment_line(text):
+            continue
+
+        parts.append(text)
+
+    return " ".join(parts).strip()
+
+
+def check_error_messages(path: Path, tree: ast.AST) -> list[Diagnostic]:
+    checker = ErrorMessageChecker(path)
+    checker.visit(tree)
+
+    return checker.diagnostics
+
+
+class ErrorMessageChecker(ast.NodeVisitor):
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.diagnostics: list[Diagnostic] = []
+
+    def visit_Assert(self, node: ast.Assert) -> None:
+        if node.msg is not None:
+            self._check_message(node.msg)
+
+        self.generic_visit(node)
+
+    def visit_Raise(self, node: ast.Raise) -> None:
+        if isinstance(node.exc, ast.Call) and is_exception_call(node.exc):
+            self._check_call_message(node.exc)
+
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        function_name = get_full_name(node.func)
+
+        if function_name in FRAMEWORK_MESSAGE_CALLS:
+            return
+
+        if function_name in {"warnings.warn", "pytest.fail"}:
+            self._check_call_message(node)
+
+        self.generic_visit(node)
+
+    def _check_call_message(self, node: ast.Call) -> None:
+        if node.args:
+            self._check_message(node.args[0])
+
+    def _check_message(self, node: ast.AST) -> None:
+        message = get_string_value(node)
+
+        if message is None:
+            return
+
+        sentence_error = validate_sentence(message)
+
+        if sentence_error is None:
+            return
+
+        self.diagnostics.append(
+            Diagnostic(
+                path=self.path,
+                line=getattr(node, "lineno", 1),
+                column=getattr(node, "col_offset", 0),
+                code="E001",
+                message=sentence_error,
+            )
+        )
+
+
+def is_exception_call(node: ast.Call) -> bool:
+    function_name = get_full_name(node.func)
+    short_name = function_name.rsplit(".", 1)[-1]
+
+    return short_name in EXCEPTION_NAMES or short_name.endswith(("Error", "Exception"))
+
+
+def get_full_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+
+    if isinstance(node, ast.Attribute):
+        prefix = get_full_name(node.value)
+
+        if prefix:
+            return f"{prefix}.{node.attr}"
+
+        return node.attr
+
+    return ""
+
+
+def get_string_value(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+
+    if isinstance(node, ast.JoinedStr):
+        parts: list[str] = []
+
+        for value in node.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                parts.append(value.value)
+            elif isinstance(value, ast.FormattedValue):
+                parts.append("value")
+
+        return "".join(parts)
+
+    return None
+
+
+def validate_sentence(text: str) -> str | None:
+    normalized = " ".join(text.strip().split())
+
+    if not normalized:
+        return None
+
+    first_alpha = next((char for char in normalized if char.isalpha()), "")
+
+    if first_alpha and first_alpha.islower():
+        return "Start the sentence with a capital letter."
+
+    if normalized[-1] not in SENTENCE_PUNCTUATION:
+        return "End the sentence with punctuation."
+
+    return None
+
+
+def check_blank_lines(
+    path: Path, tree: ast.AST, lines: list[str]
+) -> tuple[list[Diagnostic], Fixes]:
+    diagnostics: list[Diagnostic] = []
+    insertions: set[int] = set()
+    deletions: set[int] = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            diagnostics.extend(
+                check_function_signature_spacing(path, node, lines, deletions=deletions)
+            )
+
+        for statements in child_statement_lists(node):
+            diagnostics.extend(
+                check_statement_spacing(path, statements, lines, insertions=insertions)
+            )
+
+    return diagnostics, Fixes(frozenset(insertions), frozenset(deletions))
+
+
+def check_function_signature_spacing(
+    path: Path,
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    lines: list[str],
+    *,
+    deletions: set[int],
+) -> list[Diagnostic]:
+    diagnostics: list[Diagnostic] = []
+
+    if not node.body or ast.get_docstring(node, clean=False) is not None:
+        return diagnostics
+
+    first_statement = node.body[0]
+    header_end_line = find_header_end_line(node, first_statement, lines)
+
+    if header_end_line is None:
+        return diagnostics
+
+    gap_line_numbers = range(header_end_line + 1, first_statement.lineno)
+    gap_lines = [lines[line_number - 1] for line_number in gap_line_numbers]
+
+    if any(line.strip().startswith("#") for line in gap_lines):
+        return diagnostics
+
+    blank_lines = [
+        line_number
+        for line_number in gap_line_numbers
+        if not lines[line_number - 1].strip()
+    ]
+
+    if not blank_lines:
+        return diagnostics
+
+    deletions.update(blank_lines)
+    diagnostics.append(
+        Diagnostic(
+            path=path,
+            line=blank_lines[0],
+            column=0,
+            code="F001",
+            message="Remove the blank line between the function signature and body.",
+        )
+    )
+
+    return diagnostics
+
+
+def find_header_end_line(
+    node: ast.FunctionDef | ast.AsyncFunctionDef, first_statement: ast.stmt, lines: list[str]
+) -> int | None:
+    for line_number in range(first_statement.lineno - 1, node.lineno - 1, -1):
+        line = lines[line_number - 1].strip()
+
+        if not line or line.startswith("#"):
+            continue
+
+        if line.endswith(":"):
+            return line_number
+
+    return None
+
+
+def child_statement_lists(node: ast.AST) -> list[list[ast.stmt]]:
+    statement_lists: list[list[ast.stmt]] = []
+
+    for _field, value in ast.iter_fields(node):
+        if not isinstance(value, list):
+            continue
+
+        if value and all(isinstance(item, ast.stmt) for item in value):
+            statement_lists.append(value)
+
+    return statement_lists
+
+
+def check_statement_spacing(
+    path: Path,
+    statements: list[ast.stmt],
+    lines: list[str],
+    *,
+    insertions: set[int],
+) -> list[Diagnostic]:
+    diagnostics: list[Diagnostic] = []
+
+    for previous, current in zip(statements, statements[1:]):
+        if previous.end_lineno is None:
+            continue
+
+        needs_blank = False
+        code = ""
+        message = ""
+
+        if isinstance(current, ast.Return) and not isinstance(previous, CONTROL_FLOW_STATEMENTS):
+            needs_blank = True
+            code = "R001"
+            message = "Add a blank line before this return statement."
+        elif isinstance(current, CONTROL_FLOW_STATEMENTS):
+            needs_blank = True
+            code = "B001"
+            message = "Add a blank line before this control-flow statement."
+        elif isinstance(previous, CONTROL_FLOW_STATEMENTS):
+            needs_blank = True
+            code = "B002"
+            message = "Add a blank line after this control-flow statement."
+
+        if not needs_blank or has_blank_line_between(lines, previous.end_lineno, current.lineno):
+            continue
+
+        insertions.add(current.lineno)
+        diagnostics.append(
+            Diagnostic(
+                path=path,
+                line=current.lineno,
+                column=current.col_offset,
+                code=code,
+                message=message,
+            )
+        )
+
+    return diagnostics
+
+
+def has_blank_line_between(lines: list[str], previous_end_line: int, current_line: int) -> bool:
+    return any(
+        not lines[line_number - 1].strip()
+        for line_number in range(previous_end_line + 1, current_line)
+    )
+
+
+def apply_fixes(text: str, fixes: Fixes) -> str:
+    if not fixes.insertions and not fixes.deletions:
+        return text
+
+    lines = text.splitlines()
+    output: list[str] = []
+
+    for line_number, line in enumerate(lines, start=1):
+        if line_number in fixes.insertions:
+            output.append("")
+
+        if line_number not in fixes.deletions:
+            output.append(line)
+
+    if len(lines) + 1 in fixes.insertions:
+        output.append("")
+
+    fixed = "\n".join(output)
+
+    if text.endswith("\n"):
+        fixed += "\n"
+
+    return fixed
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_contributing_style.py
+++ b/scripts/check_contributing_style.py
@@ -575,7 +575,9 @@ def check_statement_spacing(
             needs_blank = True
             code = "B001"
             message = "Add a blank line before this control-flow statement."
-        elif isinstance(previous, CONTROL_FLOW_STATEMENTS):
+        elif isinstance(previous, CONTROL_FLOW_STATEMENTS) and not isinstance(
+            current, ast.Return
+        ):
             needs_blank = True
             code = "B002"
             message = "Add a blank line after this control-flow statement."

--- a/scripts/check_contributing_style.py
+++ b/scripts/check_contributing_style.py
@@ -557,8 +557,11 @@ def check_statement_spacing(
 ) -> list[Diagnostic]:
     diagnostics: list[Diagnostic] = []
 
-    for previous, current in zip(statements, statements[1:]):
+    for index, (previous, current) in enumerate(zip(statements, statements[1:])):
         if previous.end_lineno is None:
+            continue
+
+        if index == 0 and is_docstring_statement(previous):
             continue
 
         needs_blank = False
@@ -599,6 +602,14 @@ def check_statement_spacing(
         )
 
     return diagnostics
+
+
+def is_docstring_statement(statement: ast.stmt) -> bool:
+    return (
+        isinstance(statement, ast.Expr)
+        and isinstance(statement.value, ast.Constant)
+        and isinstance(statement.value.value, str)
+    )
 
 
 def has_blank_line_between(

--- a/scripts/check_contributing_style.py
+++ b/scripts/check_contributing_style.py
@@ -7,7 +7,6 @@ import argparse
 import ast
 import io
 import re
-import sys
 import tokenize
 from dataclasses import dataclass
 from pathlib import Path
@@ -157,7 +156,9 @@ def discover_python_files(paths: tuple[Path, ...]) -> list[Path]:
     return sorted(dict.fromkeys(files))
 
 
-def check_file(path: Path, text: str, *, fix: bool) -> tuple[list[Diagnostic], str | None]:
+def check_file(
+    path: Path, text: str, *, fix: bool
+) -> tuple[list[Diagnostic], str | None]:
     diagnostics: list[Diagnostic] = []
     lines = text.splitlines()
 
@@ -301,13 +302,17 @@ def is_skippable_comment_line(text: str) -> bool:
     if re.fullmatch(r"coding[:=]\s*[-\w.]+", lower):
         return True
 
-    if lower.startswith(("noqa", "type:", "pragma:", "fmt:", "isort:", "pylint:", "flake8:")):
+    if lower.startswith(
+        ("noqa", "type:", "pragma:", "fmt:", "isort:", "pylint:", "flake8:")
+    ):
         return True
 
     if text.startswith(("http://", "https://")):
         return True
 
-    return bool(re.fullmatch(r"-{2,}.*-{2,}", text) or re.fullmatch(r"[=#*-]{3,}", text))
+    return bool(
+        re.fullmatch(r"-{2,}.*-{2,}", text) or re.fullmatch(r"[=#*-]{3,}", text)
+    )
 
 
 def normalize_comment_block(block: list[CommentLine]) -> str:
@@ -514,7 +519,9 @@ def check_function_signature_spacing(
 
 
 def find_header_end_line(
-    node: ast.FunctionDef | ast.AsyncFunctionDef, first_statement: ast.stmt, lines: list[str]
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    first_statement: ast.stmt,
+    lines: list[str],
 ) -> int | None:
     for line_number in range(first_statement.lineno - 1, node.lineno - 1, -1):
         line = lines[line_number - 1].strip()
@@ -558,7 +565,9 @@ def check_statement_spacing(
         code = ""
         message = ""
 
-        if isinstance(current, ast.Return) and not isinstance(previous, CONTROL_FLOW_STATEMENTS):
+        if isinstance(current, ast.Return) and not isinstance(
+            previous, CONTROL_FLOW_STATEMENTS
+        ):
             needs_blank = True
             code = "R001"
             message = "Add a blank line before this return statement."
@@ -571,7 +580,9 @@ def check_statement_spacing(
             code = "B002"
             message = "Add a blank line after this control-flow statement."
 
-        if not needs_blank or has_blank_line_between(lines, previous.end_lineno, current.lineno):
+        if not needs_blank or has_blank_line_between(
+            lines, previous.end_lineno, current.lineno
+        ):
             continue
 
         insertions.add(current.lineno)
@@ -588,7 +599,9 @@ def check_statement_spacing(
     return diagnostics
 
 
-def has_blank_line_between(lines: list[str], previous_end_line: int, current_line: int) -> bool:
+def has_blank_line_between(
+    lines: list[str], previous_end_line: int, current_line: int
+) -> bool:
     return any(
         not lines[line_number - 1].strip()
         for line_number in range(previous_end_line + 1, current_line)

--- a/src/ninetoothed/build.py
+++ b/src/ninetoothed/build.py
@@ -53,7 +53,6 @@ def build(
         module import time and its ``ProcessPoolExecutor`` would
         otherwise deadlock on the Python import lock.
     """
-
     if caller is None:
         caller = "cuda"
 

--- a/src/ninetoothed/debugging.py
+++ b/src/ninetoothed/debugging.py
@@ -22,7 +22,6 @@ def simulate_arrangement(arrangement, tensors, device=None):
         specified in ``arrangement``, and each element in each tensor
         stores the index of that element in the source tensor.
     """
-
     if device is None:
         device = "cuda"
 

--- a/src/ninetoothed/eval.py
+++ b/src/ninetoothed/eval.py
@@ -25,7 +25,6 @@ def _eval(tensor, subs=None):
         Previously, the evaluation would flatten the dimensions of the
         outermost level.
     """
-
     if tensor.source.ndim == 0:
         return np.array(0, dtype=np.intp)
 
@@ -65,7 +64,6 @@ def _subs(tensor, subs):
     :param subs: The substitutions for symbolic variables.
     :return: A new tensor with the substitutions applied.
     """
-
     replacements = _generate_replacements(subs)
 
     source = Tensor(

--- a/src/ninetoothed/jit.py
+++ b/src/ninetoothed/jit.py
@@ -15,7 +15,7 @@ def jit(
     max_num_configs=None,
     _prettify=False,
 ):
-    """A decorator for generating compute kernels.
+    """Generate compute kernels as a decorator.
 
     :param func: The function to be compiled.
     :param caller: Who will call the compute kernel.

--- a/src/ninetoothed/jit.py
+++ b/src/ninetoothed/jit.py
@@ -32,7 +32,6 @@ def jit(
         The ``_prettify`` parameter is experimental, which might break
         the generated code.
     """
-
     default_num_warps, default_num_stages = calculate_default_configs()
 
     if num_warps is None:

--- a/src/ninetoothed/make.py
+++ b/src/ninetoothed/make.py
@@ -29,7 +29,6 @@ def make(
         configurations to use.
     :return: A handle to the compute kernel.
     """
-
     params = inspect.signature(application).parameters
     types = arrangement(*tensors)
     types = types if isinstance(types, tuple) else (types,)

--- a/src/ninetoothed/symbol.py
+++ b/src/ninetoothed/symbol.py
@@ -261,7 +261,6 @@ def block_size(lower_bound=None, upper_bound=None):
     :param upper_bound: The upper bound for the block size's range.
     :return: A block size symbol that serves as a meta-parameter.
     """
-
     name = naming.auto_generate(f"BLOCK_SIZE_{block_size._num_block_sizes}")
 
     block_size._num_block_sizes += 1

--- a/src/ninetoothed/symbol.py
+++ b/src/ninetoothed/symbol.py
@@ -7,7 +7,7 @@ import ninetoothed.naming as naming
 
 
 class Symbol:
-    """A class uesed to represent a symbol.
+    """A class used to represent a symbol.
 
     :param expr: The expression used to construct the symbol.
     :param constexpr: Whether the symbol is a constexpr.

--- a/src/ninetoothed/symbol.py
+++ b/src/ninetoothed/symbol.py
@@ -45,7 +45,9 @@ class Symbol:
         self._node = ast.parse(expr, mode="eval").body
 
         if (constexpr or meta) and not isinstance(self._node, ast.Name):
-            raise ValueError("The `constexpr` and `meta` options are properties of name symbols.")
+            raise ValueError(
+                "The `constexpr` and `meta` options are properties of name symbols."
+            )
 
         if meta:
             if constexpr is False:

--- a/src/ninetoothed/symbol.py
+++ b/src/ninetoothed/symbol.py
@@ -28,10 +28,12 @@ class Symbol:
     ):
         if isinstance(expr, type(self)):
             self._node = expr._node
+
             return
 
         if isinstance(expr, ast.AST):
             self._node = expr
+
             return
 
         if isinstance(expr, types.CodeType):
@@ -43,7 +45,7 @@ class Symbol:
         self._node = ast.parse(expr, mode="eval").body
 
         if (constexpr or meta) and not isinstance(self._node, ast.Name):
-            raise ValueError("`constexpr` and `meta` are properties of name symbols.")
+            raise ValueError("The `constexpr` and `meta` options are properties of name symbols.")
 
         if meta:
             if constexpr is False:

--- a/src/ninetoothed/tensor.py
+++ b/src/ninetoothed/tensor.py
@@ -9,7 +9,7 @@ from ninetoothed.symbol import Symbol
 
 
 class Tensor:
-    """A class uesed to represent a symbolic tensor.
+    """A class used to represent a symbolic tensor.
 
     :param ndim: The number of dimensions of the tensor.
     :param shape: The shape of the tensor.
@@ -127,7 +127,7 @@ class Tensor:
         type(self).num_instances += 1
 
     def __getitem__(self, indices):
-        """Returns an indexed tensor using the specified ``indices``.
+        """Return an indexed tensor using the specified ``indices``.
 
         :param indices: The indices of the elements to extract.
         :return: The indexed tensor.
@@ -199,7 +199,7 @@ class Tensor:
 
     @_meta_operation
     def tile(self, tile_shape, strides=None, dilation=None, floor_mode=False):
-        """Tiles the tensor into a hierarchical tensor.
+        """Tile the tensor into a hierarchical tensor.
 
         :param tile_shape: The shape of a tile.
         :param strides: The interval at which each tile is generated.
@@ -287,7 +287,7 @@ class Tensor:
 
     @_meta_operation
     def expand(self, shape):
-        """Expands the specified singleton dimensions of the tensor.
+        """Expand the specified singleton dimensions of the tensor.
 
         :param shape: The expanded shape.
         :return: The expanded tensor.
@@ -321,7 +321,7 @@ class Tensor:
 
     @_meta_operation
     def unsqueeze(self, dim):
-        """Inserts a singleton dimension in the tensor.
+        """Insert a singleton dimension in the tensor.
 
         :param dim: The dimension to be unsqueezed.
         :return: The unsqueezed tensor.
@@ -353,7 +353,7 @@ class Tensor:
 
     @_meta_operation
     def squeeze(self, dim):
-        """Removes the specified singleton dimensions of the tensor.
+        """Remove the specified singleton dimensions of the tensor.
 
         :param dim: The dimension(s) to be squeezed.
         :return: The squeezed tensor.
@@ -392,7 +392,7 @@ class Tensor:
 
     @_meta_operation
     def permute(self, dims):
-        """Permutes the dimensions of the tensor.
+        """Permute the dimensions of the tensor.
 
         :param dims: The permuted ordering of the dimensions.
         :return: The permuted tensor.
@@ -423,7 +423,7 @@ class Tensor:
 
     @_meta_operation
     def flatten(self, start_dim=None, end_dim=None):
-        """Flattens the specified dimensions of the tensor.
+        """Flatten the specified dimensions of the tensor.
 
         See :func:`ravel` for the differences between :func:`flatten`
         and :func:`ravel`.
@@ -481,7 +481,7 @@ class Tensor:
 
     @_meta_operation
     def ravel(self):
-        """Flattens the hierarchy of the tensor.
+        """Flatten the hierarchy of the tensor.
 
         :func:`ravel` differs from :func:`flatten`, which only flattens
         dimensions at a single level. For example, consider a tensor
@@ -537,7 +537,7 @@ class Tensor:
 
     @_meta_operation
     def pad(self, pad):
-        """Pads the tensor with the specified padding.
+        """Pad the tensor with the specified padding.
 
         :param pad: The amount of padding applied to the tensor.
         :return: The padded tensor.
@@ -670,7 +670,7 @@ class Tensor:
 
     @_meta_operation
     def _slice_dim(self, dim, start, stop=None, step=None):
-        """Slices the tensor along the specified dimension.
+        """Slice the tensor along the specified dimension.
 
         :param dim: The dimension to slice.
         :param start: The starting index of the slice.

--- a/src/ninetoothed/tensor.py
+++ b/src/ninetoothed/tensor.py
@@ -88,7 +88,9 @@ class Tensor:
             self.name = naming.make_constexpr(self.name)
 
         if not constexpr and value is not None:
-            raise ValueError("The `value` option can only be set for constexpr tensors.")
+            raise ValueError(
+                "The `value` option can only be set for constexpr tensors."
+            )
 
         self.value = value
 

--- a/src/ninetoothed/tensor.py
+++ b/src/ninetoothed/tensor.py
@@ -132,7 +132,6 @@ class Tensor:
         :param indices: The indices of the elements to extract.
         :return: The indexed tensor.
         """
-
         if not isinstance(indices, tuple):
             indices = (indices,)
 
@@ -209,7 +208,6 @@ class Tensor:
             compute the outer shape.
         :return: A hierarchical tensor.
         """
-
         if strides is None:
             strides = [-1 for _ in tile_shape]
 
@@ -294,7 +292,6 @@ class Tensor:
         :param shape: The expanded shape.
         :return: The expanded tensor.
         """
-
         self._inputs.append([])
 
         def _offsets(indices):
@@ -329,7 +326,6 @@ class Tensor:
         :param dim: The dimension to be unsqueezed.
         :return: The unsqueezed tensor.
         """
-
         # TODO: Add error handling.
         new_shape = list(self.shape)
         new_shape.insert(dim, 1)
@@ -362,7 +358,6 @@ class Tensor:
         :param dim: The dimension(s) to be squeezed.
         :return: The squeezed tensor.
         """
-
         if not isinstance(dim, tuple):
             dim = (dim,)
 
@@ -402,7 +397,6 @@ class Tensor:
         :param dims: The permuted ordering of the dimensions.
         :return: The permuted tensor.
         """
-
         # TODO: Add error handling.
         new_shape = [None for _ in range(self.ndim)]
 
@@ -438,7 +432,6 @@ class Tensor:
         :param end_dim: The dimension after the last to flatten.
         :return: The flattened tensor.
         """
-
         # TODO: Add error handling.
         if start_dim is None:
             start_dim = 0
@@ -499,7 +492,6 @@ class Tensor:
 
         :return: The raveled tensor.
         """
-
         # TODO: Add error handling.
         new_shape = []
         outputs = []
@@ -550,7 +542,6 @@ class Tensor:
         :param pad: The amount of padding applied to the tensor.
         :return: The padded tensor.
         """
-
         new_shape = tuple(size + sum(pad_i) for size, pad_i in zip(self.shape, pad))
 
         self._inputs.append([])
@@ -687,7 +678,6 @@ class Tensor:
         :param step: The step size of the slice.
         :return: The sliced tensor.
         """
-
         if dim < 0:
             dim += self.ndim
 

--- a/src/ninetoothed/tensor.py
+++ b/src/ninetoothed/tensor.py
@@ -79,7 +79,7 @@ class Tensor:
 
         if constexpr and self.ndim != 0:
             raise ValueError(
-                "`constexpr` can only be set for zero-dimensional tensors."
+                "The `constexpr` option can only be set for zero-dimensional tensors."
             )
 
         self.constexpr = constexpr
@@ -88,7 +88,7 @@ class Tensor:
             self.name = naming.make_constexpr(self.name)
 
         if not constexpr and value is not None:
-            raise ValueError("`value` can only be set for constexpr tensors.")
+            raise ValueError("The `value` option can only be set for constexpr tensors.")
 
         self.value = value
 
@@ -440,6 +440,7 @@ class Tensor:
         # TODO: Add error handling.
         if start_dim is None:
             start_dim = 0
+
         if end_dim is None:
             end_dim = self.ndim
 
@@ -695,11 +696,13 @@ class Tensor:
 
         if start is None:
             start = 0 if step > 0 else size - 1
+
         if stop is None:
             stop = size if step > 0 else -1
 
         if isinstance(start, int) and start < 0:
             start += size
+
         if isinstance(stop, int) and (stop < 0 if step > 0 else stop < -1):
             stop += size
 

--- a/src/ninetoothed/visualization.py
+++ b/src/ninetoothed/visualization.py
@@ -21,7 +21,6 @@ def visualize(tensor, color=None, save_path=None):
     :param color: The color to be used for visualization.
     :param save_path: The path where the visualization should be saved.
     """
-
     if color is None:
         color = f"C{visualize.count}"
 
@@ -55,7 +54,6 @@ def visualize_arrangement(arrangement, tensors):
     :param arrangement: The arrangement of the tensors.
     :param tensors: The tensors.
     """
-
     source_tensors, target_tensors = simulate_arrangement(arrangement, tensors)
 
     param_names = inspect.signature(arrangement).parameters.keys()

--- a/tests/test_aot.py
+++ b/tests/test_aot.py
@@ -139,8 +139,10 @@ def test_attention(
     query_, key_, value_, output_ = tuple(
         Tensor(4, dtype=ninetoothed_dtype) for _ in range(4)
     )
+
     for tensor in (query_, key_, value_, output_):
         tensor.shape = tensor.shape[:-1] + (emb_dim,)
+
     is_causal_ = Tensor(0, constexpr=True, value=1)
     tensors = (query_, key_, value_, is_causal_, output_)
     caller = device

--- a/tests/test_matmul.py
+++ b/tests/test_matmul.py
@@ -40,8 +40,10 @@ def arrangement(
 
 def application(lhs, rhs, output):
     accumulator = ntl.zeros(output.shape, dtype=ntl.float32)
+
     for k in range(lhs.shape[0]):
         accumulator += ntl.dot(lhs[k], rhs[k])
+
     output = accumulator.to(ntl.float16)
 
 


### PR DESCRIPTION
## Summary

- Enable Ruff docstring checks and docstring code formatting for rules Ruff can enforce directly.
- Add project-specific scripts under `scripts/` for contributing style and PR metadata checks.
- Wire the new checks into commit hooks and GitHub Actions, and apply the resulting style fixes to the current tree.

## Validation

`pytest` output:

```text
$ ssh nvidia 'cd ~/ninetoothed-validate-current && python -m pytest tests'
216 passed in 986.83s (0:16:26)
```

Additional checks run on `ssh nvidia`:

```text
$ ~/.venv/bin/ruff format --check
49 files already formatted

$ ~/.venv/bin/ruff check
All checks passed!

$ ~/.venv/bin/python scripts/check_contributing_style.py
passed

$ ~/.venv/bin/python scripts/check_contributing_metadata.py ...
passed
```

Also validated the control-flow/return spacing edge case after the latest checker fix: a regular `return` after ordinary statements is flagged, while a `return` directly following control flow is not.

## Note

The full CI-style pytest command with doctest and coverage did not complete cleanly on the remote environment: the project venv Python is missing `_tkinter` for visualization doctest collection, and the `/usr/bin/python3` fallback timed out after 30 minutes. The focused `python -m pytest tests` suite passed.