### PR TITLE
Refactor IR dataclass constructors

### DIFF
--- a/src/ninetoothed/backends/core.py
+++ b/src/ninetoothed/backends/core.py
@@ -26,7 +26,7 @@ _CANONICAL_BACKEND_NAMES = {
 }
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class Options:
     """Options passed from public APIs to a backend lowerer."""
 
@@ -36,7 +36,7 @@ class Options:
     extra: Mapping[str, Any] = field(default_factory=dict)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class Capability:
     """Human-readable status for a backend implementation."""
 
@@ -47,7 +47,7 @@ class Capability:
     notes: tuple[str, ...] = ()
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class Artifact:
     """The output of lowering a :class:`Kernel` to a backend."""
 

--- a/src/ninetoothed/backends/emitters/ssa.py
+++ b/src/ninetoothed/backends/emitters/ssa.py
@@ -55,12 +55,12 @@ _REDUCE_INIT = {
 }
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class _TensorInfo:
-    name: str
-    dtype: str = "float32"
-    shape: tuple[str, ...] = ()
     ndim: int = 1
+    shape: tuple[str, ...] = ()
+    dtype: str = "float32"
+    name: str
     source_name: str | None = None
     source_shape: tuple[str, ...] = ()
     source_strides: tuple[str, ...] = ()
@@ -69,7 +69,7 @@ class _TensorInfo:
     attrs: Mapping[str, Any] | None = None
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class _Target:
     backend: Target
     language: str
@@ -333,7 +333,7 @@ class _Target:
         return f"T.max({acc}, {term})" if operator == "max" else f"T.min({acc}, {term})"
 
 
-@dataclass
+@dataclass(kw_only=True)
 class _EmitContext:
     target: _Target
     kernel: Kernel
@@ -436,21 +436,29 @@ def emit(kernel: Kernel, backend: Target) -> Artifact:
 def _target(backend: Target) -> _Target:
     return {
         Target.TRITON: _Target(
-            backend, "python/triton", "triton.py", "ssa-unified-triton-emitter"
+            backend=backend,
+            language="python/triton",
+            suffix="triton.py",
+            source_route="ssa-unified-triton-emitter",
         ),
-        Target.CUDA: _Target(backend, "cuda/c++", "cu", "ssa-unified-cuda-emitter"),
+        Target.CUDA: _Target(
+            backend=backend,
+            language="cuda/c++",
+            suffix="cu",
+            source_route="ssa-unified-cuda-emitter",
+        ),
         Target.TILELANG: _Target(
-            backend,
-            "python/tilelang",
-            "tilelang.py",
-            "ssa-unified-tilelang-emitter",
+            backend=backend,
+            language="python/tilelang",
+            suffix="tilelang.py",
+            source_route="ssa-unified-tilelang-emitter",
             buffer_suffix="_buf",
         ),
         Target.TVM: _Target(
-            backend,
-            "python/tvm-script",
-            "tvm.py",
-            "ssa-unified-tvm-emitter",
+            backend=backend,
+            language="python/tvm-script",
+            suffix="tvm.py",
+            source_route="ssa-unified-tvm-emitter",
             buffer_suffix="_buf",
         ),
     }[backend]
@@ -589,7 +597,7 @@ def _render_body(
     )
 
     if enable_index_cse:
-        index_type = ssa.Type("index", dtype="index")
+        index_type = ssa.Type(kind="index", dtype="index")
 
         if outer_index_expr != target.index_name:
             lines.append(
@@ -946,7 +954,7 @@ def _emit_linalg_dot(
         )
 
     local = f"{_local_symbol(op.results[0].name, ctx)}_dot"
-    acc_type = ssa.Type("scalar", dtype=op.results[0].type.dtype or "float32")
+    acc_type = ssa.Type(kind="scalar", dtype=op.results[0].type.dtype or "float32")
     init = "0.0"
 
     if ctx.target.backend == Target.TRITON and ctx.mask_expr is not None:
@@ -1179,7 +1187,7 @@ def _emit_reduce_element(
         local = f"{_local_symbol(op.results[0].name, ctx)}_elem"
 
     result_type = ssa.Type(
-        "scalar", dtype=op.results[0].type.dtype if op.results else "float32"
+        kind="scalar", dtype=op.results[0].type.dtype if op.results else "float32"
     )
     init = _REDUCE_INIT[operator]
 
@@ -1960,7 +1968,7 @@ def _region_yield_element(
 
 
 def _tensor_value(name: str, ctx: _EmitContext) -> str:
-    info = ctx.tensor_infos.get(name, _TensorInfo(name))
+    info = ctx.tensor_infos.get(name, _TensorInfo(name=name))
 
     if info.ndim == 0:
         if _is_bool_scalar_value(name, ctx) and ctx.target.backend in {
@@ -2336,7 +2344,7 @@ def _materialize_index_expr(
 
     local = _fresh_temp(ctx, "nt_idx")
     ctx.lines.append(
-        ctx.target.local_decl(ssa.Type("index", dtype="index"), local, expr)
+        ctx.target.local_decl(ssa.Type(kind="index", dtype="index"), local, expr)
     )
 
     if ctx.materialized is not None:
@@ -2362,7 +2370,7 @@ def _materialize_bool_expr(
 
     local = _fresh_temp(ctx, "nt_pred")
     ctx.lines.append(
-        ctx.target.local_decl(ssa.Type("scalar", dtype="bool"), local, expr)
+        ctx.target.local_decl(ssa.Type(kind="scalar", dtype="bool"), local, expr)
     )
 
     return local
@@ -2379,7 +2387,7 @@ def _fresh_temp(ctx: _EmitContext, prefix: str) -> str:
 
 
 def _default_tensor_index(name: str, ctx: _EmitContext) -> str:
-    info = ctx.tensor_infos.get(name, _TensorInfo(name))
+    info = ctx.tensor_infos.get(name, _TensorInfo(name=name))
 
     if info.ndim <= 1:
         if (
@@ -2738,10 +2746,10 @@ def _tensor_info(tensor: TensorSpec) -> _TensorInfo:
     source_strides = tuple(str(dim) for dim in attrs.get("source_strides", ()))
 
     return _TensorInfo(
-        name=tensor.name,
-        dtype=_normalize_dtype(tensor.dtype or "float32"),
-        shape=tuple(str(dim) for dim in tensor.shape),
         ndim=max(tensor.ndim, len(tensor.shape)),
+        shape=tuple(str(dim) for dim in tensor.shape),
+        dtype=_normalize_dtype(tensor.dtype or "float32"),
+        name=tensor.name,
         source_name=str(attrs.get("source_name")) if attrs.get("source_name") else None,
         source_shape=source_shape,
         source_strides=source_strides,

--- a/src/ninetoothed/compiler/passes.py
+++ b/src/ninetoothed/compiler/passes.py
@@ -29,7 +29,7 @@ HARDWARE_DEPENDENT = "hardware_dependent"
 BACKEND_SPECIFIC = "backend_specific"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class PipelineSpec:
     """Declarative pass pipeline configuration."""
 
@@ -40,7 +40,7 @@ class PipelineSpec:
     reason: str | None = None
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class Context:
     """Context shared by SSA passes."""
 
@@ -63,7 +63,7 @@ class Pass:
         raise NotImplementedError
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class Descriptor:
     """Registry metadata for one SSA pass."""
 
@@ -832,7 +832,7 @@ def _map_block(block: ssa.Block, fn) -> ssa.Block:
 def _map_operation(operation: ssa.Operation, fn) -> ssa.Operation:
     mapped_regions = tuple(_map_block(region, fn) for region in operation.regions)
     operation = ssa.Operation(
-        operation.opcode,
+        opcode=operation.opcode,
         operands=operation.operands,
         results=operation.results,
         attrs=operation.attrs,
@@ -912,10 +912,10 @@ def _decompose_linalg_block(
             source = transpose.operands[0]
             output = operation.operands[1]
             col, temp_index = _fresh_value(
-                existing_names, temp_index, ssa.Type("index")
+                existing_names, temp_index, ssa.Type(kind="index")
             )
             row, temp_index = _fresh_value(
-                existing_names, temp_index, ssa.Type("index")
+                existing_names, temp_index, ssa.Type(kind="index")
             )
             value, temp_index = _fresh_value(
                 existing_names,
@@ -925,25 +925,25 @@ def _decompose_linalg_block(
             operations.extend(
                 (
                     ssa.Operation(
-                        "index.offset",
+                        opcode="index.offset",
                         operands=(output,),
                         results=(col,),
                         attrs={"dim": 0, "decomposition": "transpose"},
                     ),
                     ssa.Operation(
-                        "index.offset",
+                        opcode="index.offset",
                         operands=(output,),
                         results=(row,),
                         attrs={"dim": 1, "decomposition": "transpose"},
                     ),
                     ssa.Operation(
-                        "tensor.extract",
+                        opcode="tensor.extract",
                         operands=(source, row.name, col.name),
                         results=(value,),
                         attrs={"decomposition": "transpose"},
                     ),
                     ssa.Operation(
-                        "mem.store",
+                        opcode="mem.store",
                         operands=(value.name, output),
                         attrs=dict(operation.attrs)
                         | {
@@ -978,7 +978,7 @@ def _decompose_linalg_block(
         )
         operations.append(
             ssa.Operation(
-                operation.opcode,
+                opcode=operation.opcode,
                 operands=operation.operands,
                 results=operation.results,
                 attrs=operation.attrs,
@@ -1001,17 +1001,17 @@ def _decompose_matmul_store(
     output_type = value_types.get(output, matmul.results[0].type)
     scalar_type = _scalar_type(output_type)
 
-    row, temp_index = _fresh_value(existing_names, temp_index, ssa.Type("index"))
-    col, temp_index = _fresh_value(existing_names, temp_index, ssa.Type("index"))
+    row, temp_index = _fresh_value(existing_names, temp_index, ssa.Type(kind="index"))
+    col, temp_index = _fresh_value(existing_names, temp_index, ssa.Type(kind="index"))
     zero, temp_index = _fresh_value(
-        existing_names, temp_index, ssa.Type("scalar", dtype="int64")
+        existing_names, temp_index, ssa.Type(kind="scalar", dtype="int64")
     )
     one, temp_index = _fresh_value(
-        existing_names, temp_index, ssa.Type("scalar", dtype="int64")
+        existing_names, temp_index, ssa.Type(kind="scalar", dtype="int64")
     )
     acc_init, temp_index = _fresh_value(existing_names, temp_index, scalar_type)
-    kk = ssa.Value("%kk", ssa.Type("index"))
-    acc_iter = ssa.Value("%acc_iter", scalar_type)
+    kk = ssa.Value(name="%kk", type=ssa.Type(kind="index"))
+    acc_iter = ssa.Value(name="%acc_iter", type=scalar_type)
     lhs_value, temp_index = _fresh_value(
         existing_names, temp_index, _scalar_type(value_types.get(lhs, output_type))
     )
@@ -1023,7 +1023,7 @@ def _decompose_matmul_store(
     acc_result, temp_index = _fresh_value(existing_names, temp_index, scalar_type)
 
     loop = ssa.Operation(
-        "scf.for",
+        opcode="scf.for",
         operands=(zero.name, k, one.name, acc_init.name),
         results=(acc_result,),
         attrs={
@@ -1046,30 +1046,30 @@ def _decompose_matmul_store(
                 args=(kk, acc_iter),
                 operations=(
                     ssa.Operation(
-                        "tensor.extract",
+                        opcode="tensor.extract",
                         operands=(lhs, row.name, kk.name),
                         results=(lhs_value,),
                         attrs={"decomposition": "matmul", "operand": "lhs"},
                     ),
                     ssa.Operation(
-                        "tensor.extract",
+                        opcode="tensor.extract",
                         operands=(rhs, kk.name, col.name),
                         results=(rhs_value,),
                         attrs={"decomposition": "matmul", "operand": "rhs"},
                     ),
                     ssa.Operation(
-                        "arith.mul",
+                        opcode="arith.mul",
                         operands=(lhs_value.name, rhs_value.name),
                         results=(product,),
                         attrs={"decomposition": "matmul"},
                     ),
                     ssa.Operation(
-                        "arith.add",
+                        opcode="arith.add",
                         operands=(acc_iter.name, product.name),
                         results=(acc_next,),
                         attrs={"decomposition": "matmul"},
                     ),
-                    ssa.Operation("scf.yield", operands=(acc_next.name,)),
+                    ssa.Operation(opcode="scf.yield", operands=(acc_next.name,)),
                 ),
             ),
         ),
@@ -1078,35 +1078,35 @@ def _decompose_matmul_store(
     return (
         (
             ssa.Operation(
-                "index.offset",
+                opcode="index.offset",
                 operands=(output,),
                 results=(row,),
                 attrs={"dim": 0, "decomposition": "matmul"},
             ),
             ssa.Operation(
-                "index.offset",
+                opcode="index.offset",
                 operands=(output,),
                 results=(col,),
                 attrs={"dim": 1, "decomposition": "matmul"},
             ),
             ssa.Operation(
-                "arith.constant",
+                opcode="arith.constant",
                 results=(zero,),
                 attrs={"value": 0, "decomposition": "matmul"},
             ),
             ssa.Operation(
-                "arith.constant",
+                opcode="arith.constant",
                 results=(one,),
                 attrs={"value": 1, "decomposition": "matmul"},
             ),
             ssa.Operation(
-                "arith.constant",
+                opcode="arith.constant",
                 results=(acc_init,),
                 attrs={"value": 0.0, "decomposition": "matmul"},
             ),
             loop,
             ssa.Operation(
-                "mem.store",
+                opcode="mem.store",
                 operands=(acc_result.name, output),
                 attrs=dict(store.attrs)
                 | {
@@ -1149,13 +1149,13 @@ def _infer_matmul_symbols(
     value_types: Mapping[str, ssa.Type],
 ) -> tuple[str, str, str]:
     lhs_shape = tuple(
-        str(dim) for dim in value_types.get(lhs, ssa.Type("tensor")).shape
+        str(dim) for dim in value_types.get(lhs, ssa.Type(kind="tensor")).shape
     )
     rhs_shape = tuple(
-        str(dim) for dim in value_types.get(rhs, ssa.Type("tensor")).shape
+        str(dim) for dim in value_types.get(rhs, ssa.Type(kind="tensor")).shape
     )
     output_shape = tuple(
-        str(dim) for dim in value_types.get(output, ssa.Type("tensor")).shape
+        str(dim) for dim in value_types.get(output, ssa.Type(kind="tensor")).shape
     )
     m = _first_symbol(
         operation.attrs.get("m"),
@@ -1202,7 +1202,7 @@ def _first_symbol(*candidates: object) -> str:
 
 
 def _scalar_type(type_: ssa.Type) -> ssa.Type:
-    return ssa.Type("scalar", dtype=type_.dtype or "float32")
+    return ssa.Type(kind="scalar", dtype=type_.dtype or "float32")
 
 
 def _next_temp_index(existing_names: set[str]) -> int:
@@ -1224,12 +1224,12 @@ def _fresh_value(
     name = f"%{temp_index}"
     existing_names.add(name)
 
-    return ssa.Value(name, type_), temp_index + 1
+    return ssa.Value(name=name, type=type_), temp_index + 1
 
 
 def _annotate_operation(operation: ssa.Operation, **attrs: Any) -> ssa.Operation:
     return ssa.Operation(
-        operation.opcode,
+        opcode=operation.opcode,
         operands=operation.operands,
         results=operation.results,
         attrs=dict(operation.attrs) | attrs,

--- a/src/ninetoothed/frontend/python.py
+++ b/src/ninetoothed/frontend/python.py
@@ -376,12 +376,12 @@ class _ApplicationSSABuilder:
         self.param_names = tuple(arg.arg for arg in func.args.args)
         self.tensor_types = {
             tensor.name: ssa.Type(
-                "tensor" if tensor.ndim != 0 else "scalar",
-                dtype=tensor.dtype,
+                kind="tensor" if tensor.ndim != 0 else "scalar",
                 shape=tuple(
                     str(dim)
                     for dim in tensor.attrs.get("application_shape", tensor.shape)
                 ),
+                dtype=tensor.dtype,
                 attrs={
                     "ndim": tensor.ndim,
                     "constexpr": tensor.constexpr,
@@ -486,7 +486,7 @@ class _ApplicationSSABuilder:
 
                 operations.append(
                     ssa.Operation(
-                        "mem.store",
+                        opcode="mem.store",
                         operands=(value.name, output.name),
                         attrs={"target": target.id},
                     )
@@ -507,7 +507,7 @@ class _ApplicationSSABuilder:
             )
             operations.append(
                 ssa.Operation(
-                    "mem.store",
+                    opcode="mem.store",
                     operands=(value.name, destination.name),
                     attrs={
                         "subscript": _unparse(target.slice),
@@ -572,7 +572,7 @@ class _ApplicationSSABuilder:
             )
             operations.append(
                 ssa.Operation(
-                    "mem.store",
+                    opcode="mem.store",
                     operands=(result.name, destination.name),
                     attrs={
                         "subscript": _unparse(stmt.target.slice),
@@ -616,7 +616,7 @@ class _ApplicationSSABuilder:
         assigned = _assigned_names(stmt.body)
         carried = tuple(name for name in assigned if name in env)
 
-        induction = ssa.Value(f"%{stmt.target.id}", ssa.Type("index"))
+        induction = ssa.Value(name=f"%{stmt.target.id}", type=ssa.Type(kind="index"))
         block_args = [induction]
         loop_env = dict(env)
         loop_env[stmt.target.id] = induction
@@ -624,7 +624,7 @@ class _ApplicationSSABuilder:
 
         for name in carried:
             current = env[name]
-            arg = ssa.Value(f"%{name}_iter", current.type)
+            arg = ssa.Value(name=f"%{name}_iter", type=current.type)
             block_args.append(arg)
             loop_env[name] = arg
             iter_arg_attrs.append(
@@ -634,12 +634,12 @@ class _ApplicationSSABuilder:
         loop_operations: list[ssa.Operation] = []
         self._lower_statements(stmt.body, loop_operations, loop_env)
         yield_values = tuple(loop_env[name].name for name in carried)
-        loop_operations.append(ssa.Operation("scf.yield", operands=yield_values))
+        loop_operations.append(ssa.Operation(opcode="scf.yield", operands=yield_values))
 
         results = tuple(self._temp(env[name].type, hint=name) for name in carried)
         operations.append(
             ssa.Operation(
-                "scf.for",
+                opcode="scf.for",
                 operands=(
                     lower_bound.name,
                     upper_bound.name,
@@ -690,7 +690,7 @@ class _ApplicationSSABuilder:
 
             operations.append(
                 ssa.Operation(
-                    "scf.if",
+                    opcode="scf.if",
                     operands=(condition.name,),
                     attrs={"has_results": False},
                     regions=tuple(regions),
@@ -704,7 +704,8 @@ class _ApplicationSSABuilder:
         self._lower_statements(stmt.body, then_ops, then_env)
         then_ops.append(
             ssa.Operation(
-                "scf.yield", operands=tuple(then_env[name].name for name in assigned)
+                opcode="scf.yield",
+                operands=tuple(then_env[name].name for name in assigned),
             )
         )
 
@@ -716,14 +717,15 @@ class _ApplicationSSABuilder:
 
         else_ops.append(
             ssa.Operation(
-                "scf.yield", operands=tuple(else_env[name].name for name in assigned)
+                opcode="scf.yield",
+                operands=tuple(else_env[name].name for name in assigned),
             )
         )
 
         results = tuple(self._temp(env[name].type, hint=name) for name in assigned)
         operations.append(
             ssa.Operation(
-                "scf.if",
+                opcode="scf.if",
                 operands=(condition.name,),
                 results=results,
                 attrs={"assigned": assigned},
@@ -826,7 +828,7 @@ class _ApplicationSSABuilder:
                     operations,
                     f"arith.{_boolop_name(node.op)}",
                     operands=(result.name, rhs.name),
-                    result_type=ssa.Type("tensor", dtype="bool"),
+                    result_type=ssa.Type(kind="tensor", dtype="bool"),
                 )
             return result
 
@@ -907,7 +909,7 @@ class _ApplicationSSABuilder:
                 operations,
                 "symbol.attr",
                 attrs={"expr": _unparse(node)},
-                result_type=ssa.Type("symbol"),
+                result_type=ssa.Type(kind="symbol"),
             )
 
         if isinstance(node, ast.Call):
@@ -921,7 +923,7 @@ class _ApplicationSSABuilder:
                 "tuple.construct",
                 operands=tuple(item.name for item in items),
                 attrs={"items": tuple(_unparse(item) for item in node.elts)},
-                result_type=ssa.Type("tuple"),
+                result_type=ssa.Type(kind="tuple"),
             )
 
         raise LoweringError(f"Unsupported expression: {ast.dump(node)}.")
@@ -975,7 +977,7 @@ class _ApplicationSSABuilder:
                     "tensor.stride",
                     operands=(receiver.name,),
                     attrs={"dim": dim},
-                    result_type=ssa.Type("index"),
+                    result_type=ssa.Type(kind="index"),
                 )
 
             if method == "data_ptr":
@@ -983,7 +985,7 @@ class _ApplicationSSABuilder:
                     operations,
                     "mem.data_ptr",
                     operands=(receiver.name,),
-                    result_type=ssa.Type("pointer", dtype=receiver.type.dtype),
+                    result_type=ssa.Type(kind="pointer", dtype=receiver.type.dtype),
                 )
 
             if method in {"sum", "max", "min"}:
@@ -1027,7 +1029,7 @@ class _ApplicationSSABuilder:
                     "dtype": _keyword_text(node, "dtype"),
                 },
                 result_type=ssa.Type(
-                    "tensor", dtype=_keyword_text(node, "dtype"), shape=shape
+                    kind="tensor", shape=shape, dtype=_keyword_text(node, "dtype")
                 ),
             )
 
@@ -1053,7 +1055,7 @@ class _ApplicationSSABuilder:
                     "dtype": _keyword_text(node, "dtype"),
                 },
                 result_type=ssa.Type(
-                    "tensor", dtype=_keyword_text(node, "dtype"), shape=shape
+                    kind="tensor", shape=shape, dtype=_keyword_text(node, "dtype")
                 ),
             )
 
@@ -1111,7 +1113,7 @@ class _ApplicationSSABuilder:
                 "mem.atomic_add",
                 operands=tuple(value.name for value in operands),
                 result_type=ssa.Type(
-                    "scalar",
+                    kind="scalar",
                     dtype=operands[1].type.dtype if len(operands) > 1 else "float32",
                 ),
             )
@@ -1120,7 +1122,7 @@ class _ApplicationSSABuilder:
             result_type = (
                 _matmul_type(operands[0].type, operands[1].type)
                 if len(operands) >= 2
-                else ssa.Type("tensor")
+                else ssa.Type(kind="tensor")
             )
 
             return self._emit(
@@ -1148,7 +1150,7 @@ class _ApplicationSSABuilder:
                 operands=tuple(value.name for value in operands),
                 result_type=_transpose_type(operands[0].type)
                 if operands
-                else ssa.Type("tensor"),
+                else ssa.Type(kind="tensor"),
             )
 
         if name == "where":
@@ -1158,7 +1160,7 @@ class _ApplicationSSABuilder:
                 operands=tuple(value.name for value in operands),
                 result_type=operands[1].type
                 if len(operands) > 1
-                else ssa.Type("tensor"),
+                else ssa.Type(kind="tensor"),
             )
 
         if name in {"sum", "max", "min"}:
@@ -1171,7 +1173,7 @@ class _ApplicationSSABuilder:
                 attrs={"axis": axis},
                 result_type=_reduce_type(operands[0].type, axis)
                 if operands
-                else ssa.Type("tensor"),
+                else ssa.Type(kind="tensor"),
             )
 
         if name in {"maximum", "minimum"}:
@@ -1179,7 +1181,7 @@ class _ApplicationSSABuilder:
                 operations,
                 f"arith.{name}",
                 operands=tuple(value.name for value in operands),
-                result_type=operands[0].type if operands else ssa.Type("tensor"),
+                result_type=operands[0].type if operands else ssa.Type(kind="tensor"),
             )
 
         if name in _SUPPORTED_MATH_CALLS:
@@ -1187,7 +1189,7 @@ class _ApplicationSSABuilder:
                 operations,
                 f"math.{name}",
                 operands=tuple(value.name for value in operands),
-                result_type=operands[0].type if operands else ssa.Type("tensor"),
+                result_type=operands[0].type if operands else ssa.Type(kind="tensor"),
             )
 
         return self._emit(
@@ -1195,7 +1197,7 @@ class _ApplicationSSABuilder:
             f"call.{name}",
             operands=tuple(value.name for value in operands),
             attrs={"callee": _unparse(node.func)},
-            result_type=operands[0].type if operands else ssa.Type("tensor"),
+            result_type=operands[0].type if operands else ssa.Type(kind="tensor"),
         )
 
     def _store_intrinsic_result(
@@ -1210,7 +1212,7 @@ class _ApplicationSSABuilder:
 
         operations.append(
             ssa.Operation(
-                "mem.store",
+                opcode="mem.store",
                 operands=(value.name, destination.name),
                 attrs={"target": destination.name, "intrinsic": intrinsic},
             )
@@ -1240,7 +1242,7 @@ class _ApplicationSSABuilder:
                 operations,
                 "symbol.attr",
                 attrs={"expr": _unparse(node)},
-                result_type=ssa.Type("symbol"),
+                result_type=ssa.Type(kind="symbol"),
             )
         return self._lower_expr(node, operations, env)
 
@@ -1272,7 +1274,7 @@ class _ApplicationSSABuilder:
             "shape.dim",
             operands=(tensor.name,),
             attrs={"dim": _literal_value(node.slice), "source": source},
-            result_type=ssa.Type("index"),
+            result_type=ssa.Type(kind="index"),
         )
 
     def _lower_subscript_values(
@@ -1320,7 +1322,7 @@ class _ApplicationSSABuilder:
             operations,
             "arith.constant",
             attrs={"value": attr_value},
-            result_type=ssa.Type("scalar", dtype=dtype),
+            result_type=ssa.Type(kind="scalar", dtype=dtype),
         )
 
     def _emit(
@@ -1332,10 +1334,10 @@ class _ApplicationSSABuilder:
         attrs: Mapping[str, Any] | None = None,
         result_type: ssa.Type | None = None,
     ) -> ssa.Value:
-        result = self._temp(result_type or ssa.Type("tensor"))
+        result = self._temp(result_type or ssa.Type(kind="tensor"))
         operations.append(
             ssa.Operation(
-                opcode,
+                opcode=opcode,
                 operands=operands,
                 results=(result,),
                 attrs=dict(attrs or {}),
@@ -1347,7 +1349,7 @@ class _ApplicationSSABuilder:
     def _temp(self, type_: ssa.Type, *, hint: str | None = None) -> ssa.Value:
         name = f"%{self.temp_index}" if hint is None else f"%{hint}_{self.temp_index}"
         self.temp_index += 1
-        value = ssa.Value(name, type_)
+        value = ssa.Value(name=name, type=type_)
         self.values[name] = value
 
         return value
@@ -1355,7 +1357,8 @@ class _ApplicationSSABuilder:
     def _named_value(self, name: str, type_: ssa.Type | None = None) -> ssa.Value:
         if name not in self.values:
             self.values[name] = ssa.Value(
-                name, type_ or self.tensor_types.get(name, ssa.Type("tensor"))
+                name=name,
+                type=type_ or self.tensor_types.get(name, ssa.Type(kind="tensor")),
             )
         return self.values[name]
 
@@ -1369,11 +1372,11 @@ class _ApplicationSSABuilder:
             return value
 
         replacement = ssa.Value(
-            value.name,
-            ssa.Type(
-                "scalar",
-                dtype="bool",
+            name=value.name,
+            type=ssa.Type(
+                kind="scalar",
                 shape=value.type.shape,
+                dtype="bool",
                 attrs=dict(value.type.attrs),
             ),
         )
@@ -1519,7 +1522,9 @@ def _value_for_shape_node(
 
         if base is None:
             return None
-        return ssa.Value("<shape-proxy>", _subscript_type(base.type, node.slice))
+        return ssa.Value(
+            name="<shape-proxy>", type=_subscript_type(base.type, node.slice)
+        )
     return None
 
 
@@ -1582,12 +1587,16 @@ def _subscript_type(type_: ssa.Type, slice_node: ast.AST) -> ssa.Type:
             level = int(attrs.get("dtype_level", 0)) + 1
             attrs["dtype_level"] = level
 
-            return ssa.Type("tensor", dtype=type_.dtype, shape=next_shape, attrs=attrs)
-        return ssa.Type("scalar", dtype=type_.dtype, attrs=attrs)
+            return ssa.Type(
+                kind="tensor", shape=next_shape, dtype=type_.dtype, attrs=attrs
+            )
+        return ssa.Type(kind="scalar", dtype=type_.dtype, attrs=attrs)
 
     if consumed:
         attrs["partial_indices"] = int(attrs.get("partial_indices", 0)) + consumed
-    return ssa.Type("tensor", dtype=type_.dtype, shape=tuple(result_shape), attrs=attrs)
+    return ssa.Type(
+        kind="tensor", shape=tuple(result_shape), dtype=type_.dtype, attrs=attrs
+    )
 
 
 def _next_dtype_shape(type_: ssa.Type) -> tuple[str, ...] | None:
@@ -1609,7 +1618,7 @@ def _reduce_type(type_: ssa.Type, axis: Any) -> ssa.Type:
     shape = tuple(str(dim) for dim in type_.shape)
 
     if axis is None:
-        return ssa.Type("scalar", dtype=type_.dtype, attrs=dict(type_.attrs))
+        return ssa.Type(kind="scalar", dtype=type_.dtype, attrs=dict(type_.attrs))
 
     index = int(axis)
 
@@ -1622,15 +1631,15 @@ def _reduce_type(type_: ssa.Type, axis: Any) -> ssa.Type:
     result_shape = shape[:index] + shape[index + 1 :]
 
     if not result_shape:
-        return ssa.Type("scalar", dtype=type_.dtype, attrs=dict(type_.attrs))
+        return ssa.Type(kind="scalar", dtype=type_.dtype, attrs=dict(type_.attrs))
     return ssa.Type(
-        "tensor", dtype=type_.dtype, shape=result_shape, attrs=dict(type_.attrs)
+        kind="tensor", shape=result_shape, dtype=type_.dtype, attrs=dict(type_.attrs)
     )
 
 
 def _offset_type(type_: ssa.Type, dim: Any) -> ssa.Type:
     if type_.kind != "tensor":
-        return ssa.Type("scalar", dtype="index")
+        return ssa.Type(kind="scalar", dtype="index")
 
     shape = tuple(str(item) for item in type_.shape)
     dtype_target_dims = tuple(
@@ -1641,7 +1650,7 @@ def _offset_type(type_: ssa.Type, dim: Any) -> ssa.Type:
     target_dims = dtype_target_dims[level] if level < len(dtype_target_dims) else ()
 
     if not target_dims:
-        return ssa.Type("tensor", dtype="index", shape=shape)
+        return ssa.Type(kind="tensor", shape=shape, dtype="index")
 
     source_ndim = int(type_.attrs.get("source_ndim", len(target_dims)))
     source_dim = int(dim or 0)
@@ -1656,8 +1665,8 @@ def _offset_type(type_: ssa.Type, dim: Any) -> ssa.Type:
     )
 
     if not kept:
-        return ssa.Type("scalar", dtype="index")
-    return ssa.Type("tensor", dtype="index", shape=kept)
+        return ssa.Type(kind="scalar", dtype="index")
+    return ssa.Type(kind="tensor", shape=kept, dtype="index")
 
 
 def _matmul_type(lhs: ssa.Type, rhs: ssa.Type) -> ssa.Type:
@@ -1668,17 +1677,20 @@ def _matmul_type(lhs: ssa.Type, rhs: ssa.Type) -> ssa.Type:
 
     if len(lhs_shape) >= 2 and len(rhs_shape) >= 2:
         return ssa.Type(
-            "tensor", dtype=dtype, shape=(lhs_shape[-2], rhs_shape[-1]), attrs=attrs
+            kind="tensor",
+            shape=(lhs_shape[-2], rhs_shape[-1]),
+            dtype=dtype,
+            attrs=attrs,
         )
 
     if len(lhs_shape) >= 2 and len(rhs_shape) == 1:
-        return ssa.Type("tensor", dtype=dtype, shape=(lhs_shape[-2],), attrs=attrs)
+        return ssa.Type(kind="tensor", shape=(lhs_shape[-2],), dtype=dtype, attrs=attrs)
 
     if len(lhs_shape) == 1 and len(rhs_shape) >= 2:
-        return ssa.Type("tensor", dtype=dtype, shape=(rhs_shape[-1],), attrs=attrs)
+        return ssa.Type(kind="tensor", shape=(rhs_shape[-1],), dtype=dtype, attrs=attrs)
 
     if len(lhs_shape) == 1 and len(rhs_shape) == 1:
-        return ssa.Type("scalar", dtype=dtype, attrs=attrs)
+        return ssa.Type(kind="scalar", dtype=dtype, attrs=attrs)
     return _broadcast_type(lhs, rhs)
 
 
@@ -1714,18 +1726,18 @@ def _broadcast_type(lhs: ssa.Type, rhs: ssa.Type) -> ssa.Type:
     dtype = lhs.dtype or rhs.dtype
     attrs = dict(lhs.attrs if lhs.kind == "tensor" else rhs.attrs)
 
-    return ssa.Type("tensor", dtype=dtype, shape=shape, attrs=attrs)
+    return ssa.Type(kind="tensor", shape=shape, dtype=dtype, attrs=attrs)
 
 
 def _bool_type(lhs: ssa.Value, rhs: ssa.Value | None = None) -> ssa.Type:
     if rhs is not None and rhs.type.kind == "tensor":
         shape = _broadcast_type(lhs.type, rhs.type).shape
 
-        return ssa.Type("tensor", dtype="bool", shape=shape)
+        return ssa.Type(kind="tensor", shape=shape, dtype="bool")
 
     if lhs.type.kind == "tensor":
-        return ssa.Type("tensor", dtype="bool", shape=lhs.type.shape)
-    return ssa.Type("scalar", dtype="bool")
+        return ssa.Type(kind="tensor", shape=lhs.type.shape, dtype="bool")
+    return ssa.Type(kind="scalar", dtype="bool")
 
 
 _SUPPORTED_MATH_CALLS = {
@@ -1760,9 +1772,9 @@ def _transpose_type(type_: ssa.Type) -> ssa.Type:
     if type_.kind != "tensor" or len(type_.shape) < 2:
         return type_
     return ssa.Type(
-        type_.kind,
-        dtype=type_.dtype,
+        kind=type_.kind,
         shape=tuple(reversed(type_.shape)),
+        dtype=type_.dtype,
         attrs=dict(type_.attrs),
     )
 

--- a/src/ninetoothed/ir/kernel.py
+++ b/src/ninetoothed/ir/kernel.py
@@ -12,16 +12,20 @@ import sympy
 from ninetoothed.ir.ssa import Program
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class TensorSpec:
-    """A backend-neutral view of an application tensor parameter."""
+    """A backend-neutral view of an application tensor parameter.
 
-    name: str
+    ``name`` is the application parameter and SSA binding name. Source tensor
+    provenance lives in ``attrs["source_name"]`` when available.
+    """
+
     ndim: int
-    dtype: str | None = None
     shape: tuple[str, ...] = ()
-    constexpr: bool = False
+    dtype: str | None = None
     jagged_dim: int | None = None
+    constexpr: bool = False
+    name: str
     attrs: Mapping[str, Any] = field(default_factory=dict)
 
     @classmethod
@@ -35,16 +39,16 @@ class TensorSpec:
         )
 
         return cls(
-            name=str(getattr(source, "name", getattr(tensor, "name", "tensor"))),
             ndim=int(getattr(tensor, "ndim", getattr(source, "ndim", len(shape)))),
-            dtype=None if dtype is None else str(dtype),
             shape=tuple(_shape_text(size) for size in shape),
-            constexpr=bool(
-                getattr(source, "constexpr", getattr(tensor, "constexpr", False))
-            ),
+            dtype=None if dtype is None else str(dtype),
             jagged_dim=getattr(
                 source, "jagged_dim", getattr(tensor, "jagged_dim", None)
             ),
+            constexpr=bool(
+                getattr(source, "constexpr", getattr(tensor, "constexpr", False))
+            ),
+            name=str(getattr(source, "name", getattr(tensor, "name", "tensor"))),
             attrs={
                 "source_name": str(
                     getattr(source, "name", getattr(tensor, "name", "tensor"))
@@ -65,7 +69,7 @@ class TensorSpec:
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class Launch:
     """Runtime launch metadata shared by generated backends."""
 
@@ -74,7 +78,7 @@ class Launch:
     grid: str | None = None
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class Kernel:
     """A kernel-level IR record consumed by backend emitters."""
 

--- a/src/ninetoothed/ir/ssa.py
+++ b/src/ninetoothed/ir/ssa.py
@@ -7,17 +7,17 @@ from dataclasses import dataclass, field
 from typing import Any
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class Type:
     """A compact SSA value type."""
 
     kind: str
-    dtype: str | None = None
     shape: tuple[str, ...] = ()
+    dtype: str | None = None
     attrs: Mapping[str, Any] = field(default_factory=dict)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class Value:
     """A named SSA value such as ``%0`` or a public tensor argument."""
 
@@ -25,7 +25,7 @@ class Value:
     type: Type
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class Operation:
     """A single SSA operation."""
 
@@ -36,7 +36,7 @@ class Operation:
     regions: tuple["Block", ...] = ()
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class Block:
     """A straight-line SSA block."""
 
@@ -45,7 +45,7 @@ class Block:
     operations: tuple[Operation, ...] = ()
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class Program:
     """Canonical SSA-like IR for backend generation."""
 

--- a/src/ninetoothed/lowering.py
+++ b/src/ninetoothed/lowering.py
@@ -142,14 +142,14 @@ def _public_tensor_ir(name: str, tensor) -> TensorSpec:
     shape = getattr(source, "shape", getattr(tensor, "shape", ()))
 
     return TensorSpec(
-        name=str(name),
         ndim=int(getattr(source, "ndim", getattr(tensor, "ndim", len(shape)))),
-        dtype=None if dtype is None else str(dtype),
         shape=tuple(_shape_text(size) for size in shape),
+        dtype=None if dtype is None else str(dtype),
+        jagged_dim=getattr(source, "jagged_dim", getattr(tensor, "jagged_dim", None)),
         constexpr=bool(
             getattr(source, "constexpr", getattr(tensor, "constexpr", False))
         ),
-        jagged_dim=getattr(source, "jagged_dim", getattr(tensor, "jagged_dim", None)),
+        name=str(name),
         attrs=_tensor_source_attrs(tensor),
     )
 
@@ -161,14 +161,14 @@ def _application_tensor_ir(name: str, tensor) -> TensorSpec:
     application_shape = _tensor_application_shape(tensor)
 
     return TensorSpec(
-        name=str(name),
         ndim=int(getattr(tensor, "ndim", getattr(source, "ndim", len(shape)))),
-        dtype=None if dtype is None else str(dtype),
         shape=tuple(_shape_text(size) for size in shape),
+        dtype=None if dtype is None else str(dtype),
+        jagged_dim=getattr(source, "jagged_dim", getattr(tensor, "jagged_dim", None)),
         constexpr=bool(
             getattr(source, "constexpr", getattr(tensor, "constexpr", False))
         ),
-        jagged_dim=getattr(source, "jagged_dim", getattr(tensor, "jagged_dim", None)),
+        name=str(name),
         attrs=_tensor_source_attrs(tensor)
         | {
             "application_shape": application_shape,

--- a/tests/test_backend_registry.py
+++ b/tests/test_backend_registry.py
@@ -20,9 +20,9 @@ def _source_only_kernel():
             name="launch_add", args=("x", "y", "out"), grid="lambda meta: (1,)"
         ),
         tensors=(
-            TensorSpec("x", 1, dtype="float32", shape=("n",)),
-            TensorSpec("y", 1, dtype="float32", shape=("n",)),
-            TensorSpec("out", 1, dtype="float32", shape=("n",)),
+            TensorSpec(ndim=1, shape=("n",), dtype="float32", name="x"),
+            TensorSpec(ndim=1, shape=("n",), dtype="float32", name="y"),
+            TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out"),
         ),
         compiler_options={"num_warps": 4, "num_stages": 3},
     )
@@ -52,9 +52,9 @@ def _add_kernel(dtype: str = "float32") -> Kernel:
         "\ndef add(x, y, out):\n    out = x + y\n",
         name="add",
         tensors=(
-            TensorSpec("x", 1, dtype=dtype, shape=("n",)),
-            TensorSpec("y", 1, dtype=dtype, shape=("n",)),
-            TensorSpec("out", 1, dtype=dtype, shape=("n",)),
+            TensorSpec(ndim=1, shape=("n",), dtype=dtype, name="x"),
+            TensorSpec(ndim=1, shape=("n",), dtype=dtype, name="y"),
+            TensorSpec(ndim=1, shape=("n",), dtype=dtype, name="out"),
         ),
     )
 
@@ -64,9 +64,9 @@ def _matmul_kernel() -> Kernel:
         "\ndef matmul(a, b, out):\n    out = a @ b\n",
         name="matmul",
         tensors=(
-            TensorSpec("a", 2, dtype="float32", shape=("m", "k")),
-            TensorSpec("b", 2, dtype="float32", shape=("k", "n")),
-            TensorSpec("out", 2, dtype="float32", shape=("m", "n")),
+            TensorSpec(ndim=2, shape=("m", "k"), dtype="float32", name="a"),
+            TensorSpec(ndim=2, shape=("k", "n"), dtype="float32", name="b"),
+            TensorSpec(ndim=2, shape=("m", "n"), dtype="float32", name="out"),
         ),
     )
 

--- a/tests/test_kernel_ir.py
+++ b/tests/test_kernel_ir.py
@@ -1,4 +1,11 @@
-from ninetoothed.ir import Kernel, TensorSpec, ir_to_dict, ssa
+import inspect
+
+import pytest
+
+from ninetoothed.backends import Artifact, Capability, Options, Target, emit
+from ninetoothed.compiler.passes import Context, Descriptor, PipelineSpec
+from ninetoothed.frontend.python import from_source
+from ninetoothed.ir import Kernel, Launch, TensorSpec, ir_to_dict, ssa
 
 
 class FakeTensor:
@@ -21,6 +28,60 @@ class TestKernel:
         assert tensor_spec.dtype == "float16"
         assert tensor_spec.shape == ("m", "n")
 
+    def test_public_ir_dataclass_constructors_are_keyword_only(self):
+        classes = (
+            TensorSpec,
+            Launch,
+            Kernel,
+            ssa.Type,
+            ssa.Value,
+            ssa.Operation,
+            ssa.Block,
+            ssa.Program,
+            Options,
+            Capability,
+            Artifact,
+            PipelineSpec,
+            Context,
+            Descriptor,
+        )
+
+        for cls in classes:
+            parameters = inspect.signature(cls).parameters.values()
+            kinds = {parameter.kind for parameter in parameters}
+            assert kinds <= {inspect.Parameter.KEYWORD_ONLY}
+
+    def test_ir_dataclasses_reject_positional_construction(self):
+        with pytest.raises(TypeError):
+            TensorSpec(1, ("n",), "float32", name="x")  # type: ignore[misc]
+
+        with pytest.raises(TypeError):
+            Kernel("k", "source")  # type: ignore[misc]
+
+        with pytest.raises(TypeError):
+            ssa.Type("tensor")  # type: ignore[misc]
+
+        with pytest.raises(TypeError):
+            ssa.Operation("arith.constant")  # type: ignore[misc]
+
+    def test_tensor_spec_name_controls_binding_not_source_name(self):
+        tensor_spec = TensorSpec(
+            ndim=1,
+            shape=("n",),
+            dtype="float32",
+            name="x",
+            attrs={"source_name": "storage_x"},
+        )
+        program = from_source(
+            "\ndef copy(x):\n    return x\n",
+            tensor_irs=(tensor_spec,),
+            kind="copy",
+        )
+
+        assert program is not None
+        assert program.inputs[0].name == "x"
+        assert program.inputs[0].type.attrs["source_name"] == "storage_x"
+
     def test_kernel_metadata_is_immutably_extended(self):
         kernel = Kernel(kernel_name="k", source="source", metadata={"a": 1})
         updated = kernel.with_metadata(b=2)
@@ -30,21 +91,23 @@ class TestKernel:
     def test_kernel_metadata_extension_preserves_ssa(self):
         program = ssa.Program(
             kind="elementwise",
-            inputs=(ssa.Value("x", ssa.Type("tensor", dtype="float32")),),
+            inputs=(
+                ssa.Value(name="x", type=ssa.Type(kind="tensor", dtype="float32")),
+            ),
         )
         kernel = Kernel(kernel_name="k", source="source", ssa=program)
         updated = kernel.with_metadata(a=1)
         assert updated.ssa == program
 
     def test_ssa_text_render_is_readable(self):
-        value = ssa.Value("%0", ssa.Type("scalar", dtype="float32"))
+        value = ssa.Value(name="%0", type=ssa.Type(kind="scalar", dtype="float32"))
         program = ssa.Program(
             kind="add",
             blocks=(
                 ssa.Block(
                     operations=(
                         ssa.Operation(
-                            "arith.constant",
+                            opcode="arith.constant",
                             results=(value,),
                             attrs={"value": 1.0},
                         ),
@@ -64,9 +127,12 @@ class TestKernel:
                 ssa.Block(
                     operations=(
                         ssa.Operation(
-                            "arith.constant",
+                            opcode="arith.constant",
                             results=(
-                                ssa.Value("%0", ssa.Type("scalar", dtype="float32")),
+                                ssa.Value(
+                                    name="%0",
+                                    type=ssa.Type(kind="scalar", dtype="float32"),
+                                ),
                             ),
                             attrs={"value": 1.0},
                         ),
@@ -77,3 +143,23 @@ class TestKernel:
         payload = ir_to_dict(program)
         assert payload["kind"] == "fill"
         assert payload["blocks"][0]["operations"][0]["opcode"] == "arith.constant"
+
+    def test_kernel_name_controls_generated_artifact_names_and_entrypoint(self):
+        value = ssa.Value(name="out", type=ssa.Type(kind="tensor", shape=("n",)))
+        program = ssa.Program(
+            kind="generated_kernel",
+            inputs=(value,),
+            outputs=(value,),
+            blocks=(ssa.Block(operations=()),),
+        )
+        tensor_spec = TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out")
+        kernel = Kernel(
+            kernel_name="generated_kernel",
+            source="source",
+            tensors=(tensor_spec,),
+            ssa=program,
+        )
+        artifact = emit(kernel, Target.CUDA)
+        assert "generated_kernel.cu" in artifact.sources
+        assert artifact.entrypoint == "launch_generated_kernel"
+        assert "generated_kernel_kernel" in artifact.primary_source

--- a/tests/test_lowering_inference.py
+++ b/tests/test_lowering_inference.py
@@ -116,7 +116,7 @@ def _ssa(func, tensors: tuple[TensorSpec, ...] | None = None) -> ssa.Program:
     if tensors is None:
         tensors = tuple(
             (
-                TensorSpec(name, 1, dtype="float32", shape=("n",))
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name=name)
                 for name in inspect.signature(func).parameters
             )
         )
@@ -199,7 +199,7 @@ class TestLoweringInference:
     def test_unknown_intrinsic_names_stay_as_call_ops_not_coarse_attention_ir(self):
         tensors = tuple(
             (
-                TensorSpec(name, 2, dtype="float32", shape=("rows", "cols"))
+                TensorSpec(ndim=2, shape=("rows", "cols"), dtype="float32", name=name)
                 for name in ("q", "k", "v", "out")
             )
         )
@@ -225,7 +225,7 @@ class TestLoweringInference:
     def test_offsets_lower_to_explicit_index_ops(self):
         program = _ssa(
             eye_offsets,
-            (TensorSpec("out", 2, dtype="float32", shape=("rows", "cols")),),
+            (TensorSpec(ndim=2, shape=("rows", "cols"), dtype="float32", name="out"),),
         )
         opcodes = _opcodes(program)
         assert opcodes.count("index.offset") == 2
@@ -243,9 +243,9 @@ class TestLoweringInference:
 
     def test_axis_reduction_fusions_lower_to_generic_dataflow(self):
         tensors = (
-            TensorSpec("x", 2, dtype="float32", shape=("rows", "cols")),
-            TensorSpec("out0", 1, dtype="float32", shape=("rows",)),
-            TensorSpec("out1", 1, dtype="float32", shape=("rows",)),
+            TensorSpec(ndim=2, shape=("rows", "cols"), dtype="float32", name="x"),
+            TensorSpec(ndim=1, shape=("rows",), dtype="float32", name="out0"),
+            TensorSpec(ndim=1, shape=("rows",), dtype="float32", name="out1"),
         )
         program = _ssa(rowwise_aminmax, tensors)
         opcodes = _opcodes(program)
@@ -256,14 +256,14 @@ class TestLoweringInference:
 
     def test_rowwise_softmax_and_layernorm_are_dataflow_not_kernel_nodes(self):
         softmax_tensors = (
-            TensorSpec("x", 2, dtype="float32", shape=("rows", "cols")),
-            TensorSpec("out", 2, dtype="float32", shape=("rows", "cols")),
+            TensorSpec(ndim=2, shape=("rows", "cols"), dtype="float32", name="x"),
+            TensorSpec(ndim=2, shape=("rows", "cols"), dtype="float32", name="out"),
         )
         layernorm_tensors = (
-            TensorSpec("x", 2, dtype="float32", shape=("rows", "cols")),
-            TensorSpec("weight", 1, dtype="float32", shape=("cols",)),
-            TensorSpec("bias", 1, dtype="float32", shape=("cols",)),
-            TensorSpec("out", 2, dtype="float32", shape=("rows", "cols")),
+            TensorSpec(ndim=2, shape=("rows", "cols"), dtype="float32", name="x"),
+            TensorSpec(ndim=1, shape=("cols",), dtype="float32", name="weight"),
+            TensorSpec(ndim=1, shape=("cols",), dtype="float32", name="bias"),
+            TensorSpec(ndim=2, shape=("rows", "cols"), dtype="float32", name="out"),
         )
 
         for func, tensors, fragments in (

--- a/tests/test_ssa_application_lowering.py
+++ b/tests/test_ssa_application_lowering.py
@@ -32,11 +32,11 @@ def reference_attention(q, k, v, is_causal, o):
 
 def _attention_tensors():
     return (
-        TensorSpec("q", 4, dtype="float16", shape=("B", "H", "M", "D")),
-        TensorSpec("k", 4, dtype="float16", shape=("B", "H", "N", "D")),
-        TensorSpec("v", 4, dtype="float16", shape=("B", "H", "N", "D")),
-        TensorSpec("is_causal", 0, dtype="bool", constexpr=True),
-        TensorSpec("o", 4, dtype="float16", shape=("B", "H", "M", "D")),
+        TensorSpec(ndim=4, shape=("B", "H", "M", "D"), dtype="float16", name="q"),
+        TensorSpec(ndim=4, shape=("B", "H", "N", "D"), dtype="float16", name="k"),
+        TensorSpec(ndim=4, shape=("B", "H", "N", "D"), dtype="float16", name="v"),
+        TensorSpec(ndim=0, dtype="bool", constexpr=True, name="is_causal"),
+        TensorSpec(ndim=4, shape=("B", "H", "M", "D"), dtype="float16", name="o"),
     )
 
 

--- a/tests/test_ssa_first_backend_lowering.py
+++ b/tests/test_ssa_first_backend_lowering.py
@@ -325,9 +325,9 @@ class TestSSAFirstBackendLowering:
             "where": (
                 "\ndef where_application(x, y, out):\n    out = where(x > y, x, y)\n",
                 (
-                    TensorSpec("x", 1, dtype="float32", shape=("n",)),
-                    TensorSpec("y", 1, dtype="float32", shape=("n",)),
-                    TensorSpec("out", 1, dtype="float32", shape=("n",)),
+                    TensorSpec(ndim=1, shape=("n",), dtype="float32", name="x"),
+                    TensorSpec(ndim=1, shape=("n",), dtype="float32", name="y"),
+                    TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out"),
                 ),
                 {
                     "triton": "tl.where",
@@ -338,7 +338,7 @@ class TestSSAFirstBackendLowering:
             ),
             "full": (
                 "\ndef full_application(out):\n    out = full((n,), 2.5)\n",
-                (TensorSpec("out", 1, dtype="float32", shape=("n",)),),
+                (TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out"),),
                 {
                     "triton": "v1 = v0",
                     "cuda": "float v1 = v0;",
@@ -348,7 +348,7 @@ class TestSSAFirstBackendLowering:
             ),
             "zeros": (
                 "\ndef zeros_application(out):\n    out = zeros((n,))\n",
-                (TensorSpec("out", 1, dtype="float32", shape=("n",)),),
+                (TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out"),),
                 {
                     "triton": "v0 = 0.0",
                     "cuda": "float v0 = 0.0;",
@@ -359,8 +359,12 @@ class TestSSAFirstBackendLowering:
             "view": (
                 "\ndef view_application(x, out):\n    out = x[:, :]\n",
                 (
-                    TensorSpec("x", 2, dtype="float32", shape=("rows", "cols")),
-                    TensorSpec("out", 2, dtype="float32", shape=("rows", "cols")),
+                    TensorSpec(
+                        ndim=2, shape=("rows", "cols"), dtype="float32", name="x"
+                    ),
+                    TensorSpec(
+                        ndim=2, shape=("rows", "cols"), dtype="float32", name="out"
+                    ),
                 ),
                 {
                     "triton": "tl.load(x + ((index // (cols)))",
@@ -372,8 +376,8 @@ class TestSSAFirstBackendLowering:
             "extract": (
                 "\ndef extract_application(x, out):\n    out = x[0]\n",
                 (
-                    TensorSpec("x", 1, dtype="float32", shape=("n",)),
-                    TensorSpec("out", 1, dtype="float32", shape=("n",)),
+                    TensorSpec(ndim=1, shape=("n",), dtype="float32", name="x"),
+                    TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out"),
                 ),
                 {
                     "triton": "tl.load(x + v0",
@@ -385,8 +389,8 @@ class TestSSAFirstBackendLowering:
             "tanh": (
                 "\ndef tanh_application(x, out):\n    out = tanh(x)\n",
                 (
-                    TensorSpec("x", 1, dtype="float32", shape=("n",)),
-                    TensorSpec("out", 1, dtype="float32", shape=("n",)),
+                    TensorSpec(ndim=1, shape=("n",), dtype="float32", name="x"),
+                    TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out"),
                 ),
                 {
                     "triton": "tl.tanh",
@@ -420,8 +424,8 @@ class TestSSAFirstBackendLowering:
             "\ndef shape_dim_application(x, out):\n    out = x.shape[0]\n",
             "ssa_shape_dim",
             (
-                TensorSpec("x", 2, dtype="float32", shape=("rows", "cols")),
-                TensorSpec("out", 1, dtype="float32", shape=("n",)),
+                TensorSpec(ndim=2, shape=("rows", "cols"), dtype="float32", name="x"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out"),
             ),
         )
         operations = kernel.ssa.blocks[0].operations
@@ -461,8 +465,8 @@ class TestSSAFirstBackendLowering:
             "\ndef stride_application(x, out):\n    out = x.stride(0) + x.stride(1)\n",
             "ssa_tensor_stride",
             (
-                TensorSpec("x", 2, dtype="float32", shape=("rows", "cols")),
-                TensorSpec("out", 1, dtype="int64", shape=("n",)),
+                TensorSpec(ndim=2, shape=("rows", "cols"), dtype="float32", name="x"),
+                TensorSpec(ndim=1, shape=("n",), dtype="int64", name="out"),
             ),
         )
         operations = kernel.ssa.blocks[0].operations
@@ -508,9 +512,9 @@ class TestSSAFirstBackendLowering:
             "\ndef max_min_application(x, y, out):\n    tmp = maximum(x, y)\n    out = minimum(tmp, y)\n",
             "ssa_max_min",
             (
-                TensorSpec("x", 1, dtype="float32", shape=("n",)),
-                TensorSpec("y", 1, dtype="float32", shape=("n",)),
-                TensorSpec("out", 1, dtype="float32", shape=("n",)),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="x"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="y"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out"),
             ),
         )
         assert [operation.opcode for operation in kernel.ssa.blocks[0].operations] == [
@@ -540,9 +544,9 @@ class TestSSAFirstBackendLowering:
             "\ndef common_math_application(x, y, out):\n    out = log1p(abs(x)) + atan2(x, y) + pow(abs(y) + 0.25, 0.5)\n",
             "ssa_common_math",
             (
-                TensorSpec("x", 1, dtype="float32", shape=("n",)),
-                TensorSpec("y", 1, dtype="float32", shape=("n",)),
-                TensorSpec("out", 1, dtype="float32", shape=("n",)),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="x"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="y"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out"),
             ),
         )
         opcodes = [operation.opcode for operation in kernel.ssa.blocks[0].operations]
@@ -577,10 +581,10 @@ class TestSSAFirstBackendLowering:
             "\ndef python_expression_syntax_application(x, y, z, out):\n    tmp: float = x if 0 < 1 < 2 else y\n    pass\n    out = tmp + z\n    return out\n",
             "ssa_python_expression_syntax",
             (
-                TensorSpec("x", 1, dtype="float32", shape=("n",)),
-                TensorSpec("y", 1, dtype="float32", shape=("n",)),
-                TensorSpec("z", 1, dtype="float32", shape=("n",)),
-                TensorSpec("out", 1, dtype="float32", shape=("n",)),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="x"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="y"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="z"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out"),
             ),
         )
         opcodes = [operation.opcode for operation in kernel.ssa.blocks[0].operations]
@@ -630,8 +634,8 @@ class TestSSAFirstBackendLowering:
             "\ndef method_math_application(x, out):\n    denom = x.sqrt().sum(dim=0)\n    out = x.exp() / denom\n",
             "ssa_method_math",
             (
-                TensorSpec("x", 1, dtype="float32", shape=("n",)),
-                TensorSpec("out", 1, dtype="float32", shape=("n",)),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="x"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out"),
             ),
         )
         opcodes = [operation.opcode for operation in kernel.ssa.blocks[0].operations]
@@ -676,8 +680,8 @@ class TestSSAFirstBackendLowering:
             "\ndef namespace_math_application(x, out):\n    out = math.exp(x) + tl.sqrt(x)\n",
             "ssa_namespace_math",
             (
-                TensorSpec("x", 1, dtype="float32", shape=("n",)),
-                TensorSpec("out", 1, dtype="float32", shape=("n",)),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="x"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out"),
             ),
         )
         opcodes = [operation.opcode for operation in kernel.ssa.blocks[0].operations]
@@ -704,9 +708,9 @@ class TestSSAFirstBackendLowering:
             "\ndef extended_math_application(x, y, out):\n    out = acos(x) + asin(y) + atan(x) + log10(abs(y) + 1.0) + expm1(x) + sinh(x) + cosh(y)\n",
             "ssa_extended_math",
             (
-                TensorSpec("x", 1, dtype="float32", shape=("n",)),
-                TensorSpec("y", 1, dtype="float32", shape=("n",)),
-                TensorSpec("out", 1, dtype="float32", shape=("n",)),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="x"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="y"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out"),
             ),
         )
         opcodes = [operation.opcode for operation in kernel.ssa.blocks[0].operations]
@@ -756,9 +760,9 @@ class TestSSAFirstBackendLowering:
             "\ndef bitwise_shift_application(x, y, out):\n    out = (x << 1) ^ (y >> 1)\n",
             "ssa_bitwise_shift",
             (
-                TensorSpec("x", 1, dtype="int64", shape=("n",)),
-                TensorSpec("y", 1, dtype="int64", shape=("n",)),
-                TensorSpec("out", 1, dtype="int64", shape=("n",)),
+                TensorSpec(ndim=1, shape=("n",), dtype="int64", name="x"),
+                TensorSpec(ndim=1, shape=("n",), dtype="int64", name="y"),
+                TensorSpec(ndim=1, shape=("n",), dtype="int64", name="out"),
             ),
         )
         opcodes = [operation.opcode for operation in kernel.ssa.blocks[0].operations]
@@ -787,8 +791,8 @@ class TestSSAFirstBackendLowering:
             "one_dimensional": (
                 "\ndef indexed_store_application(x, out):\n    i = x.offsets(0)\n    out[i] = x\n",
                 (
-                    TensorSpec("x", 1, dtype="float32", shape=("n",)),
-                    TensorSpec("out", 1, dtype="float32", shape=("n",)),
+                    TensorSpec(ndim=1, shape=("n",), dtype="float32", name="x"),
+                    TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out"),
                 ),
                 {
                     "triton": "tl.store(out + v0",
@@ -800,8 +804,12 @@ class TestSSAFirstBackendLowering:
             "two_dimensional": (
                 "\ndef indexed_store_2d_application(x, out):\n    i = x.offsets(0)\n    j = x.offsets(1)\n    out[i, j] = x\n",
                 (
-                    TensorSpec("x", 2, dtype="float32", shape=("rows", "cols")),
-                    TensorSpec("out", 2, dtype="float32", shape=("rows", "cols")),
+                    TensorSpec(
+                        ndim=2, shape=("rows", "cols"), dtype="float32", name="x"
+                    ),
+                    TensorSpec(
+                        ndim=2, shape=("rows", "cols"), dtype="float32", name="out"
+                    ),
                 ),
                 {
                     "triton": "tl.store(out + (v0) * (cols) + (v1)",
@@ -834,8 +842,8 @@ class TestSSAFirstBackendLowering:
             "\ndef indexed_augassign_application(x, out):\n    i = x.offsets(0)\n    out[i] += x\n",
             "ssa_indexed_augassign",
             (
-                TensorSpec("x", 1, dtype="float32", shape=("n",)),
-                TensorSpec("out", 1, dtype="float32", shape=("n",)),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="x"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out"),
             ),
         )
         operations = kernel.ssa.blocks[0].operations
@@ -865,8 +873,8 @@ class TestSSAFirstBackendLowering:
             "\ndef extract_2d_application(x, out):\n    i = x.offsets(0)\n    j = x.offsets(1)\n    out = x[i, j]\n",
             "ssa_extract_2d",
             (
-                TensorSpec("x", 2, dtype="float32", shape=("rows", "cols")),
-                TensorSpec("out", 2, dtype="float32", shape=("rows", "cols")),
+                TensorSpec(ndim=2, shape=("rows", "cols"), dtype="float32", name="x"),
+                TensorSpec(ndim=2, shape=("rows", "cols"), dtype="float32", name="out"),
             ),
         )
         expected = {
@@ -1006,10 +1014,10 @@ class TestSSAFirstBackendLowering:
             "\ndef axis_addmv_application(bias, a, x, out):\n    out = bias + sum(a * x, axis=1)\n",
             "ssa_axis_addmv",
             (
-                TensorSpec("bias", 1, dtype="float32", shape=("rows",)),
-                TensorSpec("a", 2, dtype="float32", shape=("rows", "cols")),
-                TensorSpec("x", 1, dtype="float32", shape=("cols",)),
-                TensorSpec("out", 1, dtype="float32", shape=("rows",)),
+                TensorSpec(ndim=1, shape=("rows",), dtype="float32", name="bias"),
+                TensorSpec(ndim=2, shape=("rows", "cols"), dtype="float32", name="a"),
+                TensorSpec(ndim=1, shape=("cols",), dtype="float32", name="x"),
+                TensorSpec(ndim=1, shape=("rows",), dtype="float32", name="out"),
             ),
         )
         expected = {
@@ -1035,8 +1043,8 @@ class TestSSAFirstBackendLowering:
             "\ndef rowwise_norm_application(x, out):\n    out = x / sum(x, axis=1)\n",
             "ssa_rowwise_norm",
             (
-                TensorSpec("x", 2, dtype="float32", shape=("rows", "cols")),
-                TensorSpec("out", 2, dtype="float32", shape=("rows", "cols")),
+                TensorSpec(ndim=2, shape=("rows", "cols"), dtype="float32", name="x"),
+                TensorSpec(ndim=2, shape=("rows", "cols"), dtype="float32", name="out"),
             ),
         )
         expected = {
@@ -1059,9 +1067,9 @@ class TestSSAFirstBackendLowering:
             "\ndef matmul_application(a, b, out):\n    out = a @ b\n",
             "ssa_matmul",
             (
-                TensorSpec("a", 2, dtype="float32", shape=("m", "k")),
-                TensorSpec("b", 2, dtype="float32", shape=("k", "n")),
-                TensorSpec("out", 2, dtype="float32", shape=("m", "n")),
+                TensorSpec(ndim=2, shape=("m", "k"), dtype="float32", name="a"),
+                TensorSpec(ndim=2, shape=("k", "n"), dtype="float32", name="b"),
+                TensorSpec(ndim=2, shape=("m", "n"), dtype="float32", name="out"),
             ),
         )
         expected = {
@@ -1087,8 +1095,8 @@ class TestSSAFirstBackendLowering:
             "\ndef transpose_application(x, out):\n    out = transpose(x)\n",
             "ssa_transpose",
             (
-                TensorSpec("x", 2, dtype="float32", shape=("rows", "cols")),
-                TensorSpec("out", 2, dtype="float32", shape=("cols", "rows")),
+                TensorSpec(ndim=2, shape=("rows", "cols"), dtype="float32", name="x"),
+                TensorSpec(ndim=2, shape=("cols", "rows"), dtype="float32", name="out"),
             ),
         )
         expected = {
@@ -1114,8 +1122,8 @@ class TestSSAFirstBackendLowering:
             "\ndef transpose_attribute_application(x, out):\n    out = x.T\n",
             "ssa_transpose_attribute",
             (
-                TensorSpec("x", 2, dtype="float32", shape=("rows", "cols")),
-                TensorSpec("out", 2, dtype="float32", shape=("cols", "rows")),
+                TensorSpec(ndim=2, shape=("rows", "cols"), dtype="float32", name="x"),
+                TensorSpec(ndim=2, shape=("cols", "rows"), dtype="float32", name="out"),
             ),
         )
         expected = {
@@ -1144,8 +1152,8 @@ class TestSSAFirstBackendLowering:
             "\ndef loop_store_application(x, out):\n    for i in range(n):\n        out[i] = x[i] + 1.0\n",
             "ssa_loop_store",
             (
-                TensorSpec("x", 1, dtype="float32", shape=("n",)),
-                TensorSpec("out", 1, dtype="float32", shape=("n",)),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="x"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out"),
             ),
         )
         expected = {
@@ -1183,8 +1191,8 @@ class TestSSAFirstBackendLowering:
             "\ndef if_store_application(x, out):\n    if 1 < 2:\n        i = x.offsets(0)\n        out[i] = x\n",
             "ssa_if_store",
             (
-                TensorSpec("x", 1, dtype="float32", shape=("n",)),
-                TensorSpec("out", 1, dtype="float32", shape=("n",)),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="x"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out"),
             ),
         )
         expected = {
@@ -1222,9 +1230,9 @@ class TestSSAFirstBackendLowering:
             "\ndef if_else_store_application(x, y, out):\n    if 1 < 2:\n        i = x.offsets(0)\n        out[i] = x\n    else:\n        j = y.offsets(0)\n        out[j] = y\n",
             "ssa_if_else_store",
             (
-                TensorSpec("x", 1, dtype="float32", shape=("n",)),
-                TensorSpec("y", 1, dtype="float32", shape=("n",)),
-                TensorSpec("out", 1, dtype="float32", shape=("n",)),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="x"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="y"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out"),
             ),
         )
         expected = {
@@ -1274,10 +1282,10 @@ class TestSSAFirstBackendLowering:
             "\ndef multi_result_if_application(x, y, out0, out1):\n    a = x\n    b = y\n    if 1 < 2:\n        a = x + y\n        b = x - y\n    out0 = a\n    out1 = b\n",
             "ssa_multi_result_if",
             (
-                TensorSpec("x", 1, dtype="float32", shape=("n",)),
-                TensorSpec("y", 1, dtype="float32", shape=("n",)),
-                TensorSpec("out0", 1, dtype="float32", shape=("n",)),
-                TensorSpec("out1", 1, dtype="float32", shape=("n",)),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="x"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="y"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out0"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out1"),
             ),
         )
         expected = {

--- a/tests/test_ssa_pass_pipeline.py
+++ b/tests/test_ssa_pass_pipeline.py
@@ -40,9 +40,9 @@ class TestPipeline:
         program = _program(
             "\ndef add(x, y, out):\n    out = x + y\n",
             (
-                TensorSpec("x", 1, "float32", ("n",)),
-                TensorSpec("y", 1, "float32", ("n",)),
-                TensorSpec("out", 1, "float32", ("n",)),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="x"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="y"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out"),
             ),
             "add",
         )
@@ -81,9 +81,9 @@ class TestPipeline:
         program = _program(
             "\ndef matmul(a, b, out):\n    out = a @ b\n",
             (
-                TensorSpec("a", 2, "float32", ("m", "k")),
-                TensorSpec("b", 2, "float32", ("k", "n")),
-                TensorSpec("out", 2, "float32", ("m", "n")),
+                TensorSpec(ndim=2, shape=("m", "k"), dtype="float32", name="a"),
+                TensorSpec(ndim=2, shape=("k", "n"), dtype="float32", name="b"),
+                TensorSpec(ndim=2, shape=("m", "n"), dtype="float32", name="out"),
             ),
             "matmul",
         )
@@ -102,8 +102,8 @@ class TestPipeline:
         program = _program(
             "\ndef copy(x, out):\n    out = x\n",
             (
-                TensorSpec("x", 1, "float32", ("n",)),
-                TensorSpec("out", 1, "float32", ("n",)),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="x"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out"),
             ),
             "copy",
         )
@@ -165,8 +165,8 @@ class TestPipeline:
         program = _program(
             "\ndef copy(x, out):\n    out = x\n",
             (
-                TensorSpec("x", 1, "float32", ("n",)),
-                TensorSpec("out", 1, "float32", ("n",)),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="x"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out"),
             ),
             "copy",
         )
@@ -202,8 +202,8 @@ class TestPipeline:
         program = _program(
             "\ndef copy(x, out):\n    out = x\n",
             (
-                TensorSpec("x", 1, "float32", ("n",)),
-                TensorSpec("out", 1, "float32", ("n",)),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="x"),
+                TensorSpec(ndim=1, shape=("n",), dtype="float32", name="out"),
             ),
             "copy",
         )


### PR DESCRIPTION
﻿## Summary
- Make IR, backend, and pass descriptor dataclasses keyword-only so constructor call sites stay explicit.
- Align tensor-like field order with `Tensor`: shape before dtype, while keeping identity/info fields keyword-only.
- Update internal call sites and tests for the new constructor style and document the `TensorSpec.name` / source-name split.

## Testing
Server: `ssh nvidia`, image `accelerator-dev/nvidia:latest` with `--gpus all --ipc=host`.

```text
python3 /tmp/scan_ir_constructors.py
AST constructor scan passed
```

```text
python3 -m compileall -q src tests/test_backend_registry.py tests/test_kernel_ir.py tests/test_lowering_inference.py tests/test_ssa_application_lowering.py tests/test_ssa_first_backend_lowering.py tests/test_ssa_pass_pipeline.py
```

```text
uv run --with ruff ruff --version
ruff 0.15.20
```

```text
python3 scripts/check_contributing_style.py
```

```text
uv run --with ruff ruff format --check
72 files already formatted
```

```text
uv run --with ruff ruff check
All checks passed!
```

pytest output:
```text
PYTHONPATH=src python3 -m pytest -q tests/test_backend_registry.py tests/test_kernel_ir.py tests/test_lowering_inference.py tests/test_ssa_application_lowering.py tests/test_ssa_first_backend_lowering.py tests/test_ssa_pass_pipeline.py
Running 73 items in this shard
.....................................................s.................. [ 98%]
.                                                                        [100%]
72 passed, 1 skipped in 32.51s
```

```text
PYTHONPATH=src python3 -m pytest -q tests/test_naming.py tests/test_eval.py tests/test_auto_tuner.py
Running 19 items in this shard
...................                                                      [100%]
19 passed in 4.76s
```
