### PR TITLE
Improve T1-2-1 code generation specialization

### DIFF
--- a/src/ninetoothed/aot.py
+++ b/src/ninetoothed/aot.py
@@ -255,9 +255,8 @@ def _build_variant(
                 param_types.append(f"{size_type}:16")
             else:
                 param_types.append(size_type)
-        elif match := Tensor.stride_pattern().fullmatch(param):
-            source_name = match.group(1)
-            dim_index = int(match.group(3))
+        elif stride_param := _match_stride_parameter(param):
+            source_name, dim_index = stride_param
             bare_source_name = naming.remove_prefixes(source_name)
 
             if (bare_source_name, dim_index) in contiguity_set:
@@ -338,6 +337,18 @@ def _build_variant(
     output_contents.pop(c_source_file_name)
 
     return output_contents
+
+
+def _match_stride_parameter(param):
+    normalized_param = naming.remove_prefixes(param)
+
+    if match := Tensor.stride_pattern().fullmatch(normalized_param):
+        return match.group(1), int(match.group(3))
+
+    if match := Tensor.stride_pattern().fullmatch(param):
+        return naming.remove_prefixes(match.group(1)), int(match.group(3))
+
+    return None
 
 
 def _enumerate_variant_specs(launch_arg_names, tensors, find_tensor):
@@ -592,7 +603,9 @@ class _Unparser:
     def __init__(self, param_types, constexpr_inner_strides=()):
         self._param_types = param_types
 
-        self._constexpr_inner_strides = set(constexpr_inner_strides)
+        self._constexpr_inner_strides = {
+            (naming.remove_prefixes(name), dim) for name, dim in constexpr_inner_strides
+        }
 
     def unparse(self, node):
         method_name = "_unparse_" + node.__class__.__name__
@@ -608,28 +621,43 @@ class _Unparser:
     def _unparse_Expr(self, node):
         return self.unparse(node.value)
 
+    def _unparse_Assign(self, node):
+        if len(node.targets) != 1:
+            return self._generic_unparse(node)
+
+        target = node.targets[0]
+
+        if not isinstance(target, ast.Name) or self._is_excluded(target):
+            return ""
+
+        return f"auto {target.id} = {self._generic_unparse(node.value)}"
+
     def _unparse_Call(self, node):
-        call = ast.Call(
-            func=node.func,
-            args=[ast.Name(id="stream", ctx=ast.Load())]
-            + [arg for arg in node.args if not self._is_excluded(arg)],
-            keywords=[],
+        call_args = [ast.Name(id="stream", ctx=ast.Load())] + [
+            arg for arg in node.args if not self._is_excluded(arg)
+        ]
+
+        if len(call_args) != len(self._param_types):
+            raise ValueError(
+                "Launch call argument count does not match the compiled signature."
+            )
+
+        formatted_args = [
+            self._format_call_arg(arg, param_type, index)
+            for index, (arg, param_type) in enumerate(zip(call_args, self._param_types))
+        ]
+
+        return (
+            f"return {self._generic_unparse(node.func)}({', '.join(formatted_args)});"
         )
 
-        unparsed = f"return {self._generic_unparse(call)};"
+    def _format_call_arg(self, arg, param_type, index):
+        source = self._generic_unparse(arg)
 
-        pattern = rf"\((stream), {', '.join(r'([^,]*)' for _ in range(len(self._param_types) - 1))}\)"
-        args = re.search(pattern, unparsed).groups()
+        if index != 0 and isinstance(arg, ast.Name) and not naming.is_constexpr(arg.id):
+            return f"*({param_type} *){source}.data"
 
-        for i, (arg, type) in enumerate(zip(args, self._param_types)):
-            if i != 0 and "." not in arg:
-                new_arg = f"*({type} *){arg}.data"
-            else:
-                new_arg = f"({type}){arg}"
-
-            unparsed = unparsed.replace(arg, new_arg)
-
-        return unparsed
+        return f"({param_type}){source}"
 
     def _unparse_FunctionDef(self, node):
         params = ["NineToothedStream stream"]
@@ -641,10 +669,10 @@ class _Unparser:
         body_lines = []
 
         for stmt in node.body:
-            if isinstance(stmt, ast.Assign):
-                continue
-
             stmt_unparsed = self.unparse(stmt)
+
+            if not stmt_unparsed:
+                continue
 
             if isinstance(stmt, ast.Expr):
                 stmt_unparsed = stmt_unparsed.strip()
@@ -660,6 +688,9 @@ class _Unparser:
 
     def _is_excluded(self, arg):
         if isinstance(arg, ast.Name) and naming.is_constexpr(arg.id):
+            if stride_param := _match_stride_parameter(arg.id):
+                return stride_param in self._constexpr_inner_strides
+
             return True
 
         if (
@@ -670,7 +701,7 @@ class _Unparser:
             and isinstance(arg.value.value, ast.Name)
         ):
             return (
-                arg.value.value.id,
+                naming.remove_prefixes(arg.value.value.id),
                 arg.slice.value,
             ) in self._constexpr_inner_strides
 

--- a/src/ninetoothed/generation.py
+++ b/src/ninetoothed/generation.py
@@ -160,11 +160,19 @@ class CodeGenerator(ast.NodeTransformer):
         for target, value in reversed(self._invariants.items()):
             node.body.insert(0, ast.Assign(targets=[target.node], value=value.node))
 
-        symbols = {
+        all_symbols = {
             name.node.id: name
             for arg in self._args
             for name in arg.names()
             if name != "ninetoothed"
+        }
+        used_kernel_names = {
+            name.node.id for name in Symbol(node).names() if name != "ninetoothed"
+        }
+        symbols = {
+            name: symbol
+            for name, symbol in all_symbols.items()
+            if name in used_kernel_names or naming.is_meta(name)
         }
         names = symbols.keys()
         meta_names = {name for name in names if naming.is_meta(name)}
@@ -175,7 +183,7 @@ class CodeGenerator(ast.NodeTransformer):
             if naming.is_next_power_of_2(name.node.id)
         }
 
-        self._symbols = symbols
+        self._symbols = all_symbols
 
         non_meta_names = sorted(non_meta_names)
         meta_names = sorted(meta_names)
@@ -538,6 +546,7 @@ class CodeGenerator(ast.NodeTransformer):
             param
             for param in non_next_power_of_2_constexpr_params_without_prefixes
             if not Tensor.size_pattern().fullmatch(param)
+            and not Tensor.stride_pattern().fullmatch(param)
             and not Tensor.seq_len_pattern().fullmatch(param)
             and param not in arg_names
         ]
@@ -642,12 +651,116 @@ class CodeGenerator(ast.NodeTransformer):
         pointers, mask = self._generate_pointers_and_mask(tensor, indices)
         other = type(self)._generate_other(tensor)
 
-        return call("load", pointers, mask=mask, other=other).node
+        if type(self)._is_uniform_scalar_load(tensor):
+            pointers = type(self)._name_for_pointers(tensor)
+            mask = type(self)._generate_nonempty_source_mask(tensor.source)
+
+        return type(self)._generate_memory_call(
+            "load", pointers, mask=mask, other=other
+        )
 
     def _generate_store(self, tensor, value, indices=()):
         pointers, mask = self._generate_pointers_and_mask(tensor, indices)
 
-        return call("store", pointers, value, mask=mask).node
+        return type(self)._generate_memory_call("store", pointers, value, mask=mask)
+
+    @staticmethod
+    def _generate_memory_call(func, *args, mask, **kwargs):
+        call_kwargs = {}
+        mask = CodeGenerator._simplify_literal_true_conjunction(mask)
+
+        if not CodeGenerator._is_literal_true(mask):
+            call_kwargs["mask"] = mask
+
+        call_kwargs.update(kwargs)
+
+        return call(func, *args, **call_kwargs).node
+
+    @staticmethod
+    def _is_literal_true(value):
+        node = Symbol(value).node
+
+        return isinstance(node, ast.Constant) and node.value is True
+
+    @staticmethod
+    def _simplify_literal_true_conjunction(value):
+        class _Simplifier(ast.NodeTransformer):
+            def visit_BinOp(self, node):
+                node = self.generic_visit(node)
+
+                if not isinstance(node.op, ast.BitAnd):
+                    return node
+
+                left_is_true = CodeGenerator._is_literal_true(Symbol(node.left))
+                right_is_true = CodeGenerator._is_literal_true(Symbol(node.right))
+
+                if left_is_true and right_is_true:
+                    return ast.Constant(value=True)
+
+                if left_is_true:
+                    return node.right
+
+                if right_is_true:
+                    return node.left
+
+                return node
+
+        simplified = _Simplifier().visit(Symbol(value).node)
+        ast.fix_missing_locations(simplified)
+
+        return Symbol(simplified)
+
+    @staticmethod
+    def _is_uniform_scalar_load(tensor):
+        offsets = getattr(tensor, "_last_generated_offsets", None)
+
+        return (
+            tensor.source.jagged_dim is None
+            and offsets is not None
+            and len(offsets) == tensor.source.ndim
+            and all(CodeGenerator._is_zero_like(offset) for offset in offsets)
+        )
+
+    @staticmethod
+    def _generate_nonempty_source_mask(tensor):
+        mask = Symbol(True)
+
+        for size in tensor.shape:
+            if CodeGenerator._is_static_positive(size):
+                continue
+
+            if CodeGenerator._is_static_zero(size):
+                return Symbol(False)
+
+            mask &= Symbol(size) > 0
+
+        return mask
+
+    @staticmethod
+    def _is_static_positive(value):
+        node = Symbol(value).node
+
+        return isinstance(node, ast.Constant) and node.value > 0
+
+    @staticmethod
+    def _is_static_zero(value):
+        node = Symbol(value).node
+
+        return isinstance(node, ast.Constant) and node.value == 0
+
+    @staticmethod
+    def _is_zero_like(value):
+        node = Symbol(value).node
+
+        if isinstance(node, ast.Constant):
+            return node.value == 0
+
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Mult):
+            return CodeGenerator._is_zero_like(Symbol(node.left)) or (
+                CodeGenerator._is_zero_like(Symbol(node.right))
+            )
+
+        return False
 
     def _generate_pointers_and_mask(self, tensor, indices):
         if tensor is not tensor.source:
@@ -679,7 +792,9 @@ class CodeGenerator(ast.NodeTransformer):
         indices = list(Tensor._unravel_index(type(self)._NAME_FOR_PID, tensor.shape))
 
         for dim, index in enumerate(indices):
-            name = type(self)._name_for_index(tensor, dim)
+            name = type(self)._name_for_index(
+                tensor, dim, upper_bound=tensor.shape[dim] - 1
+            )
             self._invariants[name] = index
             indices[dim] = name
 
@@ -691,7 +806,9 @@ class CodeGenerator(ast.NodeTransformer):
                 size.find_and_replace(seq_len_name, max_seq_len_name)
 
             offsets_name = Symbol(tensor.source.offsets_string())
-            batch_dim_index_name = type(self)._name_for_index(tensor, 0)
+            batch_dim_index_name = type(self)._name_for_index(
+                tensor, 0, upper_bound=tensor.shape[0] - 1
+            )
             seq_start_name = type(self)._name_for_seq_start(tensor)
             seq_end_name = type(self)._name_for_seq_end(tensor)
 
@@ -833,8 +950,12 @@ class CodeGenerator(ast.NodeTransformer):
         return Symbol(f"{tensor.source.name}_seq_end")
 
     @staticmethod
-    def _name_for_index(tensor, dim):
-        return Symbol(f"{tensor.source.name}_index_{dim}")
+    def _name_for_index(tensor, dim, upper_bound=None):
+        return Symbol(
+            f"{tensor.source.name}_index_{dim}",
+            lower_bound=0,
+            upper_bound=upper_bound,
+        )
 
 
 class Tritonizer(ast.NodeTransformer):

--- a/src/ninetoothed/tensor.py
+++ b/src/ninetoothed/tensor.py
@@ -1,3 +1,4 @@
+import ast
 import copy
 import functools
 import itertools
@@ -6,6 +7,115 @@ import re
 
 import ninetoothed.naming as naming
 from ninetoothed.symbol import Symbol
+
+
+def _is_known_non_negative_index(index):
+    node = _unwrap_index_node(Symbol(index).node)
+
+    if isinstance(node, ast.Constant):
+        return isinstance(node.value, int) and node.value >= 0
+
+    if isinstance(node, ast.Name) and _has_non_negative_lower_bound(node):
+        return True
+
+    if _is_named_call(node, "arange"):
+        return len(node.args) >= 2 and _is_zero(node.args[0])
+
+    if _is_named_call(node, "program_id"):
+        return True
+
+    if isinstance(node, ast.BinOp):
+        if isinstance(node.op, (ast.Add, ast.Mult)):
+            return _is_known_non_negative_index(Symbol(node.left)) and (
+                _is_known_non_negative_index(Symbol(node.right))
+            )
+
+        if isinstance(node.op, (ast.FloorDiv, ast.Mod)):
+            return _is_known_non_negative_index(Symbol(node.left)) and (
+                _is_positive_integer(node.right)
+            )
+
+    return False
+
+
+def _is_strict_upper_bound_check_redundant(index, size):
+    node = _unwrap_index_node(Symbol(index).node)
+
+    return (
+        _is_named_call(node, "arange")
+        and len(node.args) >= 2
+        and _is_zero(node.args[0])
+        and _ast_equal(node.args[1], Symbol(size).node)
+    ) or (isinstance(node, ast.Name) and _has_matching_upper_bound(node, size))
+
+
+def _unwrap_index_node(node):
+    while isinstance(node, ast.Subscript):
+        node = node.value
+
+    return node
+
+
+def _is_named_call(node, name):
+    return isinstance(node, ast.Call) and _attribute_name(node.func) == name
+
+
+def _has_non_negative_lower_bound(node):
+    symbol = getattr(node, "symbol", None)
+    lower_bound = getattr(symbol, "lower_bound", None)
+
+    return lower_bound is not None and lower_bound >= 0
+
+
+def _has_matching_upper_bound(node, size):
+    symbol = getattr(node, "symbol", None)
+    upper_bound = getattr(symbol, "upper_bound", None)
+
+    if upper_bound is None:
+        return False
+
+    return _ast_equal(Symbol(upper_bound).node, Symbol(size - 1).node)
+
+
+def _attribute_name(node):
+    if isinstance(node, ast.Name):
+        return node.id
+
+    if isinstance(node, ast.Attribute):
+        return node.attr
+
+    return None
+
+
+def _is_zero(node):
+    return isinstance(node, ast.Constant) and node.value == 0
+
+
+def _is_positive_integer(node):
+    return (
+        isinstance(node, ast.Constant)
+        and isinstance(node.value, int)
+        and node.value > 0
+    )
+
+
+def _ast_equal(left, right):
+    return ast.dump(left, include_attributes=False) == ast.dump(
+        right, include_attributes=False
+    )
+
+
+def _broadcast_zero_offset(index):
+    if _contains_named_call(Symbol(index).node, "arange"):
+        return 0 * index
+
+    return 0
+
+
+def _contains_named_call(node, name):
+    return _is_named_call(node, name) or any(
+        _contains_named_call(child, name) for child in ast.iter_child_nodes(node)
+    )
 
 
 class Tensor:
@@ -297,7 +407,7 @@ class Tensor:
         def _offsets(indices):
             return (
                 tuple(
-                    index if new_size == -1 else 0 * index
+                    index if new_size == -1 else _broadcast_zero_offset(index)
                     for index, new_size in zip(indices, shape)
                 ),
             )
@@ -570,8 +680,11 @@ class Tensor:
         for index, size in zip(indices, self.shape):
             index = Symbol(index)
 
-            self.source._mask &= index < size
-            self.source._mask &= index >= 0
+            if not _is_strict_upper_bound_check_redundant(index, size):
+                self.source._mask &= index < size
+
+            if not _is_known_non_negative_index(index):
+                self.source._mask &= index >= 0
 
         for output_, output in zip(self._outputs, outputs):
             output_.clear()
@@ -628,7 +741,7 @@ class Tensor:
         if self.jagged_dim is not None and dim == 0:
             return 0
 
-        return naming.auto_generate(f"{self.name}_stride_{dim}")
+        return naming.make_constexpr(naming.auto_generate(f"{self.name}_s_{dim}"))
 
     def values_string(self):
         return naming.auto_generate(f"{self.name}_values")
@@ -738,7 +851,9 @@ class Tensor:
     @staticmethod
     def stride_pattern():
         return re.compile(
-            naming.auto_generate(rf"({_identifier_pattern_raw_string()})_(stride)_(.+)")
+            naming.auto_generate(
+                rf"({_identifier_pattern_raw_string()})_(stride|s)_(.+)"
+            )
         )
 
     @staticmethod

--- a/src/ninetoothed/torchifier.py
+++ b/src/ninetoothed/torchifier.py
@@ -22,6 +22,10 @@ class Torchifier(ast.NodeTransformer):
             return f"{match.group(1)}.{match.group(2)}({match.group(3)})"
 
         source = Tensor.size_pattern().sub(repl, source)
+
+        def repl(match):
+            return f"{match.group(1)}.stride({match.group(3)})"
+
         source = Tensor.stride_pattern().sub(repl, source)
 
         def repl(match):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,11 @@ import hashlib
 import random
 
 import pytest
-import torch
+
+try:
+    import torch
+except ModuleNotFoundError:
+    torch = None
 
 
 def pytest_collectstart(collector):
@@ -22,7 +26,9 @@ def set_seed_per_test(request):
 
 def _set_random_seed(seed):
     random.seed(seed)
-    torch.manual_seed(seed)
+
+    if torch is not None:
+        torch.manual_seed(seed)
 
 
 def _test_case_path_from_request(request):

--- a/tests/test_codegen_specialization.py
+++ b/tests/test_codegen_specialization.py
@@ -1,0 +1,357 @@
+import ast
+import importlib
+import sys
+import types
+from pathlib import Path
+
+
+def _copy_application(input, output):
+    output = input  # noqa: F841
+
+
+def _scalar_broadcast_application(input, output):
+    output = input  # noqa: F841
+
+
+def _import_with_triton_stub(monkeypatch, module_name):
+    package_root = Path(__file__).resolve().parents[1] / "src" / "ninetoothed"
+
+    for name in tuple(sys.modules):
+        if name == "ninetoothed" or name.startswith("ninetoothed."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    package = types.ModuleType("ninetoothed")
+    package.__path__ = [str(package_root)]
+    monkeypatch.setitem(sys.modules, "ninetoothed", package)
+
+    triton = types.ModuleType("triton")
+    triton_language = types.ModuleType("triton.language")
+    triton_language_extra = types.ModuleType("triton.language.extra")
+    triton_language_extra.libdevice = types.SimpleNamespace()
+    triton_language.extra = triton_language_extra
+    triton.language = triton_language
+    triton.runtime = types.SimpleNamespace(
+        JITFunction=type("JITFunction", (), {}),
+        driver=types.SimpleNamespace(
+            active=types.SimpleNamespace(
+                get_current_device=lambda: 0,
+                utils=types.SimpleNamespace(get_device_properties=lambda device: {}),
+            )
+        ),
+    )
+
+    monkeypatch.setitem(sys.modules, "triton", triton)
+    monkeypatch.setitem(sys.modules, "triton.language", triton_language)
+    monkeypatch.setitem(sys.modules, "triton.language.extra", triton_language_extra)
+
+    return importlib.import_module(module_name)
+
+
+def test_literal_true_mask_is_omitted_from_memory_calls(monkeypatch):
+    generation = _import_with_triton_stub(monkeypatch, "ninetoothed.generation")
+    symbol = importlib.import_module("ninetoothed.symbol")
+
+    node = generation.CodeGenerator._generate_memory_call(
+        "load", symbol.Symbol("ptr"), mask=symbol.Symbol(True), other=0
+    )
+
+    source = ast.unparse(node)
+    assert source == "ninetoothed.language.load(ptr, other=0)"
+
+
+def test_literal_true_conjunction_is_simplified_from_memory_masks(monkeypatch):
+    generation = _import_with_triton_stub(monkeypatch, "ninetoothed.generation")
+    symbol = importlib.import_module("ninetoothed.symbol")
+
+    mask = symbol.Symbol(True) & symbol.Symbol("i < n")
+    node = generation.CodeGenerator._generate_memory_call(
+        "load", symbol.Symbol("ptr"), mask=mask, other=0
+    )
+
+    source = ast.unparse(node)
+    assert source == "ninetoothed.language.load(ptr, mask=i < n, other=0)"
+
+
+def test_all_literal_true_conjunction_is_omitted_from_memory_masks(monkeypatch):
+    generation = _import_with_triton_stub(monkeypatch, "ninetoothed.generation")
+    symbol = importlib.import_module("ninetoothed.symbol")
+
+    mask = symbol.Symbol(True) & symbol.Symbol(True)
+    node = generation.CodeGenerator._generate_memory_call(
+        "store", symbol.Symbol("ptr"), symbol.Symbol("value"), mask=mask
+    )
+
+    source = ast.unparse(node)
+    assert source == "ninetoothed.language.store(ptr, value)"
+
+
+def test_redundant_arange_bounds_are_recognized(monkeypatch):
+    tensor = _import_with_triton_stub(monkeypatch, "ninetoothed.tensor")
+    symbol = importlib.import_module("ninetoothed.symbol")
+
+    index = symbol.Symbol("ninetoothed.language.arange(0, n)")
+    size = symbol.Symbol("n")
+
+    assert tensor._is_known_non_negative_index(index)
+    assert tensor._is_strict_upper_bound_check_redundant(index, size)
+
+
+def test_lower_bound_symbol_indices_are_recognized_as_non_negative(monkeypatch):
+    tensor = _import_with_triton_stub(monkeypatch, "ninetoothed.tensor")
+    symbol = importlib.import_module("ninetoothed.symbol")
+
+    index = symbol.Symbol("pid_index", lower_bound=0)
+
+    assert tensor._is_known_non_negative_index(index)
+
+
+def test_pid_grid_upper_bound_mask_is_pruned_but_tail_mask_remains(monkeypatch):
+    generation = _import_with_triton_stub(monkeypatch, "ninetoothed.generation")
+    tensor = importlib.import_module("ninetoothed.tensor")
+    symbol = importlib.import_module("ninetoothed.symbol")
+
+    block_size = symbol.Symbol("block_size", meta=True)
+    tiled = tensor.Tensor(1).tile((block_size,))
+
+    generator = generation.CodeGenerator()
+    generator._invariants = {}
+    generator._args = [tiled]
+
+    source = ast.unparse(generator._generate_load(tiled))
+
+    assert "ninetoothed_tensor_0_index_0 <" not in source
+    assert (
+        "ninetoothed_tensor_0_index_0 * ninetoothed_meta_prefix_block_size +" in source
+    )
+    assert " < ninetoothed_ninetoothed_tensor_0_size_0" in source
+
+
+def test_pid_upper_bound_mask_is_kept_for_non_grid_shapes(monkeypatch):
+    generation = _import_with_triton_stub(monkeypatch, "ninetoothed.generation")
+    tensor = importlib.import_module("ninetoothed.tensor")
+    symbol = importlib.import_module("ninetoothed.symbol")
+
+    block_size = symbol.Symbol("block_size", meta=True)
+    grid_tiled = tensor.Tensor(1).tile((block_size,))
+    non_grid_tiled = tensor.Tensor(1).tile((block_size,))
+
+    generator = generation.CodeGenerator()
+    generator._invariants = {}
+    generator._args = [grid_tiled]
+
+    source = ast.unparse(generator._generate_load(non_grid_tiled))
+
+    assert "* ninetoothed_meta_prefix_block_size +" in source
+    assert " < ninetoothed_ninetoothed_tensor_" in source
+
+
+def test_broadcast_expand_uses_zero_offset(monkeypatch):
+    tensor = _import_with_triton_stub(monkeypatch, "ninetoothed.tensor")
+    symbol = importlib.import_module("ninetoothed.symbol")
+
+    source = tensor.Tensor(shape=(1,))
+    expanded = source.expand((4,))
+
+    offset = expanded._offsets((symbol.Symbol("i"),))[0][0]
+
+    assert ast.unparse(symbol.Symbol(offset).node) == "0"
+
+
+def test_broadcast_expand_preserves_tile_offset_shape(monkeypatch):
+    tensor = _import_with_triton_stub(monkeypatch, "ninetoothed.tensor")
+    symbol = importlib.import_module("ninetoothed.symbol")
+
+    source = tensor.Tensor(shape=(1,))
+    expanded = source.expand((4,))
+
+    index = symbol.Symbol("ninetoothed.language.arange(0, block_size)")
+    offset = expanded._offsets((index,))[0][0]
+
+    assert ast.unparse(symbol.Symbol(offset).node) == (
+        "ninetoothed.language.arange(0, block_size) * 0"
+    )
+
+
+def test_uniform_scalar_broadcast_load_omits_mask_and_zero_stride(monkeypatch):
+    generation = _import_with_triton_stub(monkeypatch, "ninetoothed.generation")
+    tensor = importlib.import_module("ninetoothed.tensor")
+    symbol = importlib.import_module("ninetoothed.symbol")
+
+    source = tensor.Tensor(shape=(1,))
+    expanded_tile = source.expand((symbol.Symbol("n"),)).tile(
+        (symbol.Symbol("block_size", meta=True),)
+    )
+
+    generator = generation.CodeGenerator()
+    generator._invariants = {}
+
+    source = ast.unparse(generator._generate_load(expanded_tile))
+
+    assert source == (
+        "ninetoothed.language.load(ninetoothed_tensor_0_pointers, other=None)"
+    )
+
+
+def test_dynamic_scalar_broadcast_load_uses_scalar_nonempty_mask(monkeypatch):
+    generation = _import_with_triton_stub(monkeypatch, "ninetoothed.generation")
+    tensor = importlib.import_module("ninetoothed.tensor")
+    symbol = importlib.import_module("ninetoothed.symbol")
+
+    source = tensor.Tensor(1)
+    expanded_tile = source.expand((symbol.Symbol("n"),)).tile(
+        (symbol.Symbol("block_size", meta=True),)
+    )
+
+    generator = generation.CodeGenerator()
+    generator._invariants = {}
+
+    source = ast.unparse(generator._generate_load(expanded_tile))
+
+    assert source == (
+        "ninetoothed.language.load(ninetoothed_tensor_0_pointers, "
+        "mask=ninetoothed_ninetoothed_tensor_0_size_0 > 0, other=None)"
+    )
+
+
+def test_jit_stride_metadata_is_constexpr_without_launch_arguments(monkeypatch):
+    generation = _import_with_triton_stub(monkeypatch, "ninetoothed.generation")
+    tensor = importlib.import_module("ninetoothed.tensor")
+
+    _copy_application.__annotations__ = {
+        "input": tensor.Tensor(1).tile((128,)),
+        "output": tensor.Tensor(1).tile((128,)),
+    }
+
+    source_file = generation.CodeGenerator()(
+        _copy_application,
+        "torch",
+        "copy_stride_probe",
+        4,
+        3,
+        None,
+        False,
+    )
+    source = Path(source_file).read_text(encoding="utf-8")
+
+    assert "_s_0: triton.language.constexpr" in source
+    assert "_stride_0: triton.language.constexpr" not in source
+
+    launch_line = next(
+        line
+        for line in source.splitlines()
+        if line.startswith("def launch_copy_stride_probe")
+    )
+    launch_args = launch_line.removeprefix(
+        "def launch_copy_stride_probe("
+    ).removesuffix("):")
+
+    assert "stride" not in launch_args
+    assert "_s_0 = ninetoothed_tensor_" in source
+    assert ".stride(0)" in source
+
+
+def test_uniform_scalar_broadcast_drops_unused_source_stride_constexpr(monkeypatch):
+    generation = _import_with_triton_stub(monkeypatch, "ninetoothed.generation")
+    tensor = importlib.import_module("ninetoothed.tensor")
+    symbol = importlib.import_module("ninetoothed.symbol")
+
+    block_size = symbol.Symbol("block_size", meta=True)
+    input_source = tensor.Tensor(1)
+    output_source = tensor.Tensor(1)
+    input_arg = input_source.expand((output_source.shape[0],)).tile((block_size,))
+    output_arg = output_source.tile((block_size,))
+
+    _scalar_broadcast_application.__annotations__ = {
+        "input": input_arg,
+        "output": output_arg,
+    }
+
+    source_file = generation.CodeGenerator()(
+        _scalar_broadcast_application,
+        "torch",
+        "scalar_stride_prune_probe",
+        4,
+        3,
+        None,
+        False,
+    )
+    source = Path(source_file).read_text(encoding="utf-8")
+
+    input_stride = str(input_arg.source.stride_string(0))
+    output_stride = str(output_arg.source.stride_string(0))
+
+    assert input_stride not in source
+    assert output_stride in source
+
+
+def test_aot_unparser_handles_excluded_constexpr_stride_arguments(monkeypatch):
+    aot = _import_with_triton_stub(monkeypatch, "ninetoothed.aot")
+
+    launch_func = ast.parse(
+        """
+def launch_probe(input, output):
+    probe[input.shape[0]](input, output, input.strides[0])
+"""
+    ).body[0]
+
+    unparsed = aot._Unparser(
+        ("CUstream", "float*", "float*"),
+        constexpr_inner_strides=(("input", 0),),
+    ).unparse(launch_func)
+
+    assert "return probe[input.shape[0]]((CUstream)stream," in unparsed
+    assert "*(float* *)input.data.shape" not in unparsed
+    assert "*(float* *)input.data" in unparsed
+    assert "input.strides[0]" not in unparsed
+
+
+def test_aot_unparser_keeps_unspecialized_constexpr_stride_arguments(monkeypatch):
+    aot = _import_with_triton_stub(monkeypatch, "ninetoothed.aot")
+
+    launch_func = ast.parse(
+        """
+def launch_probe(input, output):
+    ninetoothed_constexpr_prefix_ninetoothed_ninetoothed_tensor_0_s_0 = input.strides[0]
+    probe[input.shape[0]](ninetoothed_constexpr_prefix_ninetoothed_ninetoothed_tensor_0_s_0, input, output)
+"""
+    ).body[0]
+
+    unparsed = aot._Unparser(
+        ("CUstream", "int64_t", "float*", "float*"),
+    ).unparse(launch_func)
+
+    assert (
+        "(int64_t)ninetoothed_constexpr_prefix_ninetoothed_ninetoothed_tensor_0_s_0"
+        in unparsed
+    )
+    assert (
+        "auto ninetoothed_constexpr_prefix_ninetoothed_ninetoothed_tensor_0_s_0 = "
+        "input.strides[0]" in unparsed
+    )
+    assert (
+        "*ninetoothed_constexpr_prefix_ninetoothed_ninetoothed_tensor_0_s_0.data"
+        not in unparsed
+    )
+
+
+def test_aot_unparser_drops_specialized_constexpr_stride_names(monkeypatch):
+    aot = _import_with_triton_stub(monkeypatch, "ninetoothed.aot")
+
+    launch_func = ast.parse(
+        """
+def launch_probe(input, output):
+    ninetoothed_constexpr_prefix_ninetoothed_ninetoothed_tensor_0_s_0 = input.strides[0]
+    probe[input.shape[0]](ninetoothed_constexpr_prefix_ninetoothed_ninetoothed_tensor_0_s_0, input, output)
+"""
+    ).body[0]
+
+    unparsed = aot._Unparser(
+        ("CUstream", "float*", "float*"),
+        constexpr_inner_strides=(("ninetoothed_tensor_0", 0),),
+    ).unparse(launch_func)
+
+    assert (
+        "ninetoothed_constexpr_prefix_ninetoothed_ninetoothed_tensor_0_s_0"
+        not in unparsed
+    )
+    assert "*(float* *)input.data" in unparsed


### PR DESCRIPTION
## Competition Information

- Contest: InfiniTensor 2026 Spring
- Challenge: T1-2-1 NineToothed code generation specialization
- Team: weiwei
- Member: wyb
- GitHub ID: wyb123465
- Branch: `2026-spring-wyb123465-t1-2-1`
- Base: `InfiniTensor/ninetoothed@c9ebd4950a185beed8d4c1db9ff4a1fd133934ae`

## Summary

This PR improves NineToothed code generation for constrained specialization cases without matching test names, benchmark names, hidden paths, environment variables, or fixed input sizes.

- Prune provably redundant literal-true mask terms in generated `tl.load` and `tl.store` calls.
- Simplify scalar and broadcast load paths by removing unnecessary zero-offset expressions, vector masks, and unused stride parameters.
- Pass JIT stride metadata as constexpr values while keeping the public launch interface tensor-only.
- Drop tensor metadata parameters unused by the transformed kernel body.
- Build AOT launch call arguments from AST nodes instead of regex-parsing call text.

## Files Changed

- `src/ninetoothed/generation.py`
- `src/ninetoothed/tensor.py`
- `src/ninetoothed/torchifier.py`
- `src/ninetoothed/aot.py`
- `tests/conftest.py`
- `tests/test_codegen_specialization.py`

## Latest Local Validation

Environment: Windows, Python 3.13.12. The branch was rebased onto the latest upstream `master` before validation.

`pytest` output:

```text
python -m ruff format --check .
50 files already formatted

python -m ruff check .
All checks passed!

PYTHONPATH=src python -m pytest tests/test_codegen_specialization.py -q
................                                                         [100%]
16 passed in 0.59s
```

The remaining CUDA-dependent suite cannot be collected in this Windows environment because PyTorch/Triton CUDA dependencies are unavailable.

## Previous CUDA Validation

Environment: RTX 4090 D, CUDA 12.8.

```text
PYTHONPATH=src pytest tests/test_codegen_specialization.py -q
16 passed in 0.42s

PYTHONPATH=src pytest tests/test_codegen_specialization.py tests/test_expand.py tests/test_jagged.py tests/test_generation.py -q
109 passed in 16.73s

PYTHONPATH=src pytest tests -q
225 passed, 3 failed, 1 skipped in 1064.42s
```

The three full-suite failures were reproduced or observed on the unmodified baseline and are documented as environment/upstream compatibility issues in the contest attachment.

## Benchmark

| Case | Median speedup | Source bytes | Stride expr | Zero-times |
| --- | ---: | ---: | ---: | ---: |
| `fallback_copy_contiguous` | `1.029873x` | `4491 -> 3577` | `14 -> 2` | `6 -> 4` |
| `fallback_add_contiguous` | `1.045782x` | `6116 -> 4745` | `21 -> 3` | `9 -> 6` |
| `hit_scalar_broadcast_tile` | `1.031882x` | `4994 -> 2939` | `14 -> 1` | `12 -> 2` |
| `hit_zero_size_expand` | `1.034477x` | `3398 -> 1786` | `7 -> 0` | `9 -> 0` |

All four benchmark cases reported `correct: true`.

## Compliance And Risks

- Specialization conditions use tensor metadata, AST structure, shape/grid relationships, stride/offset semantics, and constexpr values.
- Existing tests are not deleted, skipped, or weakened.
- Fallback behavior remains active when specialization conditions are not provable.
- Runtime results can vary with GPU frequency, cache state, and Triton compilation cache.
- The contest website attachment contains the signed Honor Code, Reference disclosure, final PDF report, test images, validation report, benchmark scripts, and raw result files.
