### PR TITLE
Add 2026 spring T3-1-1 skill submission for hutou666

### DIFF
--- a/skills/competition/ninetoothed-op-dev-skill/HONOR_CODE.md
+++ b/skills/competition/ninetoothed-op-dev-skill/HONOR_CODE.md
@@ -1,0 +1,14 @@
+# HONOR_CODE.md
+
+I confirm that this submission:
+
+- Does not contain hidden evaluation answers.
+- Does not hardcode hidden task names or evaluation script behavior.
+- Does not include API keys, credentials, or private accounts.
+- Does not instruct agents to delete tests, bypass tests, or fabricate results.
+- Discloses external references, third-party code, and AI assistance in `REFERENCE.md`.
+- Is intended to be reproducible in the competition environment.
+
+Participant: **胡家瑞**  
+Team: **胡家瑞**（单人队）  
+Date: **2026-07-10**

--- a/skills/competition/ninetoothed-op-dev-skill/README.md
+++ b/skills/competition/ninetoothed-op-dev-skill/README.md
@@ -1,0 +1,119 @@
+# ninetoothed-op-dev-skill
+
+NineToothed operator development Agent Skill for competition T3-1-1.
+
+## Skill name
+
+`ninetoothed-op-dev-skill`
+
+## Scope
+
+Guides AI agents through:
+
+- Operator contract extraction
+- NineToothed arrange-and-apply implementation
+- Correctness tests vs PyTorch / repo references
+- Benchmark and performance regression analysis
+- Generated source / AOT inspection
+- Non-contiguous / stride / offset handling
+- Failing-test minimal repair with logs
+
+## Out of scope
+
+- NineToothed compiler core changes (unless explicitly required)
+- API keys, hidden answers, test bypassing, fabricated benchmarks
+- Shipping pre-written self-test patches or answer artifacts inside the runtime skill
+
+## Package structure (runtime)
+
+```text
+SKILL.md
+README.md
+HONOR_CODE.md
+REFERENCE.md
+pyproject.toml
+references/00–11   # capability guides only
+scripts/           # runtime core only (see pack whitelist)
+examples/01,03,05,09
+tests/             # structure + smoke + pack whitelist
+```
+
+This directory is already the packed runtime submission.
+Copy it directly to:
+
+```text
+skills/competition/ninetoothed-op-dev-skill/
+```
+
+No repacking step is required.
+
+## Installation (inside a NineToothed fork/clone)
+
+1. Clone or fork [InfiniTensor/ninetoothed](https://github.com/InfiniTensor/ninetoothed).
+2. Copy this skill directory to:
+
+```text
+<ninetoothed-repo>/skills/competition/ninetoothed-op-dev-skill/
+```
+
+3. Activate a Python env with `torch`, `ninetoothed` (editable install of the fork), and `pytest`.
+
+**No pip install is required for the skill itself.**
+
+### Acceptance commands (must all pass before submit)
+
+Run from the **NineToothed repository root** (the directory that contains `src/ninetoothed/`):
+
+```bash
+cd /path/to/ninetoothed   # fork/clone root
+source ~/venvs/ninetoothed-skill/bin/activate   # or your env
+
+python skills/competition/ninetoothed-op-dev-skill/scripts/audit_packed_skill.py \
+  skills/competition/ninetoothed-op-dev-skill
+python skills/competition/ninetoothed-op-dev-skill/scripts/quick_validate.py
+pytest skills/competition/ninetoothed-op-dev-skill/tests -q
+python skills/competition/ninetoothed-op-dev-skill/scripts/env_check.py --repo-root .
+```
+
+All **repo-accessing** helpers accept `--repo-root` (and optional `--examples-root`).
+Pure text tools (`make_task_card`, `score_task`, `summarize_run`, `quick_validate`) do not require `--repo-root`.
+
+Environment variables (optional):
+
+| Variable | Meaning |
+|----------|---------|
+| `NINETOOTHED_REPO_ROOT` | Target NineToothed repo root |
+| `NINETOOTHED_SKILL_ROOT` | Skill package root |
+| `NINETOOTHED_EXAMPLES_ROOT` | Optional ninetoothed-examples root |
+
+## Usage
+
+1. Ensure the agent loads `SKILL.md`.
+2. Point `--repo-root` at the NineToothed fork (must contain `src/ninetoothed/`).
+3. Follow the **D1–D9** decision tree in `SKILL.md` (compact spine is a checklist only).
+4. Save logs under `<repo-root>/logs/`.
+
+Example:
+
+```bash
+python skills/competition/ninetoothed-op-dev-skill/scripts/run_correctness.py \
+  --repo-root . \
+  --task-id demo_add \
+  --cwd . -- \
+  pytest tests/test_add.py -v --tb=short
+```
+
+## Capability families (not fixed task IDs)
+
+| Family | Reference |
+|--------|-----------|
+| Elementwise / broadcast | `references/03_elementwise_broadcast_patterns.md` |
+| Reduction / block | `references/04_reduction_block_patterns.md` |
+| Layout-sensitive | `references/05_layout_stride_offset_patterns.md` |
+| Performance / diagnosis | `references/07_benchmark_patterns.md` + `08_…` / `09_…` |
+
+Runtime must not ship `evals/`, `submission/`, workspace-only artifacts, answer-shaped products, or caches.
+
+## Safety and compliance
+
+See `HONOR_CODE.md` and `SKILL.md` § Hard compliance rules.

--- a/skills/competition/ninetoothed-op-dev-skill/REFERENCE.md
+++ b/skills/competition/ninetoothed-op-dev-skill/REFERENCE.md
@@ -1,0 +1,54 @@
+# REFERENCE.md
+
+Upstream citations, version pins, licenses, and AI-assistance disclosure for the
+**runtime** skill package. Competition studies, workspace gate logs, and local
+path pins live in the external evidence bundle linked in the PR description —
+not in this runtime tree.
+
+## Upstream projects
+
+| Project | URL | Notes |
+|---------|-----|-------|
+| NineToothed | https://github.com/InfiniTensor/ninetoothed | Target `--repo-root` (contains `src/ninetoothed/`) |
+| NineToothed docs | https://ninetoothed.org/ | Concepts, AOT / build |
+| ninetoothed-examples | https://github.com/InfiniTensor/ninetoothed-examples | Optional `--examples-root` |
+| ntops | https://github.com/InfiniTensor/ntops | Related ops library |
+
+## Version pins (reproducibility)
+
+Pin the fork you develop against; re-verify with `env_check.py --repo-root .`.
+
+| Component | Suggested pin |
+|-----------|----------------|
+| Python | 3.10+ |
+| PyTorch | CUDA build matching the GPU (e.g. cu128 nightly for sm_120) |
+| pytest | recent 8.x / 9.x |
+| ninetoothed | editable install of the fork at a known commit |
+| ninetoothed-examples | optional; known commit if used |
+
+```bash
+cd <repo-root>
+python -c "import torch, ninetoothed; print(torch.__version__, ninetoothed.__version__)"
+git rev-parse HEAD
+python /path/to/ninetoothed-op-dev-skill/scripts/env_check.py --repo-root .
+```
+
+## Licenses
+
+| Component | License | Notes |
+|-----------|---------|-------|
+| This skill package | See competition / repo license | No hidden answers or credentials |
+| NineToothed (`<repo-root>`) | Apache-2.0 | Prefer patches outside compiler core |
+| ninetoothed-examples (`--examples-root`) | Apache-2.0 | Optional reference / bench only |
+
+## AI assistance disclosure
+
+Drafting of `SKILL.md`, `references/`, helper scripts, reports, and packaging
+checklists used generative AI assistants (**Cursor** and **Codex / GPT-family**
+tools) under human direction. The submitter remains responsible for factual
+accuracy, reproducible commands, and honest benchmark claims. Packaged
+`examples/` are workflow demos, not evaluation answer keys.
+
+## Agent skill conventions
+
+- Cursor Agent Skills / Open Agent Skills layout (`SKILL.md` + `references/` + `scripts/`)

--- a/skills/competition/ninetoothed-op-dev-skill/SKILL.md
+++ b/skills/competition/ninetoothed-op-dev-skill/SKILL.md
@@ -42,6 +42,10 @@ Output a short card with **all** of:
 
 If any field is unknown → search the repo (D3) or mark `TODO: verify`; do not invent.
 
+If `make_task_card.py --strict` cannot parse the task, do not use a partial card and
+do not stop the task. Read the original task directly and complete the same card
+manually. Resolve remaining unknowns through D3; never infer them from a task ID.
+
 ### D2 — Route by family → nearest pattern
 
 Pick **one** primary family, then open the listed starting points (under `--repo-root`):
@@ -60,8 +64,8 @@ Read `references/03`–`05` / `07`–`09` only for the chosen family. **Reuse** 
 From the NineToothed repo root, search then read hits **before** editing:
 
 ```bash
-rg -n "arrangement|application|ninetoothed.make" tests/ -g "*.py" | head
-rg -n "<op_keyword>" tests/ src/ninetoothed/ -g "*.py" | head
+rg -n -m 20 "arrangement|application|ninetoothed.make" tests/ -g "*.py"
+rg -n -m 20 "<op_keyword>" tests/ src/ninetoothed/ -g "*.py"
 ```
 
 Record: nearest test path + nearest kernel/example path. No `rg` → no patch.
@@ -70,7 +74,9 @@ Record: nearest test path + nearest kernel/example path. No `rg` → no patch.
 
 - Touch only files the task needs; mirror `tests/test_<op>.py` layout.
 - Prefer `ninetoothed.make` / `@ninetoothed.jit` patterns already in-repo.
-- fp16 defaults: `atol=2e-2, rtol=1e-2` unless the task tightens.
+- Reuse the task's tolerance or the nearest upstream test's tolerance. Only when
+  neither exists, use `atol=2e-2, rtol=1e-2` as a starting point and verify it
+  against the reference; never treat it as a universal pass threshold.
 
 ### D5 — Layout branch (if layout ≠ contiguous-only)
 
@@ -159,6 +165,7 @@ kernel = ninetoothed.make(arrangement, application, tensors)
 |------|------|
 | `00_repo_map.md` | repo layout |
 | `01_ninetoothed_concepts.md` | arrangement / application |
+| `02_arrangement_application_patterns.md` | implementing arrangement / application |
 | `03_elementwise_broadcast_patterns.md` | elementwise / broadcast |
 | `04_reduction_block_patterns.md` | reduce / block |
 | `05_layout_stride_offset_patterns.md` | stride / offset |

--- a/skills/competition/ninetoothed-op-dev-skill/SKILL.md
+++ b/skills/competition/ninetoothed-op-dev-skill/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: ninetoothed-op-dev-skill
+description: NineToothed operator development skill for arrangement/application implementation, correctness tests, benchmark, generated source, AOT build, non-contiguous/stride/offset handling, performance regression diagnosis, and failing test repair. Use when implementing, testing, benchmarking, debugging, repairing, or documenting NineToothed operators, Triton kernels, or InfiniTensor ninetoothed repositories.
+---
+
+# NineToothed Operator Development Skill
+
+## When to use
+
+- Implement / fix a **NineToothed** kernel (`arrangement` / `application` / `ninetoothed.make`)
+- Correctness vs PyTorch or repo tests; layout (stride/offset); benchmark / AOT / failing-test repair
+
+## Do not use for
+
+- Compiler-core edits (`src/ninetoothed/generation.py`, `cudaifier.py`, …) unless the task explicitly requires it
+- Fabricating benchmarks, deleting/skipping tests, or guessing hidden evaluation answers
+
+## Hard compliance
+
+1. No hidden answers, hardcoded hidden task names, API keys, or anti-eval logic.
+2. Minimal patches only; log every command for offline reproduction.
+
+---
+
+## Execution decision tree (MANDATORY)
+
+**Stop conditions:** Do not write kernel code until D1–D3 are done. Skip a branch only if the task card marks it N/A.
+
+### D1 — Emit task card first (before any code)
+
+Output a short card with **all** of:
+
+| Field | Must state |
+|-------|------------|
+| Math | operator semantics (exact formula / PyTorch op) |
+| Shape | every input/output shape (symbolic OK) |
+| dtype | per tensor |
+| Broadcast | rules or `N/A` |
+| Layout | contiguous / stride / offset / view requirements |
+| Boundaries | empty, mask, padding, fp16 tol, etc. |
+| Reference | PyTorch op **or** nearest repo test/kernel path |
+
+If any field is unknown → search the repo (D3) or mark `TODO: verify`; do not invent.
+
+### D2 — Route by family → nearest pattern
+
+Pick **one** primary family, then open the listed starting points (under `--repo-root`):
+
+| Family | Route to |
+|--------|----------|
+| Elementwise / broadcast | `tests/test_add.py`, `tests/test_expand.py`, `tests/test_pow.py`; examples `ops/.../add.py` |
+| Reduction / block | `tests/test_softmax.py`, `tests/test_max_pool2d.py`, `tests/test_matmul.py` |
+| Stride / offset / layout | `tests/test_clone.py`, `tests/test_data_ptr.py`, `tests/test_getitem.py` |
+| Perf / diagnosis / AOT | `tests/test_generation.py`, `tests/test_aot.py`, `tests/test_auto_tuner.py` |
+
+Read `references/03`–`05` / `07`–`09` only for the chosen family. **Reuse** that file’s `arrangement` / `application` / test style — do not invent APIs.
+
+### D3 — `rg` before code (non-negotiable)
+
+From the NineToothed repo root, search then read hits **before** editing:
+
+```bash
+rg -n "arrangement|application|ninetoothed.make" tests/ -g "*.py" | head
+rg -n "<op_keyword>" tests/ src/ninetoothed/ -g "*.py" | head
+```
+
+Record: nearest test path + nearest kernel/example path. No `rg` → no patch.
+
+### D4 — Implement minimal patch
+
+- Touch only files the task needs; mirror `tests/test_<op>.py` layout.
+- Prefer `ninetoothed.make` / `@ninetoothed.jit` patterns already in-repo.
+- fp16 defaults: `atol=2e-2, rtol=1e-2` unless the task tightens.
+
+### D5 — Layout branch (if layout ≠ contiguous-only)
+
+**Forced:**
+
+1. Build inputs as non-contiguous views (transpose / `as_strided` / slice) matching the card.
+2. In tests: `assert not inp.is_contiguous()` (and on other strided tensors the card requires).
+3. **Forbidden:** `.contiguous()` / materializing copies unless the task card explicitly allows it.
+4. Prefer stride/offset load patterns from `test_clone.py` / `references/05_*`.
+
+### D6 — Correctness gate
+
+```bash
+pytest <test_file> -v --tb=short
+```
+
+Log command + exit code under `logs/correctness/`. **FAIL → D7. PASS + perf task → D8. Else → D9.**
+
+### D7 — Failure loop (forced format)
+
+On every failure, output exactly:
+
+1. **Symptom** — command + error excerpt (≤20 lines)
+2. **Hypothesis** — one minimal, falsifiable claim (shape / dtype / stride / wrong op / codegen)
+3. **Minimal fix** — smallest diff that tests the hypothesis
+4. **Re-verify** — **same original command**; new exit code + excerpt
+
+Rules:
+
+- One hypothesis per iteration; do not shotgun-edit.
+- If the message says “broadcast/layout” but values look like wrong op (`*` vs `+`), read `application` **before** changing `arrangement`.
+- Loop or declare **unsupported** with reason — never claim PASS on FAIL.
+
+### D8 — Performance branch (only if task is perf-sensitive)
+
+**Forced order — skip any step → no performance claim:**
+
+1. **Correctness first** — D6 PASS at every config you will time (e.g. each `BLOCK_SIZE`).
+2. **Fixed inputs** — document exact shapes, dtype, device; do not change mid-bench.
+3. **Warmup** — ≥5 iterations (per config) before timing.
+4. **Repeat** — ≥20 timed iters (or project standard); report **median / p10 / p90** (and `spread_ratio=p90/median`); note if CI unavailable.
+5. **Fair baseline** — same dtype/device/size; disable or disclose autotuning (`meta=True`); constexpr `BLOCK_SIZE` when comparing tiles.
+6. **Conclusion bounds** — one line: what is comparable vs **N/A / incomparable** (e.g. autotuning window). Never invent numbers.
+
+Log under `logs/benchmark/`.
+
+### D9 — Report (mandatory fields)
+
+- `changed_files` — path + one-line purpose
+- `commands` — copy-pasteable, execution order
+- `correctness_result` — PASS/FAIL + log path
+- `benchmark_result` — numbers **or** `N/A` + reason
+- `failure_diagnosis` — D7 block **or** `N/A`
+- `unsupported_cases` — explicit list (may be empty)
+
+---
+
+## Compact execution spine
+
+Use this only as a checklist; **decisions live in D1–D9**.
+
+| # | Action | Gate |
+|---|--------|------|
+| 1 | Task card (D1) | all fields filled |
+| 2 | Family route (D2) + `rg` (D3) | nearest paths recorded |
+| 3 | Minimal patch (D4) + layout rules (D5) | no illegal `.contiguous()` |
+| 4 | Correctness (D6) | PASS or enter D7 |
+| 5 | Perf if required (D8) | correctness-first + fair baseline |
+| 6 | Report (D9) | all mandatory fields |
+
+Arrange-and-apply sketch (verify against repo, do not invent):
+
+```python
+import ninetoothed
+import ninetoothed.language as ntl
+from ninetoothed import Tensor
+
+kernel = ninetoothed.make(arrangement, application, tensors)
+```
+
+---
+
+## References (on demand)
+
+| File | When |
+|------|------|
+| `00_repo_map.md` | repo layout |
+| `01_ninetoothed_concepts.md` | arrangement / application |
+| `03_elementwise_broadcast_patterns.md` | elementwise / broadcast |
+| `04_reduction_block_patterns.md` | reduce / block |
+| `05_layout_stride_offset_patterns.md` | stride / offset |
+| `06_correctness_testing_patterns.md` | pytest patterns |
+| `07_benchmark_patterns.md` | D8 details |
+| `08_generated_source_aot_debugging.md` | codegen / AOT |
+| `09_failure_diagnosis_playbook.md` | D7 details |
+| `10_patch_minimality_checklist.md` | before submit |
+| `11_unsupported_cases.md` | limits |
+
+Fallback: `src/ninetoothed/` + `tests/` under `--repo-root`.
+
+## Helpers
+
+- `env_check.py --repo-root .` — env report only
+- `make_task_card.py` — task card from prompt (no `--repo-root`)
+- `run_correctness.py` / `run_benchmark.py` — logged wrappers (`--repo-root`)
+- `repo_pattern_index.py` / `check_patch_minimality.py` — repo scan / diff (`--repo-root`)
+- `score_task.py` / `gate_eval.py` — evidence scoring (no `--repo-root`)
+- `summarize_run.py` / `quick_validate.py` — text / package checks (no `--repo-root`)
+
+Scripts must not bypass tests or fabricate results.
+
+## Rubric focus (0–10)
+
+| Pts | Optimize for |
+|-----|----------------|
+| 4 | Semantics, shapes, dtypes, boundaries |
+| 2 | Tests + verification trail |
+| 1 | Perf awareness when required (D8) |
+| 1 | Minimal diff |
+| 1 | Repo style |
+| 1 | Compliance + reproducible logs |
+
+**Search the repo; never guess hidden task names or answers.**

--- a/skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/benchmark_result.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/benchmark_result.md
@@ -1,0 +1,39 @@
+# Benchmark — example 01
+
+## When to run
+
+Only after correctness PASS (SKILL.md D8).
+
+## Commands
+
+```bash
+python skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/verify.py \
+  --benchmark \
+  --json-output logs/benchmark/final-runtime-02/broadcast_add.json \
+  --markdown-output logs/benchmark/final-runtime-02/broadcast_add.md
+```
+
+## Protocol (Phase 2B)
+
+| Item | Value |
+|------|-------|
+| Shapes | `(128,256)`, `(512,512)`, `(2048,2048)` |
+| dtype / device | float32 / CUDA |
+| Output buffers | preallocated `out=` |
+| Timer | `torch.cuda.Event(enable_timing=True)` |
+| Warmup / repeats / inner | **30 / 30 / 100** |
+| Stats | median, p10, p90; `spread_ratio=p90/median` |
+
+## Recorded results (`logs/benchmark/final-runtime-02/broadcast_add.md`)
+
+- device: `NVIDIA GeForce RTX 5070 Ti Laptop GPU`
+- ninetoothed_commit: `ef4c52899f5f836e3d77001b56c3544849cacf2c`
+- measurement_scope: preallocated-output steady-state CUDA Event
+
+| M | N | NT median | Torch median | ratio | NT stab | Torch stab |
+|---|---|----------:|-------------:|------:|---------|------------|
+| 128 | 256 | 0.125396 | 0.121555 | 1.0316 | stable | stable |
+| 512 | 512 | 0.120316 | 0.115456 | 1.0421 | stable | stable |
+| 2048 | 2048 | 0.049763 | 0.047555 | 1.0464 | noisy | stable |
+
+Size inversion warnings (disclosed): NT/Torch (512,512)→(2048,2048) median decrease.

--- a/skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/changed_files.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/changed_files.md
@@ -1,0 +1,9 @@
+# Changed files — example 01
+
+| Path (under this example) | Purpose |
+|---------------------------|---------|
+| `solution/broadcast_add.py` | Minimal broadcast-add kernel via `ninetoothed.make` |
+| `tests/test_example_broadcast_add.py` | Correctness vs `torch.add` |
+| `verify.py` | One-shot correctness (+ optional micro-bench) |
+
+NineToothed `src/` / compiler core: **not modified**.

--- a/skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/correctness_result.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/correctness_result.md
@@ -1,0 +1,21 @@
+# Correctness — example 01
+
+## Command (from NineToothed fork/clone root)
+
+```bash
+export PYTHONPATH="$PWD/src${PYTHONPATH:+:$PYTHONPATH}"
+pytest skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/tests/test_example_broadcast_add.py -q
+# or:
+python skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/verify.py
+```
+
+## Result summary
+
+| Item | Value |
+|------|-------|
+| Verdict | **PASS** |
+| NineToothed commit | `ef4c52899f5f836e3d77001b56c3544849cacf2c` |
+| Evidence | `logs/benchmark_phase2b_gate_final_02.log` (examples section); Phase 4.1 reconfirm `logs/phase41_release_acceptance_final_02.log` |
+| Coverage | broadcast shapes vs `torch.add`; `out=` reuse; float16 correctness (atol/rtol=1e-2) |
+
+Stdout contains `correctness: PASS` on verify; pytest exit code `0`.

--- a/skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/run_log.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/run_log.md
@@ -1,0 +1,34 @@
+# Run log — example 01
+
+## D1 Task card
+
+See `task_card.md`.
+
+## D2–D3 Route + rg
+
+Family: **elementwise / broadcast**.
+
+```bash
+cd "$REPO"   # NineToothed root (has src/ninetoothed/)
+rg -n "arrangement|application|ninetoothed.make" tests/test_add.py
+rg -n "expand|broadcast" tests/test_expand.py tests/test_add.py
+```
+
+Nearest patterns: `tests/test_add.py` (`@ninetoothed.jit` / make style), expand helpers.
+
+## D4 Minimal patch
+
+- `solution/broadcast_add.py` — `arrangement` tiles + expand, `application` add
+- `tests/test_example_broadcast_add.py` — vs `torch.add`
+
+## D6 Correctness
+
+```bash
+python skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/verify.py
+# or:
+pytest skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/tests -v --tb=short
+```
+
+## D8 Benchmark
+
+Optional; see `benchmark_result.md` (verify.py prints ms/iter when CUDA available).

--- a/skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/run_prompt.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/run_prompt.md
@@ -1,0 +1,13 @@
+Use skill `ninetoothed-op-dev-skill` (SKILL.md decision tree D1–D9).
+
+## Task
+
+Broadcast add: `a` shape `(M,1)`, `b` shape `(1,N)`, `out = a + b` → `(M,N)`, float32.
+
+## Required process
+
+1. Write a task card (math, shape, dtype, broadcast, layout, boundaries, reference).
+2. From the NineToothed repo root, `rg` nearest patterns in `tests/test_add.py` / `tests/test_expand.py` **before** coding.
+3. Add a **minimal** `ninetoothed.make` kernel + pytest under this example directory.
+4. Run correctness; optionally micro-bench vs `torch.add` with warmup.
+5. Do not invent APIs; do not edit compiler core.

--- a/skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/solution/broadcast_add.py
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/solution/broadcast_add.py
@@ -1,0 +1,53 @@
+"""Minimal broadcast-add kernel for example 01 (fork-runnable demo)."""
+
+from __future__ import annotations
+
+import torch
+
+import ninetoothed
+import ninetoothed.language as ntl
+from ninetoothed import Symbol, Tensor
+
+BLOCK_M = Symbol("BLOCK_M", constexpr=True)
+BLOCK_N = Symbol("BLOCK_N", constexpr=True)
+
+
+def arrangement(a, b, out, BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N):
+    # Expand singleton dims to match out, then tile in lockstep (repo pattern).
+    a = a.expand((-1, out.shape[1])).tile((BLOCK_M, BLOCK_N))
+    b = b.expand((out.shape[0], -1)).tile((BLOCK_M, BLOCK_N))
+    out = out.tile((BLOCK_M, BLOCK_N))
+    return a, b, out
+
+
+def application(a, b, out):
+    out = ntl.cast(a, ntl.float32) + ntl.cast(b, ntl.float32)  # noqa: F841
+
+
+_kernel = ninetoothed.make(arrangement, application, (Tensor(2), Tensor(2), Tensor(2)))
+
+
+def broadcast_add(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    *,
+    block_m: int = 32,
+    block_n: int = 32,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    assert a.ndim == 2 and b.ndim == 2
+    m, _ = a.shape
+    _, n = b.shape
+
+    if out is None:
+        out = torch.empty((m, n), dtype=a.dtype, device=a.device)
+
+    if out.shape != (m, n):
+        raise ValueError(f"out shape must be {(m, n)}, got {tuple(out.shape)}")
+    if out.dtype != a.dtype:
+        raise ValueError(f"out dtype must be {a.dtype}, got {out.dtype}")
+    if out.device != a.device:
+        raise ValueError(f"out device must be {a.device}, got {out.device}")
+
+    _kernel(a, b, out, BLOCK_M=block_m, BLOCK_N=block_n)
+    return out

--- a/skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/task.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/task.md
@@ -1,0 +1,34 @@
+# Example 01 — elementwise / broadcast add
+
+## Task description
+
+Implement broadcast add with NineToothed arrange-and-apply:
+
+\[
+\mathrm{out}[i,j] = a[i,0] + b[0,j]
+\]
+
+Shapes: `a` `(M,1)`, `b` `(1,N)`, `out` `(M,N)`.
+
+**Correctness dtypes:** `float32` and `float16` (fp16 uses explicit atol/rtol in pytest).  
+**Benchmark dtype:** `float32` only — do not extend performance claims to float16.
+
+## Workflow (must follow SKILL.md D1–D9)
+
+1. **Task card** → see `task_card.md`
+2. **Route** → elementwise / broadcast (`references/03_*`)
+3. **`rg` in repo** (from `--repo-root`):
+
+```bash
+rg -n "arrangement|ninetoothed.make|broadcast|expand" tests/test_add.py tests/test_expand.py
+rg -n "def add|broadcast" tests/ -g "*.py" | head
+```
+
+4. **Minimal implementation** → `solution/broadcast_add.py` + `tests/test_example_broadcast_add.py`
+5. **pytest / verify** → see `correctness_result.md`
+6. **Benchmark** → optional micro-bench in `verify.py` (float32 only; see `benchmark_result.md`)
+
+## Deliverables in this directory
+
+`task_card.md`, `run_prompt.md`, `run_log.md`, `changed_files.md`,
+`correctness_result.md`, `benchmark_result.md`, `solution/`, `tests/`, `verify.py`.

--- a/skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/task_card.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/task_card.md
@@ -1,0 +1,15 @@
+# Task card — broadcast add
+
+| Field | Value |
+|-------|-------|
+| Math | `out = a + b` with NumPy/PyTorch broadcast |
+| Shape | a `(M,1)`, b `(1,N)`, out `(M,N)` |
+| Correctness dtype | float32 and float16 (fp16: explicit atol/rtol) |
+| Benchmark dtype | float32 only |
+| Broadcast | yes — column vector + row vector |
+| Layout | contiguous inputs; out contiguous |
+| Boundaries | M,N ≥ 1; CUDA preferred, CPU OK for smoke |
+| Reference | `tests/test_add.py`, `tests/test_expand.py`; `torch.add` |
+| Tests | `tests/test_example_broadcast_add.py` + `verify.py` |
+| Benchmark | optional micro-bench vs `torch.add` (float32 shapes only) |
+| Unsupported | int dtypes; autotuning claims; no float16 performance claims |

--- a/skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/tests/test_example_broadcast_add.py
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/tests/test_example_broadcast_add.py
@@ -1,0 +1,71 @@
+"""Correctness test for example 01 broadcast add."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+_EX = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_EX / "solution"))
+
+from broadcast_add import broadcast_add  # noqa: E402
+
+
+def _device() -> str:
+    return "cuda" if torch.cuda.is_available() else "cpu"
+
+
+@pytest.mark.parametrize("m,n", [(8, 16), (32, 64)])
+def test_broadcast_add_matches_torch(m: int, n: int):
+    device = _device()
+    if device == "cpu":
+        pytest.skip("NineToothed kernels typically require CUDA; skip CPU")
+    a = torch.randn(m, 1, dtype=torch.float32, device=device)
+    b = torch.randn(1, n, dtype=torch.float32, device=device)
+    out = broadcast_add(a, b)
+    ref = torch.add(a, b)
+    assert out.shape == (m, n)
+    assert torch.allclose(out, ref, atol=1e-5, rtol=1e-5)
+
+
+def test_broadcast_add_reuses_out_buffer():
+    device = _device()
+    if device == "cpu":
+        pytest.skip("NineToothed kernels typically require CUDA; skip CPU")
+    m, n = 16, 32
+    a = torch.randn(m, 1, dtype=torch.float32, device=device)
+    b = torch.randn(1, n, dtype=torch.float32, device=device)
+    out_buffer = torch.empty((m, n), device=device, dtype=a.dtype)
+    returned = broadcast_add(a, b, out=out_buffer)
+    assert returned is out_buffer
+    assert torch.allclose(out_buffer, torch.add(a, b), atol=1e-5, rtol=1e-5)
+
+
+def test_broadcast_add_rejects_bad_out_shape():
+    device = _device()
+    if device == "cpu":
+        pytest.skip("NineToothed kernels typically require CUDA; skip CPU")
+    m, n = 16, 32
+    a = torch.randn(m, 1, dtype=torch.float32, device=device)
+    b = torch.randn(1, n, dtype=torch.float32, device=device)
+    bad = torch.empty((m, n + 1), device=device, dtype=a.dtype)
+    with pytest.raises(ValueError, match="out shape"):
+        broadcast_add(a, b, out=bad)
+
+
+def test_broadcast_add_float16_matches_torch():
+    """Minimal float16 correctness; benchmark remains float32-only."""
+    device = _device()
+    if device == "cpu":
+        pytest.skip("NineToothed kernels typically require CUDA; skip CPU")
+    m, n = 8, 16
+    a = torch.randn(m, 1, dtype=torch.float16, device=device)
+    b = torch.randn(1, n, dtype=torch.float16, device=device)
+    out = broadcast_add(a, b)
+    ref = torch.add(a, b)
+    assert out.dtype == torch.float16
+    assert out.shape == (m, n)
+    assert torch.allclose(out, ref, atol=1e-2, rtol=1e-2)

--- a/skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/verify.py
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/01_elementwise_broadcast_add/verify.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""Fork-runnable verify for example 01 (correctness-first; preallocated-out bench)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import torch
+
+_EX = Path(__file__).resolve().parent
+sys.path.insert(0, str(_EX / "solution"))
+
+from broadcast_add import broadcast_add  # noqa: E402
+
+BENCH_SHAPES = ((128, 256), (512, 512), (2048, 2048))
+CORR_SHAPES = ((8, 16), (32, 64), (128, 256))
+QUICK_SHAPES = ((64, 128), (128, 256))
+
+WARMUP = 30
+REPEATS = 30
+INNER_ITERATIONS = 100
+QUICK_WARMUP = 3
+QUICK_REPEATS = 3
+QUICK_INNER = 8
+
+
+def _percentile(sorted_vals: list[float], p: float) -> float:
+    if not sorted_vals:
+        return float("nan")
+    k = (len(sorted_vals) - 1) * (p / 100.0)
+    f = int(k)
+    c = min(f + 1, len(sorted_vals) - 1)
+    if f == c:
+        return sorted_vals[f]
+    return sorted_vals[f] * (c - k) + sorted_vals[c] * (k - f)
+
+
+def _stats(samples: list[float]) -> dict[str, float | str]:
+    ordered = sorted(samples)
+    med = float(statistics.median(ordered))
+    p10 = float(_percentile(ordered, 10))
+    p90 = float(_percentile(ordered, 90))
+    spread = float(p90 / med) if med > 0 else float("inf")
+    if spread <= 2:
+        label = "stable"
+    elif spread <= 5:
+        label = "noisy"
+    else:
+        label = "highly_noisy"
+    return {
+        "median_ms": med,
+        "p10_ms": p10,
+        "p90_ms": p90,
+        "spread_ratio": spread,
+        "stability": label,
+    }
+
+
+def _git_commit() -> str:
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=Path.cwd(),
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        return out.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return "unknown"
+
+
+def _require_fresh_path(path: Path) -> None:
+    if path.exists():
+        raise SystemExit(f"STOP: output already exists (refusing overwrite): {path}")
+
+
+def _validate_samples(label: str, samples: list[float], expected: int) -> None:
+    if len(samples) != expected:
+        raise SystemExit(
+            f"STOP: incomplete batches for {label}: {len(samples)} != {expected}"
+        )
+    for i, v in enumerate(samples):
+        if v != v:
+            raise SystemExit(f"STOP: NaN timing for {label} batch={i}")
+        if v < 0:
+            raise SystemExit(f"STOP: negative timing for {label} batch={i}: {v}")
+        if v == 0.0:
+            raise SystemExit(f"STOP: zero timing for {label} batch={i}")
+
+
+def _run_correctness(shapes: list[tuple[int, int]], *, dtype, device: str) -> None:
+    for m, n in shapes:
+        a = torch.rand(m, 1, dtype=dtype, device=device)
+        b = torch.rand(1, n, dtype=dtype, device=device)
+        out = broadcast_add(a, b)
+        ref = torch.add(a, b)
+        assert out.shape == ref.shape
+        assert torch.allclose(out, ref, atol=1e-5, rtol=1e-5), (
+            f"correctness fail M={m} N={n}"
+        )
+        buf = torch.empty((m, n), dtype=dtype, device=device)
+        ret = broadcast_add(a, b, out=buf)
+        assert ret is buf
+        assert torch.allclose(buf, ref, atol=1e-5, rtol=1e-5)
+    print(f"correctness: PASS shapes={shapes}")
+
+
+def _measure_alternating(
+    nt_fn,
+    torch_fn,
+    *,
+    warmup: int,
+    repeats: int,
+    inner: int,
+) -> tuple[list[float], list[float]]:
+    for _ in range(warmup):
+        nt_fn()
+        torch_fn()
+    torch.cuda.synchronize()
+
+    nt_batch_ms: list[float] = []
+    torch_batch_ms: list[float] = []
+
+    def _one_batch(fn) -> float:
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(inner):
+            fn()
+        end.record()
+        torch.cuda.synchronize()
+        return float(start.elapsed_time(end))
+
+    for i in range(repeats):
+        if i % 2 == 0:
+            nt_batch_ms.append(_one_batch(nt_fn))
+            torch_batch_ms.append(_one_batch(torch_fn))
+        else:
+            torch_batch_ms.append(_one_batch(torch_fn))
+            nt_batch_ms.append(_one_batch(nt_fn))
+
+    return nt_batch_ms, torch_batch_ms
+
+
+def _per_iter_ms(batch_ms: list[float], inner: int) -> list[float]:
+    return [b / float(inner) for b in batch_ms]
+
+
+def _size_inversion_warnings(size_rows: list[dict]) -> list[dict]:
+    warnings: list[dict] = []
+    for side in ("nt", "torch"):
+        prev_med = None
+        prev_shape = None
+        for row in size_rows:
+            med = float(row[side]["median_ms"])
+            shape = (row["M"], row["N"])
+            if prev_med is not None and med < 0.5 * prev_med:
+                warnings.append(
+                    {
+                        "impl": side,
+                        "prev_shape": prev_shape,
+                        "prev_median_ms": prev_med,
+                        "shape": shape,
+                        "median_ms": med,
+                        "size_inversion_warning": True,
+                    }
+                )
+            prev_med = med
+            prev_shape = shape
+    return warnings
+
+
+def _write_markdown(path: Path, payload: dict) -> None:
+    lines: list[str] = [
+        "# Broadcast-add benchmark (example 01, Phase 2B)",
+        "",
+        f"- generated_at_utc: `{payload['generated_at_utc']}`",
+        f"- device: `{payload['device']}`",
+        f"- torch_version: `{payload['torch_version']}`",
+        f"- ninetoothed_commit: `{payload['ninetoothed_commit']}`",
+        f"- measurement_scope: `{payload['measurement_scope']}`",
+        f"- allocation_inside_timed_region: `{payload['allocation_inside_timed_region']}`",
+        f"- warmup/repeats/inner: `{payload['warmup']}/{payload['repeats']}/{payload['inner_iterations']}`",
+        "",
+        "Bounds: preallocated-output steady-state CUDA Event; single-GPU; "
+        "quantitative claims only for stable/noisy rows; highly_noisy is descriptive only.",
+        "",
+        "| M | N | NT median | Torch median | ratio | NT stab | Torch stab |",
+        "|---|---|----------:|-------------:|------:|---------|------------|",
+    ]
+    for row in payload["sizes"]:
+        lines.append(
+            f"| {row['M']} | {row['N']} | {row['nt']['median_ms']:.6f} | "
+            f"{row['torch']['median_ms']:.6f} | {row['ratio_nt_over_torch']:.4f} | "
+            f"{row['nt']['stability']} | {row['torch']['stability']} |"
+        )
+    lines.append("")
+    if payload["size_inversion_warnings"]:
+        lines.append("Size inversion warnings:")
+        for w in payload["size_inversion_warnings"]:
+            lines.append(
+                f"- {w['impl']}: {w['prev_shape']} median={w['prev_median_ms']:.6f} "
+                f"-> {w['shape']} median={w['median_ms']:.6f}"
+            )
+    else:
+        lines.append("Size inversion warnings: none")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _run_benchmark(
+    *,
+    shapes: list[tuple[int, int]],
+    warmup: int,
+    repeats: int,
+    inner: int,
+    mode: str,
+    json_output: Path | None,
+    markdown_output: Path | None,
+) -> int:
+    if not torch.cuda.is_available():
+        print("STOP: CUDA required for --benchmark/--quick")
+        return 1
+
+    if json_output is not None:
+        _require_fresh_path(json_output)
+    if markdown_output is not None:
+        _require_fresh_path(markdown_output)
+
+    device = "cuda"
+    dtype = torch.float32
+    torch.manual_seed(42)
+
+    _run_correctness(shapes, dtype=dtype, device=device)
+
+    size_rows: list[dict] = []
+    raw_batch_ms: list[dict] = []
+    all_nt_med: list[float] = []
+    all_torch_med: list[float] = []
+    all_ratios: list[float] = []
+
+    print(
+        f"benchmark: mode={mode} dtype={dtype} device={device} "
+        f"warmup={warmup} repeats={repeats} inner={inner} "
+        f"timer=cuda.Event order=alternating "
+        f"measurement_scope=preallocated-output"
+    )
+
+    for m, n in shapes:
+        a = torch.rand(m, 1, dtype=dtype, device=device)
+        b = torch.rand(1, n, dtype=dtype, device=device)
+        nt_out = torch.empty((m, n), dtype=dtype, device=device)
+        torch_out = torch.empty((m, n), dtype=dtype, device=device)
+
+        # Correctness on this exact input before timing.
+        broadcast_add(a, b, out=nt_out)
+        torch.add(a, b, out=torch_out)
+        assert torch.allclose(nt_out, torch_out, atol=1e-5, rtol=1e-5)
+
+        def nt_once(a=a, b=b, nt_out=nt_out):
+            broadcast_add(a, b, out=nt_out)
+
+        def torch_once(a=a, b=b, torch_out=torch_out):
+            torch.add(a, b, out=torch_out)
+
+        nt_batch, torch_batch = _measure_alternating(
+            nt_once,
+            torch_once,
+            warmup=warmup,
+            repeats=repeats,
+            inner=inner,
+        )
+        _validate_samples(f"nt M={m} N={n}", nt_batch, repeats)
+        _validate_samples(f"torch M={m} N={n}", torch_batch, repeats)
+
+        nt_iter = _per_iter_ms(nt_batch, inner)
+        torch_iter = _per_iter_ms(torch_batch, inner)
+        nt_s = _stats(nt_iter)
+        torch_s = _stats(torch_iter)
+        if not (nt_s["p10_ms"] <= nt_s["median_ms"] <= nt_s["p90_ms"]):
+            raise SystemExit(f"STOP: NT percentile order broken M={m} N={n}")
+        if not (torch_s["p10_ms"] <= torch_s["median_ms"] <= torch_s["p90_ms"]):
+            raise SystemExit(f"STOP: Torch percentile order broken M={m} N={n}")
+        ratio = float(nt_s["median_ms"]) / float(torch_s["median_ms"])
+
+        print(
+            f"shape M={m} N={n}: NT median={nt_s['median_ms']:.6f} "
+            f"({nt_s['stability']}) Torch median={torch_s['median_ms']:.6f} "
+            f"({torch_s['stability']}) ratio={ratio:.4f}"
+        )
+
+        size_rows.append(
+            {
+                "M": m,
+                "N": n,
+                "inner_iterations": inner,
+                "nt": nt_s,
+                "torch": torch_s,
+                "ratio_nt_over_torch": ratio,
+            }
+        )
+        raw_batch_ms.append(
+            {
+                "M": m,
+                "N": n,
+                "inner_iterations": inner,
+                "nt_batch_ms": nt_batch,
+                "torch_batch_ms": torch_batch,
+                "nt_per_iter_ms": nt_iter,
+                "torch_per_iter_ms": torch_iter,
+            }
+        )
+        all_nt_med.append(float(nt_s["median_ms"]))
+        all_torch_med.append(float(torch_s["median_ms"]))
+        all_ratios.append(ratio)
+
+    inversions = _size_inversion_warnings(size_rows)
+    for w in inversions:
+        print(
+            f"WARNING size_inversion: {w['impl']} {w['prev_shape']}->"
+            f"{w['shape']} medians {w['prev_median_ms']:.6f}->{w['median_ms']:.6f}"
+        )
+
+    payload = {
+        "generated_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "device": torch.cuda.get_device_name(0),
+        "torch_version": torch.__version__,
+        "ninetoothed_commit": _git_commit(),
+        "dtype": str(dtype).replace("torch.", ""),
+        "measurement_scope": "preallocated-output steady-state CUDA execution",
+        "allocation_inside_timed_region": False,
+        "inner_iterations_constant_across_sizes": True,
+        "warmup": warmup,
+        "repeats": repeats,
+        "inner_iterations": inner,
+        "mode": mode,
+        "sizes": size_rows,
+        "raw_batch_ms": raw_batch_ms,
+        "median_ms": {"nt": all_nt_med, "torch": all_torch_med},
+        "p10_ms": {
+            "nt": [r["nt"]["p10_ms"] for r in size_rows],
+            "torch": [r["torch"]["p10_ms"] for r in size_rows],
+        },
+        "p90_ms": {
+            "nt": [r["nt"]["p90_ms"] for r in size_rows],
+            "torch": [r["torch"]["p90_ms"] for r in size_rows],
+        },
+        "ratio": all_ratios,
+        "spread_ratios": {
+            "nt": [r["nt"]["spread_ratio"] for r in size_rows],
+            "torch": [r["torch"]["spread_ratio"] for r in size_rows],
+        },
+        "stability_labels": {
+            "nt": [r["nt"]["stability"] for r in size_rows],
+            "torch": [r["torch"]["stability"] for r in size_rows],
+        },
+        "size_inversion_warnings": inversions,
+        "bounds": (
+            "single-GPU; preallocated out; quantitative claims only for "
+            "stable/noisy; highly_noisy descriptive only; no cross-device claim"
+        ),
+    }
+
+    # Persist only after measurement completes (never inside timed region).
+    if json_output is not None:
+        json_output.parent.mkdir(parents=True, exist_ok=True)
+        json_output.write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        print(f"wrote JSON: {json_output}")
+    if markdown_output is not None:
+        markdown_output.parent.mkdir(parents=True, exist_ok=True)
+        _write_markdown(markdown_output, payload)
+        print(f"wrote Markdown: {markdown_output}")
+
+    print(
+        "bounds: preallocated-output; single-GPU; quantitative claims only for stable/noisy"
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--benchmark", action="store_true")
+    parser.add_argument("--quick", action="store_true")
+    parser.add_argument("--json-output", type=Path, default=None)
+    parser.add_argument("--markdown-output", type=Path, default=None)
+    args = parser.parse_args()
+
+    if args.benchmark and args.quick:
+        print("STOP: pass only one of --benchmark or --quick")
+        return 1
+
+    if not torch.cuda.is_available():
+        if args.benchmark or args.quick:
+            print("STOP: CUDA required for --benchmark/--quick")
+            return 1
+        print("SKIP: CUDA required for this example kernel")
+        return 0
+
+    dtype = torch.float32
+    device = "cuda"
+    torch.manual_seed(42)
+
+    if not args.benchmark and not args.quick:
+        _run_correctness(list(CORR_SHAPES), dtype=dtype, device=device)
+        return 0
+
+    if args.quick:
+        return _run_benchmark(
+            shapes=list(QUICK_SHAPES),
+            warmup=QUICK_WARMUP,
+            repeats=QUICK_REPEATS,
+            inner=QUICK_INNER,
+            mode="quick",
+            json_output=args.json_output,
+            markdown_output=args.markdown_output,
+        )
+
+    return _run_benchmark(
+        shapes=list(BENCH_SHAPES),
+        warmup=WARMUP,
+        repeats=REPEATS,
+        inner=INNER_ITERATIONS,
+        mode="benchmark",
+        json_output=args.json_output,
+        markdown_output=args.markdown_output,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/competition/ninetoothed-op-dev-skill/examples/03_rowwise_softmax_reduce/benchmark_result.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/03_rowwise_softmax_reduce/benchmark_result.md
@@ -1,0 +1,11 @@
+# Benchmark — example 03
+
+**N/A** for the default correctness demo.
+
+| Reason | Detail |
+|--------|--------|
+| Goal | Validate reduction/block pattern + numerical stability |
+| Perf | Not required unless the task card explicitly asks for D8 |
+| If needed later | Fixed `(M,N)`, warmup ≥5, vs `torch.softmax`, disclose autotuning |
+
+Do not invent ms/iter numbers here.

--- a/skills/competition/ninetoothed-op-dev-skill/examples/03_rowwise_softmax_reduce/changed_files.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/03_rowwise_softmax_reduce/changed_files.md
@@ -1,0 +1,9 @@
+# Changed files — example 03
+
+| Path (under this example) | Purpose |
+|---------------------------|---------|
+| `solution/softmax_kernel.py` | Optional minimal row-softmax demo via `ninetoothed.make` |
+| `tests/test_example_softmax.py` | Optional local correctness vs `torch.softmax` |
+| `verify.py` | One-shot correctness vs `torch.softmax` |
+
+NineToothed `src/` / compiler core: **not modified**. Upstream `tests/test_softmax.py` is the preferred gate when present in the fork.

--- a/skills/competition/ninetoothed-op-dev-skill/examples/03_rowwise_softmax_reduce/correctness_result.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/03_rowwise_softmax_reduce/correctness_result.md
@@ -1,0 +1,21 @@
+# Correctness — example 03
+
+## Command (from NineToothed fork/clone root)
+
+```bash
+export PYTHONPATH="$PWD/src${PYTHONPATH:+:$PYTHONPATH}"
+pytest skills/competition/ninetoothed-op-dev-skill/examples/03_rowwise_softmax_reduce/tests -q
+# or:
+python skills/competition/ninetoothed-op-dev-skill/examples/03_rowwise_softmax_reduce/verify.py
+```
+
+## Result summary
+
+| Item | Value |
+|------|-------|
+| Verdict | **PASS** |
+| NineToothed commit | `ef4c52899f5f836e3d77001b56c3544849cacf2c` |
+| Evidence | `logs/benchmark_phase2b_gate_final_02.log`; Phase 4.1 `logs/phase41_release_acceptance_final_02.log` |
+| Coverage | stable row-wise softmax / max-sum reduce |
+
+Stdout contains `correctness: PASS` on verify; pytest exit code `0`.

--- a/skills/competition/ninetoothed-op-dev-skill/examples/03_rowwise_softmax_reduce/run_log.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/03_rowwise_softmax_reduce/run_log.md
@@ -1,0 +1,34 @@
+# Run log — example 03
+
+## D1 Task card
+
+See `task_card.md`.
+
+## D2–D3 Route + rg
+
+Family: **reduction / block**.
+
+```bash
+cd "$REPO"   # NineToothed root (has src/ninetoothed/)
+rg -n "softmax|ntl.max|ntl.sum" tests/test_softmax.py
+rg -n "tile\(\(1," tests/ -g "*softmax*"
+```
+
+Nearest pattern: `tests/test_softmax.py` (row tile `(1, BLOCK_SIZE)`, max/exp/sum).
+
+## D4 Minimal patch
+
+- Prefer **no** fork `src/` change — run upstream test.
+- Optional local demo: `solution/softmax_kernel.py` + `verify.py` (same arrange-and-apply idea).
+
+## D6 Correctness
+
+```bash
+pytest tests/test_softmax.py -v --tb=short
+# optional local demo:
+python .../examples/03_rowwise_softmax_reduce/verify.py
+```
+
+## D8 Benchmark
+
+**N/A** for the default correctness trajectory (see `benchmark_result.md`).

--- a/skills/competition/ninetoothed-op-dev-skill/examples/03_rowwise_softmax_reduce/run_prompt.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/03_rowwise_softmax_reduce/run_prompt.md
@@ -1,0 +1,13 @@
+Use skill `ninetoothed-op-dev-skill` (SKILL.md decision tree D1–D9).
+
+## Task
+
+Row-wise softmax on `(M,N)` float32 tensors (reduction / block family).
+
+## Required process
+
+1. Write a task card (math, shape, dtype, layout, boundaries, reference).
+2. From the NineToothed repo root, `rg` `tests/test_softmax.py` and reduction patterns **before** coding.
+3. Prefer validating the upstream test; only add a minimal kernel under this example if needed for a local demo.
+4. Run correctness (`pytest tests/test_softmax.py` and/or `verify.py`).
+5. Do not invent APIs; do not edit compiler core.

--- a/skills/competition/ninetoothed-op-dev-skill/examples/03_rowwise_softmax_reduce/solution/softmax_kernel.py
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/03_rowwise_softmax_reduce/solution/softmax_kernel.py
@@ -1,0 +1,35 @@
+"""Minimal row-wise softmax kernel for example 03 (fork-runnable demo)."""
+
+from __future__ import annotations
+
+import torch
+
+import ninetoothed
+import ninetoothed.language as ntl
+from ninetoothed import Symbol, Tensor
+
+BLOCK_SIZE = Symbol("BLOCK_SIZE", constexpr=True)
+
+
+def arrangement(input, output, BLOCK_SIZE=BLOCK_SIZE):
+    return input.tile((1, BLOCK_SIZE)), output.tile((1, BLOCK_SIZE))
+
+
+def application(input, output):
+    input_loaded = input
+    row_minus_max = input_loaded - ntl.max(input_loaded)
+    numerator = ntl.exp(row_minus_max)
+    denominator = ntl.sum(numerator)
+    output = numerator / denominator  # noqa: F841
+
+
+_tensors = (Tensor(2, other=float("-inf")), Tensor(2))
+_kernel = ninetoothed.make(arrangement, application, _tensors)
+
+
+def softmax(input: torch.Tensor, *, block_size: int | None = None) -> torch.Tensor:
+    if block_size is None:
+        block_size = int(input.shape[-1])
+    output = torch.empty_like(input)
+    _kernel(input, output, BLOCK_SIZE=block_size)
+    return output

--- a/skills/competition/ninetoothed-op-dev-skill/examples/03_rowwise_softmax_reduce/task.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/03_rowwise_softmax_reduce/task.md
@@ -1,0 +1,32 @@
+# Example 03 — reduction / block (row-wise softmax)
+
+## Task description
+
+Implement or validate row-wise softmax with NineToothed reduction/block patterns:
+
+\[
+\mathrm{out}[i,:] = \mathrm{softmax}(\mathrm{in}[i,:])
+\]
+
+Stable form: subtract row max, then `exp` / row-sum. Shapes `(M,N)` → `(M,N)`, dtype `float32`.
+
+## Workflow (must follow SKILL.md D1–D9)
+
+1. **Task card** → see `task_card.md`
+2. **Route** → reduction / block (`references/04_*`)
+3. **`rg` in repo** (from `--repo-root`):
+
+```bash
+rg -n "softmax|ntl.max|ntl.sum|ntl.exp" tests/test_softmax.py
+rg -n "def arrangement|tile\(\(1," tests/ -g "*.py" | head
+```
+
+4. **Prefer upstream first** → if `tests/test_softmax.py` already covers the op, run it before writing a new kernel
+5. **Minimal demo** (optional) → `solution/softmax_kernel.py` + `verify.py`
+6. **pytest** → see `correctness_result.md`
+7. **Benchmark** → N/A for default correctness demo (see `benchmark_result.md`)
+
+## Deliverables in this directory
+
+`task_card.md`, `run_prompt.md`, `run_log.md`, `changed_files.md`,
+`correctness_result.md`, `benchmark_result.md`, `solution/`, `verify.py`.

--- a/skills/competition/ninetoothed-op-dev-skill/examples/03_rowwise_softmax_reduce/task_card.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/03_rowwise_softmax_reduce/task_card.md
@@ -1,0 +1,14 @@
+# Task card — row-wise softmax
+
+| Field | Value |
+|-------|-------|
+| Math | row-wise softmax (stable: max → exp → sum) |
+| Shape | input `(M,N)` → output `(M,N)` |
+| dtype | float32 |
+| Broadcast | N/A |
+| Layout | contiguous inputs/outputs |
+| Boundaries | M,N ≥ 1; numerical stability (max before exp); CUDA preferred |
+| Reference | `tests/test_softmax.py`; `torch.softmax(..., dim=-1)` |
+| Tests | upstream `pytest tests/test_softmax.py` and/or `verify.py` |
+| Benchmark | N/A for default demo (correctness-only) |
+| Unsupported | claiming peak perf without D8; rewriting compiler core |

--- a/skills/competition/ninetoothed-op-dev-skill/examples/03_rowwise_softmax_reduce/tests/test_example_softmax.py
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/03_rowwise_softmax_reduce/tests/test_example_softmax.py
@@ -1,0 +1,25 @@
+"""Correctness test for example 03 row-wise softmax (optional local demo)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+_EX = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_EX / "solution"))
+
+from softmax_kernel import softmax  # noqa: E402
+
+
+def test_softmax_matches_torch():
+    if not torch.cuda.is_available():
+        pytest.skip("NineToothed kernels typically require CUDA; skip CPU")
+    m, n = 32, 64
+    x = torch.rand((m, n), dtype=torch.float32, device="cuda")
+    out = softmax(x)
+    expected = torch.softmax(x, dim=-1)
+    assert out.shape == expected.shape
+    assert torch.allclose(out, expected, atol=1e-5, rtol=1e-5)

--- a/skills/competition/ninetoothed-op-dev-skill/examples/03_rowwise_softmax_reduce/verify.py
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/03_rowwise_softmax_reduce/verify.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Fork-runnable verify for example 03 (correctness vs torch.softmax)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import torch
+
+_EX = Path(__file__).resolve().parent
+sys.path.insert(0, str(_EX / "solution"))
+
+from softmax_kernel import softmax  # noqa: E402
+
+
+def main() -> int:
+    if not torch.cuda.is_available():
+        print("SKIP: CUDA required for this example kernel")
+        return 0
+
+    device = "cuda"
+    m, n = 64, 128
+    x = torch.rand((m, n), dtype=torch.float32, device=device)
+    out = softmax(x)
+    expected = torch.softmax(x, dim=-1)
+    assert out.shape == expected.shape
+    assert torch.allclose(out, expected, atol=1e-5, rtol=1e-5)
+    max_err = (out - expected).abs().max().item()
+    print(f"correctness: PASS shape={tuple(out.shape)} max_err={max_err:.2e}")
+    print(
+        "note: prefer upstream `pytest tests/test_softmax.py` when available in the fork"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/competition/ninetoothed-op-dev-skill/examples/05_non_contiguous_transpose_add/benchmark_result.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/05_non_contiguous_transpose_add/benchmark_result.md
@@ -1,0 +1,11 @@
+# Benchmark — example 05
+
+**N/A** for this layout / stride demo.
+
+| Reason | Detail |
+|--------|--------|
+| Goal | Prove non-contiguous inputs work without illegal materialization |
+| Perf | Not in scope unless a later task card requires D8 |
+| If needed later | Same strided shapes, warmup ≥5, fair baseline, disclose layout |
+
+Do not invent ms/iter numbers here.

--- a/skills/competition/ninetoothed-op-dev-skill/examples/05_non_contiguous_transpose_add/changed_files.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/05_non_contiguous_transpose_add/changed_files.md
@@ -1,0 +1,9 @@
+# Changed files — example 05
+
+| Path (under this example) | Purpose |
+|---------------------------|---------|
+| `solution/strided_add_kernel.py` | Minimal strided add via `ninetoothed.make` |
+| `tests/test_example_strided_add.py` | Non-contiguous asserts + vs `torch.add` |
+| `verify.py` | One-shot correctness |
+
+NineToothed `src/` / compiler core: **not modified**.

--- a/skills/competition/ninetoothed-op-dev-skill/examples/05_non_contiguous_transpose_add/correctness_result.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/05_non_contiguous_transpose_add/correctness_result.md
@@ -1,0 +1,21 @@
+# Correctness — example 05
+
+## Command (from NineToothed fork/clone root)
+
+```bash
+export PYTHONPATH="$PWD/src${PYTHONPATH:+:$PYTHONPATH}"
+pytest skills/competition/ninetoothed-op-dev-skill/examples/05_non_contiguous_transpose_add/tests -q
+# or:
+python skills/competition/ninetoothed-op-dev-skill/examples/05_non_contiguous_transpose_add/verify.py
+```
+
+## Result summary
+
+| Item | Value |
+|------|-------|
+| Verdict | **PASS** |
+| NineToothed commit | `ef4c52899f5f836e3d77001b56c3544849cacf2c` |
+| Evidence | `logs/benchmark_phase2b_gate_final_02.log`; Phase 4.1 `logs/phase41_release_acceptance_final_02.log` |
+| Coverage | non-contiguous / stride inputs; no silent `.contiguous()` materialization |
+
+Stdout contains `correctness: PASS` on verify; pytest exit code `0`.

--- a/skills/competition/ninetoothed-op-dev-skill/examples/05_non_contiguous_transpose_add/run_log.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/05_non_contiguous_transpose_add/run_log.md
@@ -1,0 +1,33 @@
+# Run log — example 05
+
+## D1 Task card
+
+See `task_card.md` (layout branch mandatory).
+
+## D2–D3 Route + rg
+
+Family: **layout / stride**.
+
+```bash
+cd "$REPO"
+rg -n "is_contiguous|stride|as_strided" tests/test_clone.py tests/test_data_ptr.py
+rg -n "ninetoothed.make|arrangement" tests/test_add.py
+```
+
+Nearest patterns: clone/data_ptr layout tests; elementwise `make` from add tests.
+
+## D4–D5 Minimal patch + layout branch
+
+- `solution/strided_add_kernel.py` — tile + add; no `.contiguous()` in the hot path
+- `tests/test_example_strided_add.py` — transpose / empty_strided views + asserts
+
+## D6 Correctness
+
+```bash
+python .../examples/05_non_contiguous_transpose_add/verify.py
+pytest .../examples/05_non_contiguous_transpose_add/tests -v --tb=short
+```
+
+## D8 Benchmark
+
+**N/A** — this example gates layout contract, not performance.

--- a/skills/competition/ninetoothed-op-dev-skill/examples/05_non_contiguous_transpose_add/run_prompt.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/05_non_contiguous_transpose_add/run_prompt.md
@@ -1,0 +1,13 @@
+Use skill `ninetoothed-op-dev-skill` (SKILL.md decision tree D1–D9, especially **D5**).
+
+## Task
+
+Elementwise add on non-contiguous (e.g. transposed) float32 CUDA tensors.
+
+## Required process
+
+1. Write a task card with layout = non-contiguous / stride.
+2. From the NineToothed repo root, `rg` `tests/test_clone.py` / stride patterns **before** coding.
+3. Add a minimal `ninetoothed.make` kernel + pytest under this example; tests must assert non-contiguous inputs.
+4. Do **not** call `.contiguous()` unless the card explicitly allows materialization.
+5. Run correctness; skip benchmark unless the task asks for D8.

--- a/skills/competition/ninetoothed-op-dev-skill/examples/05_non_contiguous_transpose_add/solution/strided_add_kernel.py
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/05_non_contiguous_transpose_add/solution/strided_add_kernel.py
@@ -1,0 +1,31 @@
+"""Minimal strided add kernel for example 05 (fork-runnable demo)."""
+
+from __future__ import annotations
+
+import torch
+
+import ninetoothed
+from ninetoothed import Tensor
+
+
+def arrangement(lhs, rhs, output):
+    block_shape = (ninetoothed.block_size(), ninetoothed.block_size())
+    return (
+        lhs.tile(block_shape),
+        rhs.tile(block_shape),
+        output.tile(block_shape),
+    )
+
+
+def application(lhs, rhs, output):
+    output = lhs + rhs  # noqa: F841
+
+
+_kernel = ninetoothed.make(arrangement, application, (Tensor(2), Tensor(2), Tensor(2)))
+
+
+def add_strided(lhs: torch.Tensor, rhs: torch.Tensor) -> torch.Tensor:
+    """Add two possibly non-contiguous tensors. Does not call .contiguous()."""
+    output = torch.empty_like(lhs)
+    _kernel(lhs, rhs, output)
+    return output

--- a/skills/competition/ninetoothed-op-dev-skill/examples/05_non_contiguous_transpose_add/task.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/05_non_contiguous_transpose_add/task.md
@@ -1,0 +1,31 @@
+# Example 05 — layout / stride (non-contiguous transpose add)
+
+## Task description
+
+Add two **non-contiguous** CUDA tensors with NineToothed without illegally calling `.contiguous()`:
+
+\[
+\mathrm{out} = a + b
+\]
+
+Inputs are strided views (e.g. transpose-derived). Tests must assert `not a.is_contiguous()`.
+
+## Workflow (must follow SKILL.md D1–D9)
+
+1. **Task card** → see `task_card.md` (layout ≠ contiguous-only)
+2. **Route** → layout / stride (`references/05_*`)
+3. **`rg` in repo** (from `--repo-root`):
+
+```bash
+rg -n "is_contiguous|stride|as_strided|transpose" tests/test_clone.py tests/test_data_ptr.py
+rg -n "def arrangement|ninetoothed.make" tests/test_add.py
+```
+
+4. **Minimal implementation** → `solution/strided_add_kernel.py` + `tests/test_example_strided_add.py`
+5. **pytest / verify** → see `correctness_result.md`
+6. **Benchmark** → N/A (layout contract demo; see `benchmark_result.md`)
+
+## Deliverables in this directory
+
+`task_card.md`, `run_prompt.md`, `run_log.md`, `changed_files.md`,
+`correctness_result.md`, `benchmark_result.md`, `solution/`, `tests/`, `verify.py`.

--- a/skills/competition/ninetoothed-op-dev-skill/examples/05_non_contiguous_transpose_add/task_card.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/05_non_contiguous_transpose_add/task_card.md
@@ -1,0 +1,14 @@
+# Task card — non-contiguous transpose add
+
+| Field | Value |
+|-------|-------|
+| Math | `out = a + b` |
+| Shape | 2-D views, e.g. `(M,N)` matching after transpose view |
+| dtype | float32 |
+| Broadcast | N/A |
+| Layout | **non-contiguous** inputs (transpose / empty_strided); out may be contiguous |
+| Boundaries | `assert not a.is_contiguous()` (and b); no blind `.contiguous()` |
+| Reference | `tests/test_clone.py`, `tests/test_data_ptr.py`; `torch.add` on same views |
+| Tests | `tests/test_example_strided_add.py` + `verify.py` |
+| Benchmark | N/A (layout correctness, not perf) |
+| Unsupported | fixing layout by materializing with `.contiguous()` unless card allows |

--- a/skills/competition/ninetoothed-op-dev-skill/examples/05_non_contiguous_transpose_add/tests/test_example_strided_add.py
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/05_non_contiguous_transpose_add/tests/test_example_strided_add.py
@@ -1,0 +1,49 @@
+"""Correctness test for example 05 non-contiguous add."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+_EX = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_EX / "solution"))
+
+from strided_add_kernel import add_strided  # noqa: E402
+
+
+def _device() -> str:
+    return "cuda" if torch.cuda.is_available() else "cpu"
+
+
+def test_transpose_view_add():
+    device = _device()
+    if device == "cpu":
+        pytest.skip("NineToothed kernels typically require CUDA; skip CPU")
+    m, n = 64, 48
+    base_a = torch.randn(m, n, device=device)
+    base_b = torch.randn(m, n, device=device)
+    lhs = base_a.t().contiguous().t()
+    rhs = base_b.t().contiguous().t()
+    assert not lhs.is_contiguous()
+    assert not rhs.is_contiguous()
+    out = add_strided(lhs, rhs)
+    ref = lhs + rhs
+    assert torch.allclose(out, ref, atol=1e-5, rtol=1e-5)
+
+
+def test_empty_strided_add():
+    device = _device()
+    if device == "cpu":
+        pytest.skip("NineToothed kernels typically require CUDA; skip CPU")
+    shape = (64, 48)
+    strides = (96, 1)
+    lhs = torch.empty_strided(shape, strides, device=device)
+    rhs = torch.empty_strided(shape, strides, device=device)
+    lhs.copy_(torch.randn(shape, device=device))
+    rhs.copy_(torch.randn(shape, device=device))
+    assert not lhs.is_contiguous()
+    out = add_strided(lhs, rhs)
+    assert torch.allclose(out, lhs + rhs, atol=1e-5, rtol=1e-5)

--- a/skills/competition/ninetoothed-op-dev-skill/examples/05_non_contiguous_transpose_add/verify.py
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/05_non_contiguous_transpose_add/verify.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Fork-runnable verify for example 05 (non-contiguous add)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import torch
+
+_EX = Path(__file__).resolve().parent
+sys.path.insert(0, str(_EX / "solution"))
+
+from strided_add_kernel import add_strided  # noqa: E402
+
+
+def check_transpose_add(device: str = "cuda") -> None:
+    m, n = 64, 48
+    base_a = torch.randn(m, n, device=device)
+    base_b = torch.randn(m, n, device=device)
+    lhs = base_a.t().contiguous().t()
+    rhs = base_b.t().contiguous().t()
+    assert not lhs.is_contiguous()
+    assert not rhs.is_contiguous()
+    out = add_strided(lhs, rhs)
+    expected = lhs + rhs
+    assert out.shape == expected.shape
+    assert torch.allclose(out, expected, atol=1e-5, rtol=1e-5)
+    print(
+        f"correctness: PASS shape={tuple(out.shape)} "
+        f"lhs_stride={tuple(lhs.stride())} contiguous={lhs.is_contiguous()}"
+    )
+
+
+def check_empty_strided(device: str = "cuda") -> None:
+    shape = (64, 48)
+    strides = (96, 1)
+    lhs = torch.empty_strided(shape, strides, device=device)
+    rhs = torch.empty_strided(shape, strides, device=device)
+    lhs.copy_(torch.randn(shape, device=device))
+    rhs.copy_(torch.randn(shape, device=device))
+    assert not lhs.is_contiguous()
+    out = add_strided(lhs, rhs)
+    assert torch.allclose(out, lhs + rhs, atol=1e-5, rtol=1e-5)
+    print(f"correctness: PASS empty_strided strides={strides}")
+
+
+def main() -> int:
+    if not torch.cuda.is_available():
+        print("SKIP: CUDA required for this example kernel")
+        return 0
+    check_transpose_add()
+    check_empty_strided()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/benchmark_result.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/benchmark_result.md
@@ -1,0 +1,46 @@
+# Benchmark — example 09
+
+## When to run
+
+Only after correctness PASS at **each** `BLOCK_SIZE` (SKILL.md D8).
+
+## Commands
+
+```bash
+python skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/verify.py \
+  --benchmark \
+  --json-output logs/benchmark/final-runtime-02/block_size.json \
+  --markdown-output logs/benchmark/final-runtime-02/block_size.md
+```
+
+## Protocol (Phase 2B)
+
+| Item | Value |
+|------|-------|
+| Op | 1-D add, constexpr `BLOCK_SIZE` (no `meta=True`) |
+| Sizes | `N ∈ {98432, 1048576, 4194304}` |
+| Configs | `BLOCK_SIZE ∈ {32, 256, 1024}` |
+| Timer | `torch.cuda.Event(enable_timing=True)` |
+| Warmup / repeats / inner | **30 / 30 / 100** |
+| Stats | median/p10/p90; spread_ratio; stability; fastest **per size** |
+
+## Recorded results (`logs/benchmark/final-runtime-02/block_size.md`)
+
+- device: `NVIDIA GeForce RTX 5070 Ti Laptop GPU`
+- ninetoothed_commit: `ef4c52899f5f836e3d77001b56c3544849cacf2c`
+- size_dependence: yes
+
+| N | BLOCK_SIZE | median ms | p10 | p90 | spread | stability |
+|---|------------|----------:|----:|----:|-------:|-----------|
+| 98432 | 32 | 0.125983 | 0.049237 | 0.157446 | 1.250 | stable |
+| 98432 | 256 | 0.130278 | 0.078267 | 0.147752 | 1.134 | stable |
+| 98432 | 1024 | 0.128404 | 0.075815 | 0.150004 | 1.168 | stable |
+| 1048576 | 32 | 0.087471 | 0.055216 | 0.107493 | 1.229 | stable |
+| 1048576 | 256 | 0.072024 | 0.058294 | 0.114206 | 1.586 | stable |
+| 1048576 | 1024 | 0.071493 | 0.032741 | 0.104581 | 1.463 | stable |
+| 4194304 | 32 | 0.557959 | 0.528783 | 0.594734 | 1.066 | stable |
+| 4194304 | 256 | 0.133946 | 0.121333 | 0.164150 | 1.225 | stable |
+| 4194304 | 1024 | 0.134427 | 0.114178 | 0.156808 | 1.166 | stable |
+
+Fastest by size (median): N=98432→32; N=1048576→1024; N=4194304→256.  
+At N=4,194,304, BS=32 median is ~4.16× slower than BS=256/1024.

--- a/skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/changed_files.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/changed_files.md
@@ -1,0 +1,9 @@
+# Changed files — example 09
+
+| Path (under this example) | Purpose |
+|---------------------------|---------|
+| `solution/add_tunable.py` | 1-D add with constexpr `BLOCK_SIZE` |
+| `tests/test_example_block_size.py` | Correctness at multiple block sizes |
+| `verify.py` | Correctness then D8 micro-bench |
+
+NineToothed `src/` / compiler core: **not modified**.

--- a/skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/correctness_result.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/correctness_result.md
@@ -1,0 +1,21 @@
+# Correctness — example 09
+
+## Command (from NineToothed fork/clone root)
+
+```bash
+export PYTHONPATH="$PWD/src${PYTHONPATH:+:$PYTHONPATH}"
+pytest skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/tests -q
+# or:
+python skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/verify.py
+```
+
+## Result summary
+
+| Item | Value |
+|------|-------|
+| Verdict | **PASS** |
+| NineToothed commit | `ef4c52899f5f836e3d77001b56c3544849cacf2c` |
+| Evidence | `logs/benchmark_phase2b_gate_final_02.log`; Phase 4.1 `logs/phase41_release_acceptance_final_02.log` |
+| Coverage | correctness for `BLOCK_SIZE` ∈ {32, 256, 1024} before any timing claim |
+
+Stdout contains `correctness: PASS` on verify; pytest exit code `0`.

--- a/skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/failure_diagnosis.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/failure_diagnosis.md
@@ -1,0 +1,21 @@
+# Failure diagnosis — example 09
+
+If timing looks absurd or percentiles collapse:
+
+1. **Symptom** — paste `--benchmark` JSON (`raw_batch_ms`, median/p10/p90, `stability`)
+2. **Hypothesis** — allocation inside timed region / `meta=True` / cold compile / GPU contention
+3. **Minimal fix** — keep constexpr `BLOCK_SIZE`; preallocate `out=`; warmup ≥30 **per** block; keep all 30 batches (no outlier drops)
+4. **Re-verify** — new results directory (never overwrite prior JSON/MD)
+
+## Stability labels
+
+- `spread_ratio = p90 / median`
+- `<=2` stable; `<=5` noisy; `>5` highly_noisy
+- Keep all batches; quantitative claims only for stable/noisy
+
+## Size dependence / inversion
+
+- Fastest block differing across N → conclude **规模依赖**
+- Larger-N median < 50% of previous size median → `size_inversion_warning` (warn only)
+
+See SKILL.md D7–D8 and `benchmark_result.md`.

--- a/skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/run_log.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/run_log.md
@@ -1,0 +1,35 @@
+# Run log — example 09
+
+## D1 Task card
+
+See `task_card.md`.
+
+## D2–D3 Route + rg
+
+Family: **perf / diagnosis**.
+
+```bash
+cd "$REPO"
+rg -n "BLOCK_SIZE|constexpr|meta=True" tests/test_generation.py
+rg -n "Symbol\\(\"BLOCK" tests/test_add.py tests/ -g "*.py" | head
+```
+
+Nearest patterns: constexpr `BLOCK_SIZE` tiling; avoid undisclosed `meta=True` when comparing configs.
+
+## D4–D6 Minimal patch + correctness
+
+- `solution/add_tunable.py` — 1-D add with constexpr `BLOCK_SIZE`
+- `tests/test_example_block_size.py` — correctness at 32 and 1024
+
+```bash
+pytest .../examples/09_performance_regression_fix/tests -v --tb=short
+```
+
+## D8 Benchmark
+
+```bash
+python .../examples/09_performance_regression_fix/verify.py
+```
+
+Fixed `N`, warmup, timed iters, print ms/iter for both BLOCK sizes + slowdown ratio.
+If ratio is absurd, see `failure_diagnosis.md`.

--- a/skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/run_prompt.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/run_prompt.md
@@ -1,0 +1,13 @@
+Use skill `ninetoothed-op-dev-skill` (SKILL.md decision tree D1–D9, especially **D8**).
+
+## Task
+
+Document a block-size performance regression: same add kernel at `BLOCK_SIZE=32` vs `1024`.
+
+## Required process
+
+1. Write a task card; `rg` nearest tunable / generation tests before coding.
+2. Correctness PASS at **every** `BLOCK_SIZE` you will time.
+3. Then benchmark: fixed inputs, warmup ≥5, repeated measurement, fair baseline, bounded conclusion.
+4. If ratios look absurd, follow `failure_diagnosis.md` (autotuning / unfair baseline).
+5. Do not claim peak performance under autotuning without disclosure.

--- a/skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/solution/add_tunable.py
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/solution/add_tunable.py
@@ -1,0 +1,48 @@
+"""1-D add with tunable BLOCK_SIZE for example 09 (fork-runnable demo)."""
+
+from __future__ import annotations
+
+import torch
+
+import ninetoothed
+from ninetoothed import Symbol, Tensor
+
+BLOCK_SIZE = Symbol("BLOCK_SIZE", constexpr=True)
+
+
+def arrangement(lhs, rhs, output, BLOCK_SIZE=BLOCK_SIZE):
+    return (
+        lhs.tile((BLOCK_SIZE,)),
+        rhs.tile((BLOCK_SIZE,)),
+        output.tile((BLOCK_SIZE,)),
+    )
+
+
+def application(lhs, rhs, output):
+    output = lhs + rhs  # noqa: F841
+
+
+_kernel = ninetoothed.make(arrangement, application, tuple(Tensor(1) for _ in range(3)))
+
+
+def add(
+    lhs: torch.Tensor,
+    rhs: torch.Tensor,
+    *,
+    block_size: int,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if out is None:
+        out = torch.empty_like(lhs)
+
+    if out.shape != lhs.shape:
+        raise ValueError(
+            f"out shape must be {tuple(lhs.shape)}, got {tuple(out.shape)}"
+        )
+    if out.dtype != lhs.dtype:
+        raise ValueError(f"out dtype must be {lhs.dtype}, got {out.dtype}")
+    if out.device != lhs.device:
+        raise ValueError(f"out device must be {lhs.device}, got {out.device}")
+
+    _kernel(lhs, rhs, out, BLOCK_SIZE=block_size)
+    return out

--- a/skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/task.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/task.md
@@ -1,0 +1,27 @@
+# Example 09 — performance / diagnosis (block-size regression)
+
+## Task description
+
+Compare the **same** elementwise-add kernel under two fixed `BLOCK_SIZE` values
+(e.g. 32 vs 1024) with a fair micro-benchmark **after** correctness (SKILL.md **D8**).
+
+## Workflow (must follow SKILL.md D1–D9)
+
+1. **Task card** → see `task_card.md`
+2. **Route** → perf / diagnosis (`references/07_*`)
+3. **`rg` in repo** (from `--repo-root`):
+
+```bash
+rg -n "BLOCK_SIZE|constexpr|meta=True" tests/test_generation.py tests/test_add.py
+rg -n "Symbol\\(\"BLOCK" tests/ -g "*.py" | head
+```
+
+4. **Minimal implementation** → `solution/add_tunable.py` + `tests/test_example_block_size.py`
+5. **Correctness first** at **each** `BLOCK_SIZE` to be timed
+6. **Benchmark** → `verify.py` (see `benchmark_result.md`); diagnose absurd ratios in `failure_diagnosis.md`
+
+## Deliverables in this directory
+
+`task_card.md`, `run_prompt.md`, `run_log.md`, `changed_files.md`,
+`correctness_result.md`, `benchmark_result.md`, `failure_diagnosis.md`,
+`solution/`, `tests/`, `verify.py`.

--- a/skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/task_card.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/task_card.md
@@ -1,0 +1,14 @@
+# Task card — block-size performance regression
+
+| Field | Value |
+|-------|-------|
+| Math | 1-D elementwise `out = a + b` |
+| Shape | fixed `N` (document in bench output; default 98432) |
+| dtype | float32 |
+| Broadcast | N/A |
+| Layout | contiguous |
+| Boundaries | correctness PASS at each `BLOCK_SIZE` before timing |
+| Reference | `tests/test_generation.py`; `references/07_benchmark_patterns.md` |
+| Tests | `tests/test_example_block_size.py` + `verify.py` |
+| Benchmark | D8: warmup ≥5, repeated timing, compare BLOCK 32 vs 1024 |
+| Unsupported | peak-perf claims under undisclosed `meta=True` autotuning |

--- a/skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/tests/test_example_block_size.py
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/tests/test_example_block_size.py
@@ -1,0 +1,49 @@
+"""Correctness test for example 09 block-size configs."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+_EX = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_EX / "solution"))
+
+from add_tunable import add  # noqa: E402
+
+
+@pytest.mark.parametrize("block_size", [32, 1024])
+def test_add_block_size_matches_torch(block_size: int):
+    if not torch.cuda.is_available():
+        pytest.skip("NineToothed kernels typically require CUDA; skip CPU")
+    n = 4096
+    lhs = torch.rand(n, dtype=torch.float32, device="cuda")
+    rhs = torch.rand(n, dtype=torch.float32, device="cuda")
+    out = add(lhs, rhs, block_size=block_size)
+    assert torch.allclose(out, lhs + rhs, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.parametrize("block_size", [32, 256, 1024])
+def test_add_reuses_out_buffer(block_size: int):
+    if not torch.cuda.is_available():
+        pytest.skip("NineToothed kernels typically require CUDA; skip CPU")
+    n = 4096
+    lhs = torch.rand(n, dtype=torch.float32, device="cuda")
+    rhs = torch.rand(n, dtype=torch.float32, device="cuda")
+    out_buffer = torch.empty_like(lhs)
+    returned = add(lhs, rhs, block_size=block_size, out=out_buffer)
+    assert returned is out_buffer
+    assert torch.allclose(out_buffer, lhs + rhs, atol=1e-5, rtol=1e-5)
+
+
+def test_add_rejects_bad_out_shape():
+    if not torch.cuda.is_available():
+        pytest.skip("NineToothed kernels typically require CUDA; skip CPU")
+    n = 4096
+    lhs = torch.rand(n, dtype=torch.float32, device="cuda")
+    rhs = torch.rand(n, dtype=torch.float32, device="cuda")
+    bad = torch.empty((n + 1,), dtype=torch.float32, device="cuda")
+    with pytest.raises(ValueError, match="out shape"):
+        add(lhs, rhs, block_size=256, out=bad)

--- a/skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/verify.py
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/09_performance_regression_fix/verify.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""Fork-runnable verify for example 09 (correctness-first; preallocated-out bench)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import torch
+
+_EX = Path(__file__).resolve().parent
+sys.path.insert(0, str(_EX / "solution"))
+
+from add_tunable import add  # noqa: E402
+
+BENCH_SIZES = (98_432, 1_048_576, 4_194_304)
+CORR_SIZES = (16_384, 65_536, 98_432)
+QUICK_SIZES = (16_384, 65_536)
+BLOCK_SIZES = (32, 256, 1024)
+CORR_BLOCKS = (32, 1024)
+
+WARMUP = 30
+REPEATS = 30
+INNER_ITERATIONS = 100
+QUICK_WARMUP = 3
+QUICK_REPEATS = 3
+QUICK_INNER = 8
+
+
+def _percentile(sorted_vals: list[float], p: float) -> float:
+    if not sorted_vals:
+        return float("nan")
+    k = (len(sorted_vals) - 1) * (p / 100.0)
+    f = int(k)
+    c = min(f + 1, len(sorted_vals) - 1)
+    if f == c:
+        return sorted_vals[f]
+    return sorted_vals[f] * (c - k) + sorted_vals[c] * (k - f)
+
+
+def _stats(samples: list[float]) -> dict[str, float | str]:
+    ordered = sorted(samples)
+    med = float(statistics.median(ordered))
+    p10 = float(_percentile(ordered, 10))
+    p90 = float(_percentile(ordered, 90))
+    spread = float(p90 / med) if med > 0 else float("inf")
+    if spread <= 2:
+        label = "stable"
+    elif spread <= 5:
+        label = "noisy"
+    else:
+        label = "highly_noisy"
+    return {
+        "median_ms": med,
+        "p10_ms": p10,
+        "p90_ms": p90,
+        "spread_ratio": spread,
+        "stability": label,
+    }
+
+
+def _git_commit() -> str:
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=Path.cwd(),
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        return out.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return "unknown"
+
+
+def _require_fresh_path(path: Path) -> None:
+    if path.exists():
+        raise SystemExit(f"STOP: output already exists (refusing overwrite): {path}")
+
+
+def _validate_samples(label: str, samples: list[float], expected: int) -> None:
+    if len(samples) != expected:
+        raise SystemExit(
+            f"STOP: incomplete batches for {label}: {len(samples)} != {expected}"
+        )
+    for i, v in enumerate(samples):
+        if v != v:
+            raise SystemExit(f"STOP: NaN timing for {label} batch={i}")
+        if v < 0:
+            raise SystemExit(f"STOP: negative timing for {label} batch={i}: {v}")
+        if v == 0.0:
+            raise SystemExit(f"STOP: zero timing for {label} batch={i}")
+
+
+def _run_correctness(
+    sizes: list[int],
+    blocks: list[int],
+    *,
+    dtype,
+    device: str,
+) -> None:
+    for size in sizes:
+        lhs = torch.rand(size, dtype=dtype, device=device)
+        rhs = torch.rand(size, dtype=dtype, device=device)
+        ref = lhs + rhs
+        for bs in blocks:
+            out = add(lhs, rhs, block_size=bs)
+            assert torch.allclose(out, ref, atol=1e-5, rtol=1e-5), (
+                f"correctness fail size={size} BLOCK_SIZE={bs}"
+            )
+            buf = torch.empty_like(lhs)
+            ret = add(lhs, rhs, block_size=bs, out=buf)
+            assert ret is buf
+            assert torch.allclose(buf, ref, atol=1e-5, rtol=1e-5)
+    print(f"correctness: PASS sizes={sizes} blocks={blocks}")
+
+
+def _measure_rotated_blocks(
+    make_fn,
+    blocks: list[int],
+    *,
+    warmup: int,
+    repeats: int,
+    inner: int,
+) -> dict[int, list[float]]:
+    for bs in blocks:
+        fn = make_fn(bs)
+        for _ in range(warmup):
+            fn()
+    torch.cuda.synchronize()
+
+    batch_ms: dict[int, list[float]] = {bs: [] for bs in blocks}
+
+    def _one_batch(fn) -> float:
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(inner):
+            fn()
+        end.record()
+        torch.cuda.synchronize()
+        return float(start.elapsed_time(end))
+
+    n_blocks = len(blocks)
+    for i in range(repeats):
+        order = blocks[i % n_blocks :] + blocks[: i % n_blocks]
+        for bs in order:
+            batch_ms[bs].append(_one_batch(make_fn(bs)))
+
+    return batch_ms
+
+
+def _per_iter_ms(batch_ms: list[float], inner: int) -> list[float]:
+    return [b / float(inner) for b in batch_ms]
+
+
+def _size_inversion_warnings(size_rows: list[dict], blocks: list[int]) -> list[dict]:
+    warnings: list[dict] = []
+    for bs in blocks:
+        key = str(bs)
+        prev_med = None
+        prev_n = None
+        for row in size_rows:
+            med = float(row["blocks"][key]["median_ms"])
+            n = int(row["N"])
+            if prev_med is not None and med < 0.5 * prev_med:
+                warnings.append(
+                    {
+                        "block_size": bs,
+                        "prev_N": prev_n,
+                        "prev_median_ms": prev_med,
+                        "N": n,
+                        "median_ms": med,
+                        "size_inversion_warning": True,
+                    }
+                )
+            prev_med = med
+            prev_n = n
+    return warnings
+
+
+def _write_markdown(path: Path, payload: dict) -> None:
+    lines: list[str] = [
+        "# BLOCK_SIZE benchmark (example 09, Phase 2B)",
+        "",
+        f"- generated_at_utc: `{payload['generated_at_utc']}`",
+        f"- device: `{payload['device']}`",
+        f"- torch_version: `{payload['torch_version']}`",
+        f"- ninetoothed_commit: `{payload['ninetoothed_commit']}`",
+        f"- measurement_scope: `{payload['measurement_scope']}`",
+        f"- allocation_inside_timed_region: `{payload['allocation_inside_timed_region']}`",
+        f"- warmup/repeats/inner: `{payload['warmup']}/{payload['repeats']}/{payload['inner_iterations']}`",
+        f"- size_dependence: `{payload['size_dependence']}`",
+        "",
+        "Bounds: constexpr BLOCK_SIZE; preallocated out; no meta=True; "
+        "quantitative claims only for stable/noisy; size dependence disclosed.",
+        "",
+        "| N | BLOCK_SIZE | median ms | p10 | p90 | spread | stability |",
+        "|---|------------|----------:|----:|----:|-------:|-----------|",
+    ]
+    for row in payload["sizes"]:
+        for bs, st in row["blocks"].items():
+            lines.append(
+                f"| {row['N']} | {bs} | {st['median_ms']:.6f} | {st['p10_ms']:.6f} | "
+                f"{st['p90_ms']:.6f} | {st['spread_ratio']:.3f} | {st['stability']} |"
+            )
+    lines.append("")
+    lines.append("Fastest BLOCK_SIZE by size (median; all labels retained):")
+    for row in payload["sizes"]:
+        lines.append(
+            f"- N={row['N']}: BLOCK_SIZE={row['fastest_block_size']} "
+            f"(median={row['fastest_median_ms']:.6f}, "
+            f"stability={row['fastest_stability']})"
+        )
+    lines.append("")
+    if payload["size_inversion_warnings"]:
+        lines.append("Size inversion warnings:")
+        for w in payload["size_inversion_warnings"]:
+            lines.append(
+                f"- BLOCK_SIZE={w['block_size']}: N={w['prev_N']}->"
+                f"{w['N']} medians {w['prev_median_ms']:.6f}->{w['median_ms']:.6f}"
+            )
+    else:
+        lines.append("Size inversion warnings: none")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _run_benchmark(
+    *,
+    sizes: list[int],
+    blocks: list[int],
+    warmup: int,
+    repeats: int,
+    inner: int,
+    mode: str,
+    json_output: Path | None,
+    markdown_output: Path | None,
+) -> int:
+    if not torch.cuda.is_available():
+        print("STOP: CUDA required for --benchmark/--quick")
+        return 1
+
+    if json_output is not None:
+        _require_fresh_path(json_output)
+    if markdown_output is not None:
+        _require_fresh_path(markdown_output)
+
+    device = "cuda"
+    dtype = torch.float32
+    torch.manual_seed(42)
+
+    _run_correctness(sizes, blocks, dtype=dtype, device=device)
+
+    size_rows: list[dict] = []
+    raw_batch_ms: list[dict] = []
+    fastest_by_size: list[int] = []
+    all_medians: list[dict] = []
+
+    print(
+        f"benchmark: mode={mode} dtype={dtype} device={device} "
+        f"warmup={warmup} repeats={repeats} inner={inner} "
+        f"timer=cuda.Event blocks={blocks} order=rotated "
+        f"measurement_scope=preallocated-output"
+    )
+
+    for size in sizes:
+        lhs = torch.rand(size, dtype=dtype, device=device)
+        rhs = torch.rand(size, dtype=dtype, device=device)
+        out_by_block = {bs: torch.empty_like(lhs) for bs in blocks}
+        ref = lhs + rhs
+        for bs in blocks:
+            add(lhs, rhs, block_size=bs, out=out_by_block[bs])
+            assert torch.allclose(out_by_block[bs], ref, atol=1e-5, rtol=1e-5)
+
+        def make_fn(bs: int, lhs=lhs, rhs=rhs, out_by_block=out_by_block):
+            out = out_by_block[bs]
+            return lambda: add(lhs, rhs, block_size=bs, out=out)
+
+        batches = _measure_rotated_blocks(
+            make_fn,
+            list(blocks),
+            warmup=warmup,
+            repeats=repeats,
+            inner=inner,
+        )
+
+        block_stats: dict[str, dict] = {}
+        block_raw: dict[str, dict] = {}
+        best_bs = None
+        best_med = float("inf")
+        best_stab = None
+
+        print(f"size N={size}:")
+        for bs in blocks:
+            raw = batches[bs]
+            _validate_samples(f"N={size} BLOCK_SIZE={bs}", raw, repeats)
+            per_iter = _per_iter_ms(raw, inner)
+            st = _stats(per_iter)
+            if not (st["p10_ms"] <= st["median_ms"] <= st["p90_ms"]):
+                raise SystemExit(
+                    f"STOP: percentile order broken N={size} BLOCK_SIZE={bs}"
+                )
+            print(
+                f"  BLOCK_SIZE={bs}: median={st['median_ms']:.6f} "
+                f"p10={st['p10_ms']:.6f} p90={st['p90_ms']:.6f} "
+                f"spread={st['spread_ratio']:.3f} ({st['stability']})"
+            )
+            block_stats[str(bs)] = st
+            block_raw[str(bs)] = {"batch_ms": raw, "per_iter_ms": per_iter}
+            if float(st["median_ms"]) < best_med:
+                best_med = float(st["median_ms"])
+                best_bs = bs
+                best_stab = st["stability"]
+
+        assert best_bs is not None
+        fastest_by_size.append(int(best_bs))
+        size_rows.append(
+            {
+                "N": size,
+                "inner_iterations": inner,
+                "blocks": block_stats,
+                "fastest_block_size": int(best_bs),
+                "fastest_median_ms": float(best_med),
+                "fastest_stability": best_stab,
+            }
+        )
+        raw_batch_ms.append({"N": size, "inner_iterations": inner, "blocks": block_raw})
+        all_medians.append(
+            {str(bs): block_stats[str(bs)]["median_ms"] for bs in blocks}
+        )
+
+    unique_fastest = sorted(set(fastest_by_size))
+    size_dependence = "yes" if len(unique_fastest) > 1 else "no"
+    if size_dependence == "yes":
+        conclusion = (
+            "规模依赖: fastest BLOCK_SIZE differs across N; "
+            "do not claim a single block is always optimal."
+        )
+    else:
+        conclusion = (
+            f"On this device/run, BLOCK_SIZE={unique_fastest[0]} had the best "
+            f"median at every measured N; still not a universal claim."
+        )
+
+    inversions = _size_inversion_warnings(size_rows, list(blocks))
+    for w in inversions:
+        print(
+            f"WARNING size_inversion: BLOCK_SIZE={w['block_size']} "
+            f"N={w['prev_N']}->{w['N']} "
+            f"medians {w['prev_median_ms']:.6f}->{w['median_ms']:.6f}"
+        )
+
+    print(f"size_dependence={size_dependence}; fastest_by_size={fastest_by_size}")
+    print(f"conclusion: {conclusion}")
+
+    payload = {
+        "generated_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "device": torch.cuda.get_device_name(0),
+        "torch_version": torch.__version__,
+        "ninetoothed_commit": _git_commit(),
+        "dtype": str(dtype).replace("torch.", ""),
+        "measurement_scope": "preallocated-output steady-state CUDA execution",
+        "allocation_inside_timed_region": False,
+        "inner_iterations_constant_across_sizes": True,
+        "warmup": warmup,
+        "repeats": repeats,
+        "inner_iterations": inner,
+        "mode": mode,
+        "block_sizes": list(blocks),
+        "sizes": size_rows,
+        "raw_batch_ms": raw_batch_ms,
+        "median_ms": all_medians,
+        "p10_ms": [
+            {bs: row["blocks"][bs]["p10_ms"] for bs in row["blocks"]}
+            for row in size_rows
+        ],
+        "p90_ms": [
+            {bs: row["blocks"][bs]["p90_ms"] for bs in row["blocks"]}
+            for row in size_rows
+        ],
+        "ratio": [
+            {
+                f"{a}_over_{b}": (
+                    float(row["blocks"][str(a)]["median_ms"])
+                    / float(row["blocks"][str(b)]["median_ms"])
+                )
+                for a in blocks
+                for b in blocks
+                if a != b
+            }
+            for row in size_rows
+        ],
+        "spread_ratios": [
+            {bs: row["blocks"][bs]["spread_ratio"] for bs in row["blocks"]}
+            for row in size_rows
+        ],
+        "stability_labels": [
+            {bs: row["blocks"][bs]["stability"] for bs in row["blocks"]}
+            for row in size_rows
+        ],
+        "fastest_block_by_size": fastest_by_size,
+        "size_dependence": size_dependence,
+        "size_inversion_warnings": inversions,
+        "conclusion": conclusion,
+        "bounds": (
+            "constexpr BLOCK_SIZE; preallocated out; no meta=True; "
+            "quantitative claims only for stable/noisy; disclose size dependence"
+        ),
+    }
+
+    if json_output is not None:
+        json_output.parent.mkdir(parents=True, exist_ok=True)
+        json_output.write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        print(f"wrote JSON: {json_output}")
+    if markdown_output is not None:
+        markdown_output.parent.mkdir(parents=True, exist_ok=True)
+        _write_markdown(markdown_output, payload)
+        print(f"wrote Markdown: {markdown_output}")
+
+    print(
+        "bounds: preallocated-output; constexpr BLOCK_SIZE; quantitative claims only for stable/noisy"
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--benchmark", action="store_true")
+    parser.add_argument("--quick", action="store_true")
+    parser.add_argument("--json-output", type=Path, default=None)
+    parser.add_argument("--markdown-output", type=Path, default=None)
+    args = parser.parse_args()
+
+    if args.benchmark and args.quick:
+        print("STOP: pass only one of --benchmark or --quick")
+        return 1
+
+    if not torch.cuda.is_available():
+        if args.benchmark or args.quick:
+            print("STOP: CUDA required for --benchmark/--quick")
+            return 1
+        print("SKIP: CUDA required for this example kernel")
+        return 0
+
+    dtype = torch.float32
+    device = "cuda"
+    torch.manual_seed(42)
+
+    if not args.benchmark and not args.quick:
+        _run_correctness(
+            list(CORR_SIZES), list(CORR_BLOCKS), dtype=dtype, device=device
+        )
+        return 0
+
+    if args.quick:
+        return _run_benchmark(
+            sizes=list(QUICK_SIZES),
+            blocks=list(BLOCK_SIZES),
+            warmup=QUICK_WARMUP,
+            repeats=QUICK_REPEATS,
+            inner=QUICK_INNER,
+            mode="quick",
+            json_output=args.json_output,
+            markdown_output=args.markdown_output,
+        )
+
+    return _run_benchmark(
+        sizes=list(BENCH_SIZES),
+        blocks=list(BLOCK_SIZES),
+        warmup=WARMUP,
+        repeats=REPEATS,
+        inner=INNER_ITERATIONS,
+        mode="benchmark",
+        json_output=args.json_output,
+        markdown_output=args.markdown_output,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/competition/ninetoothed-op-dev-skill/examples/README.md
+++ b/skills/competition/ninetoothed-op-dev-skill/examples/README.md
@@ -1,0 +1,54 @@
+# Examples — four capability families (fork-runnable)
+
+Each example is a **complete agent trajectory** for use inside a NineToothed
+fork/clone (`--repo-root` = directory containing `src/ninetoothed/`).
+
+| Dir | Family | Runnable entry |
+|-----|--------|----------------|
+| `01_elementwise_broadcast_add/` | Elementwise / broadcast | `python …/verify.py` |
+| `03_rowwise_softmax_reduce/` | Reduction / block | upstream `pytest tests/test_softmax.py` (+ optional `verify.py`) |
+| `05_non_contiguous_transpose_add/` | Layout / stride | `python …/verify.py` |
+| `09_performance_regression_fix/` | Perf / diagnosis | `python …/verify.py` |
+
+## Uniform artifact set
+
+| File | Role |
+|------|------|
+| `task.md` | Task description |
+| `task_card.md` | D1 card (math / shape / dtype / broadcast / layout / boundaries / reference) |
+| `run_prompt.md` | First agent message |
+| `run_log.md` | D2–D6/D8 execution notes (`rg` → patch → pytest) |
+| `changed_files.md` | Minimal file list |
+| `correctness_result.md` | Exact pytest / verify commands |
+| `benchmark_result.md` | Numbers protocol **or** N/A + reason |
+| `solution/` + `tests/` | Minimal implementation (01/05/09; 03 optional) |
+| `verify.py` | One-shot correctness (+ bench when applicable) |
+
+## How to run
+
+Requires editable NineToothed + CUDA for kernel demos:
+
+```bash
+cd /path/to/ninetoothed
+pip install -e .
+source ~/venvs/ninetoothed-skill/bin/activate   # or your venv
+
+EX=/path/to/ninetoothed-op-dev-skill/examples
+
+# 01 elementwise / broadcast
+python "$EX/01_elementwise_broadcast_add/verify.py"
+pytest "$EX/01_elementwise_broadcast_add/tests" -v --tb=short
+
+# 03 reduction / block (prefer upstream)
+pytest tests/test_softmax.py -v --tb=short
+python "$EX/03_rowwise_softmax_reduce/verify.py"   # optional local demo
+
+# 05 layout / stride
+python "$EX/05_non_contiguous_transpose_add/verify.py"
+
+# 09 perf / diagnosis (correctness then D8)
+python "$EX/09_performance_regression_fix/verify.py"
+```
+
+These four families are **generic demos** for the D1–D9 workflow. They are not
+competition answer keys; always re-run verify/pytest on the target fork.

--- a/skills/competition/ninetoothed-op-dev-skill/pyproject.toml
+++ b/skills/competition/ninetoothed-op-dev-skill/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "ninetoothed-op-dev-skill-tests"
+version = "0.0.0"
+requires-python = ">=3.10"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["scripts"]
+filterwarnings = ["error"]

--- a/skills/competition/ninetoothed-op-dev-skill/pytest.ini
+++ b/skills/competition/ninetoothed-op-dev-skill/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+cache_dir = ../../.cache/pytest_ninetoothed_skill

--- a/skills/competition/ninetoothed-op-dev-skill/references/00_repo_map.md
+++ b/skills/competition/ninetoothed-op-dev-skill/references/00_repo_map.md
@@ -1,0 +1,149 @@
+# 00 — Repository map
+
+> Paths use **`<repo-root>/...`** where `--repo-root` is the NineToothed clone
+> (directory containing `src/ninetoothed/`).  
+> Optional examples use **`<examples-root>/...`** via `--examples-root`
+> (or `NINETOOTHED_EXAMPLES_ROOT`).
+
+## 1. Layout overview
+
+```text
+<repo-root>/                        # --repo-root .
+  src/ninetoothed/                  # DSL, codegen, JIT, AOT, debugging
+  tests/                            # Official correctness + generation/AOT tests
+  docs/source/                      # Sphinx: basics, build (AOT), API
+  skills/competition/ninetoothed-op-dev-skill/   # this skill (when installed in-fork)
+
+<examples-root>/                    # optional --examples-root
+  ops/ninetoothed/kernels/          # Canonical arrange-and-apply kernels
+  ops/triton/kernels/               # Triton baselines
+  tests/                            # Cross-op correctness + benchmark markers
+```
+
+## 2. Core concepts → source files
+
+| Concept | Primary modules | Notes |
+|---------|-----------------|-------|
+| `Tensor`, tiling | `<repo-root>/src/ninetoothed/tensor.py` | Rank, `tile`, `expand`, `ravel`, stride views |
+| `Symbol`, `block_size` | `<repo-root>/src/ninetoothed/symbol.py` | `meta=True` → autotuning; `constexpr=True` → fixed at launch |
+| `ninetoothed.language` (`ntl`) | `<repo-root>/src/ninetoothed/language.py` | `dot`, `max`, `sum`, `exp`, `load`, `atomic_add`, … |
+| `ninetoothed.make` | `<repo-root>/src/ninetoothed/make.py` | arrange-and-apply → kernel |
+| `@ninetoothed.jit` | `<repo-root>/src/ninetoothed/jit.py` | Inline kernel functions (see `tests/test_add.py`) |
+| Code generation | `<repo-root>/src/ninetoothed/generation.py` | Generated Triton/C++ source; `kernel._source` |
+| AOT build | `<repo-root>/src/ninetoothed/build.py`, `aot.py` | Ahead-of-time `.so`; see `docs/source/build.rst` |
+| Autotuner | `<repo-root>/src/ninetoothed/auto_tuner.py` | `test_auto_tuner.py`, `test_generation.py` |
+| Debugging / viz | `<repo-root>/src/ninetoothed/debugging.py`, `visualization.py` | `test_debugging.py` |
+| dtypes | `<repo-root>/src/ninetoothed/dtype.py` | `float16`, `bfloat16`, `float32`, … |
+
+Public API surface: `<repo-root>/src/ninetoothed/__init__.py` exports `make`, `jit`, `Tensor`, `Symbol`, `block_size`, `build`, dtypes.
+
+## 3. `<repo-root>/tests/` index (agent search order)
+
+| File | Use for |
+|------|---------|
+| `test_add.py` | Elementwise add, **`@ninetoothed.jit`** style |
+| `test_expand.py`, `test_pow.py` | Broadcast / elementwise |
+| `test_softmax.py` | Row softmax, numerical stability (`max` before `exp`) |
+| `test_matmul.py`, `test_addmm.py` | `make` + reduction dot pattern |
+| `test_max_pool2d.py` | 4D block reduce / window |
+| `test_conv2d.py` | Spatial / padding |
+| `test_data_ptr.py` | `data_ptr`, `atomic_add`, storage-level ops |
+| `test_clone.py` | **stride/offset** via `offsets`, `stride`, manual `ntl.load` |
+| `test_getitem.py` | Indexing / views |
+| `test_generation.py` | Read **generated source** from `kernel._source` |
+| `test_aot.py`, `test_aot_auto_tuning.py` | AOT compile + load |
+| `test_auto_tuner.py` | Tuning configs |
+| `test_debugging.py` | Debug hooks |
+| `test_naming.py` | Light smoke / naming (good first pytest) |
+| `conftest.py` | Per-test deterministic seeds |
+| `utils.py` | `get_available_devices()` → `cuda` (and optional `mlu`) |
+
+## 4. `<examples-root>/` index (optional)
+
+| Path | Use for |
+|------|---------|
+| `ops/ninetoothed/kernels/add.py` | Minimal `make` elementwise template |
+| `ops/ninetoothed/kernels/softmax.py` | Reduction |
+| `ops/ninetoothed/kernels/max_pool2d.py` | Block/window max pool |
+| `ops/ninetoothed/kernels/mm.py`, `bmm.py` | Matmul family |
+| `ops/ninetoothed/kernels/conv2d.py` | Conv |
+| `ops/ninetoothed/torch.py` | Wiring kernels to torch tensors |
+| `ops/triton/kernels/*` | Baseline implementations |
+| `tests/test_ops.py` | Correctness across ops |
+| `tests/test_benchmarks.py` | `@pytest.mark.benchmark` |
+| `README.md` | `pytest`, `pytest -m benchmark`, autotuning disable |
+| `bench.py` | `assert_match`, plotting helpers |
+
+## 5. Commands
+
+```bash
+REPO="<repo-root>"          # --repo-root
+EXAMPLES="<examples-root>"  # optional --examples-root
+```
+
+### NineToothed repo tests
+
+```bash
+cd "$REPO"
+pytest tests/test_naming.py -v --tb=short
+pytest tests/test_add.py -v --tb=short
+pytest tests/test_softmax.py -v --tb=short
+pytest tests/test_data_ptr.py -v --tb=short
+pytest tests/test_generation.py -v --tb=short
+pytest tests/test_aot.py -v --tb=short   # slower; may need build toolchain
+```
+
+### Examples (optional)
+
+```bash
+cd "$EXAMPLES"
+pip install -e .    # ⚠️ user action; not auto-run by skill
+pytest -v --tb=short
+pytest -m benchmark -k TestMM
+```
+
+### Skill installability checks (inside the fork)
+
+```bash
+cd "$REPO"
+pytest skills/competition/ninetoothed-op-dev-skill/tests -q
+python skills/competition/ninetoothed-op-dev-skill/scripts/quick_validate.py
+python skills/competition/ninetoothed-op-dev-skill/scripts/env_check.py --repo-root .
+```
+
+## 6. Two implementation styles (do not mix blindly)
+
+### Style A — `@ninetoothed.jit` (compact, used in some tests)
+
+See `<repo-root>/tests/test_add.py`.
+
+### Style B — `make(arrangement, application, tensors)` (examples + README matmul)
+
+See `<examples-root>/ops/ninetoothed/kernels/add.py` and `<repo-root>/README.md` matmul.
+
+**Agent rule:** Find the closest existing file for your operator family and **match its style**.
+
+## 7. Code style conventions
+
+- Tests: `pytest`, `@pytest.mark.parametrize`, `torch.allclose`, `get_available_devices()`
+- Kernel body assigns via `output = expr  # noqa: F841` pattern
+- Examples: `Symbol(..., meta=True)` for autotuning; use `constexpr=True` + launch arg to disable for fast dev
+- Seeds: automatic per module/test via `conftest.py`
+
+## 8. Common misconceptions
+
+| Wrong | Right |
+|-------|-------|
+| Invent `ntl.*` ops without checking `language.py` | Grep `<repo-root>/src/ninetoothed/language.py` or copy from nearest test |
+| Patch compiler core by default | Prefer user/examples targets or skill `examples/` trajectories |
+| Assume CPU tests | `get_available_devices()` skips CPU; CUDA required for most tests |
+| Run full `pytest` + autotuning on first try | Disable autotuning or run a single file |
+| `nvcc` always available | AOT may need CUDA toolkit; declare unsupported if missing |
+
+## 9. Agent file search order
+
+1. Task type → table in §3 or §4  
+2. Open matching `<examples-root>/ops/ninetoothed/kernels/<op>.py` if `--examples-root` is set  
+3. Else open `<repo-root>/tests/test_<op>.py`  
+4. Read `conftest.py` + `utils.py` for device/dtype patterns  
+5. For perf/AOT → `test_generation.py`, `test_aot.py`, `docs/source/build.rst`

--- a/skills/competition/ninetoothed-op-dev-skill/references/01_ninetoothed_concepts.md
+++ b/skills/competition/ninetoothed-op-dev-skill/references/01_ninetoothed_concepts.md
@@ -1,0 +1,55 @@
+# 01 — NineToothed concepts
+
+## TOM and arrange-and-apply
+
+NineToothed uses **tensor-oriented meta-programming (TOM)**. User code splits into:
+
+1. **`arrangement`** — how logical tensors are tiled/expanded/viewed for parallel work  
+2. **`application`** — serial semantics over arranged tiles (`ntl` ops)  
+3. **`tensors`** — `Tensor(rank)` metadata tuple passed to `make`
+
+```python
+kernel = ninetoothed.make(arrangement, application, tensors)
+kernel(*torch_tensors)
+```
+
+Official intro: `<repo-root>/README.md`, `<repo-root>/docs/source/basics.rst`.
+
+## Key types
+
+| Symbol | Role |
+|--------|------|
+| `Tensor(n)` | n-dimensional meta-tensor in arrangement |
+| `Symbol("NAME", meta=True)` | Autotuning dimension |
+| `Symbol(..., constexpr=True)` | Fixed at kernel launch |
+| `block_size()` | Special symbol for block tiling |
+| `ntl` | `import ninetoothed.language as ntl` — ops inside `application` |
+
+## Alternative: `@ninetoothed.jit`
+
+Some tests use decorated functions instead of explicit `make`:
+
+```python
+@ninetoothed.jit
+def add_kernel(lhs: Tensor(1).tile((BLOCK_SIZE,)), ...):
+    output = lhs + rhs
+```
+
+See `tests/test_add.py`. Prefer the style of your nearest reference file.
+
+## JIT vs AOT
+
+| API | When |
+|-----|------|
+| `ninetoothed.make` / `jit` | JIT; first call compiles |
+| `ninetoothed.build` | AOT; emits `.so` to disk (`docs/source/build.rst`) |
+
+## Generated source
+
+Compiled kernels expose generated source path via `kernel._source` (see `test_generation.py`). Use for redundancy / load-store diagnosis.
+
+## When to read more
+
+- API details → `docs/source/python_api/*.rst`  
+- Build/AOT → `docs/source/build.rst`  
+- Repo file index → `00_repo_map.md`

--- a/skills/competition/ninetoothed-op-dev-skill/references/02_arrangement_application_patterns.md
+++ b/skills/competition/ninetoothed-op-dev-skill/references/02_arrangement_application_patterns.md
@@ -1,0 +1,48 @@
+# 02 — Arrangement / application patterns
+
+## When to use
+
+Implementing any new kernel: define how tiles map to memory (`arrangement`) and what compute runs per tile (`application`).
+
+## Search order
+
+1. `<examples-root>/ops/ninetoothed/kernels/<op>.py` (if `--examples-root` is set)  
+2. `<repo-root>/tests/test_<op>.py`  
+3. `<repo-root>/README.md` (matmul example)
+
+## Common arrangement moves
+
+| Pattern | Example location |
+|---------|------------------|
+| `tile((BLOCK,))` 1D | `<examples-root>/.../add.py` |
+| `tile((M,N))` 2D | `<repo-root>/tests/test_softmax.py` (row tiles) |
+| `expand` broadcast | `<repo-root>/README.md` matmul arrangement |
+| `ravel` / `flatten` | `<examples-root>/.../max_pool2d.py` |
+| `dtype.squeeze` on arranged tensor | `max_pool2d.py`, matmul README |
+
+## Application patterns
+
+- Elementwise: `output = input + other`  
+- Reduce: `ntl.max(input, axis=1)`, `ntl.sum`, softmax stable form in `test_softmax.py`  
+- Matmul: accumulator loop with `ntl.dot` in README  
+
+## `make` kwargs (performance)
+
+From `<repo-root>/tests/test_generation.py`:
+
+- `num_warps`, `num_stages` — Triton launch params  
+- Passing tuples triggers autotuning paths  
+
+For fast correctness dev: fix block sizes as integers / `constexpr=True`.
+
+## Validation
+
+```bash
+cd <repo-root>
+pytest tests/test_<nearest_op>.py -v --tb=short
+```
+
+## Failure notes
+
+- Wrong `tile`/`expand` → shape mismatch or silent wrong results; compare torch ref first  
+- Mixing `jit` and `make` styles in one op → pick one reference and stick to it

--- a/skills/competition/ninetoothed-op-dev-skill/references/03_elementwise_broadcast_patterns.md
+++ b/skills/competition/ninetoothed-op-dev-skill/references/03_elementwise_broadcast_patterns.md
@@ -1,0 +1,42 @@
+# 03 — Elementwise / broadcast patterns
+
+## When to use
+
+add, relu, gelu, mask, where, dtype-specific elementwise ops.
+
+## Reference files
+
+| Op | Path |
+|----|------|
+| add (`make`) | `<examples-root>/ops/ninetoothed/kernels/add.py` |
+| add (`jit`) | `<repo-root>/tests/test_add.py` |
+| pow / unary | `<repo-root>/tests/test_pow.py` |
+| expand / broadcast | `<repo-root>/tests/test_expand.py` |
+| dropout / mask-like | `<repo-root>/tests/test_dropout.py` |
+
+## Contract checklist
+
+- [ ] Same shape or explicit broadcast rules  
+- [ ] `dtype` in parametrize matches torch ref  
+- [ ] `device` from `get_available_devices()`  
+- [ ] `torch.allclose` tolerances (`rtol`/`atol` for fp16)
+
+## Minimal test pattern
+
+```python
+@pytest.mark.parametrize("device", get_available_devices())
+@pytest.mark.parametrize("dtype", (torch.float32,))
+def test(..., dtype, device):
+    ...
+    assert torch.allclose(output, expected)
+```
+
+## Benchmark (optional)
+
+Examples repo: `pytest -m benchmark` under `--examples-root` (⚠️ requires examples install).
+
+## Common errors
+
+- Using CPU tensor when tests expect CUDA  
+- Forgetting `torch.empty_like` output buffer before kernel call  
+- Mask dtype not bool / shape not broadcastable

--- a/skills/competition/ninetoothed-op-dev-skill/references/04_reduction_block_patterns.md
+++ b/skills/competition/ninetoothed-op-dev-skill/references/04_reduction_block_patterns.md
@@ -1,0 +1,42 @@
+# 04 — Reduction / block patterns
+
+## When to use
+
+softmax, sum/max along dim, matmul, max_pool2d, conv2d.
+
+## Reference files
+
+| Op | Path |
+|----|------|
+| softmax | `tests/test_softmax.py`, `examples/.../softmax.py` |
+| matmul | `tests/test_matmul.py`, `examples/.../mm.py` |
+| max_pool2d | `tests/test_max_pool2d.py`, `examples/.../max_pool2d.py` |
+| conv2d | `tests/test_conv2d.py`, `examples/.../conv2d.py` |
+| attention | `tests/test_attention.py`, `examples/.../scaled_dot_product_attention.py` |
+
+## Numerical stability (softmax)
+
+Pattern from `test_softmax.py`:
+
+```python
+row_minus_max = input_row - ntl.max(input_row)
+numerator = ntl.exp(row_minus_max)
+denominator = ntl.sum(numerator)
+output_row = numerator / denominator
+```
+
+## Block / window ops
+
+`max_pool2d` example uses `WINDOW_HEIGHT/WIDTH` symbols + multi-step `tile`/`flatten`.
+
+## Validation
+
+```bash
+pytest tests/test_softmax.py -v
+pytest tests/test_max_pool2d.py -v
+```
+
+## Performance notes
+
+- Autotuning (`Symbol(..., meta=True)`) can take minutes — disable for quick iteration (examples README)  
+- Report `num_warps` / block sizes when benchmarking

--- a/skills/competition/ninetoothed-op-dev-skill/references/05_layout_stride_offset_patterns.md
+++ b/skills/competition/ninetoothed-op-dev-skill/references/05_layout_stride_offset_patterns.md
@@ -1,0 +1,46 @@
+# 05 — Layout / stride / offset patterns
+
+## When to use
+
+non-contiguous inputs, transpose views, strided slice, `storage_offset`, manual load from pointer.
+
+## Reference files
+
+| Topic | Path |
+|-------|------|
+| stride + offsets + `ntl.load` | `tests/test_clone.py` (`application_1`–`_3`) |
+| `data_ptr` + `atomic_add` | `tests/test_data_ptr.py` |
+| getitem / views | `tests/test_getitem.py` |
+| pad | `tests/test_pad.py` |
+
+## Key APIs (verify in repo before use)
+
+From `test_clone.py`:
+
+```python
+input.source.data_ptr()
+input.offsets(0)[:, None] * input.source.stride(0)
+ntl.load(ptr + ...)
+input.source[i, j]  # arranged indexing
+```
+
+## Test strategy
+
+1. Build torch tensor, then `transpose` / `slice` for non-contiguous  
+2. Compare to torch op on **same view**  
+3. Run `test_clone.py` / `test_data_ptr.py` as templates  
+
+```bash
+pytest tests/test_clone.py -v
+pytest tests/test_data_ptr.py -v
+```
+
+## Common errors
+
+- Assuming contiguous storage when input is a view  
+- Wrong stride axis in manual `ntl.load`  
+- Comparing against torch ref on contiguous copy instead of view
+
+## Report points
+
+Document: `is_contiguous()`, `stride()`, `storage_offset()` in task card and final report.

--- a/skills/competition/ninetoothed-op-dev-skill/references/06_correctness_testing_patterns.md
+++ b/skills/competition/ninetoothed-op-dev-skill/references/06_correctness_testing_patterns.md
@@ -1,0 +1,54 @@
+# 06 — Correctness testing patterns
+
+## When to use
+
+Every operator task — before benchmark or optimization.
+
+## Standard harness (ninetoothed repo)
+
+- **Runner:** `pytest`  
+- **Devices:** `tests/utils.py` → `get_available_devices()` (CUDA if available)  
+- **Seeds:** `tests/conftest.py` — deterministic per module/test  
+- **Assertion:** `torch.allclose(output, expected)`  
+
+## Minimal workflow
+
+1. Implement kernel wrapper (like `test_add.py` top-level `add()`).  
+2. Parametrize `device`, `dtype`, shapes.  
+3. Compare to `torch` reference on same device/dtype/view.  
+4. Log command + exit code to `logs/correctness/`.
+
+```bash
+cd <repo-root>
+pytest tests/test_add.py -v --tb=short 2>&1 | tee logs/correctness/test_add.log
+```
+
+## Optional examples (`--examples-root`)
+
+```bash
+cd <examples-root>
+pytest tests/test_ops.py -v --tb=short
+```
+
+Uses `bench.assert_match` pattern in `<examples-root>/bench.py` for multi-impl comparison.
+
+## fp16 / bf16
+
+- Use explicit tolerances if needed: `torch.allclose(a, b, rtol=1e-2, atol=1e-2)`  
+- See `test_aot.py` for `bfloat16` / `ninetoothed.bfloat16` pairing
+
+## Compliance
+
+- Do **not** delete or skip failing tests to pass  
+- Do **not** claim pass without saved pytest output  
+- If CUDA unavailable, state unsupported — do not fake GPU results
+
+## Report template
+
+```markdown
+## Correctness
+- Command: `pytest ...`
+- Exit code: 0
+- Log: logs/correctness/xxx.log
+- Cases: dtype, shape, layout (list)
+```

--- a/skills/competition/ninetoothed-op-dev-skill/references/07_benchmark_patterns.md
+++ b/skills/competition/ninetoothed-op-dev-skill/references/07_benchmark_patterns.md
@@ -1,0 +1,61 @@
+# 07 — Benchmark patterns
+
+## When to use
+
+Performance-sensitive hidden tasks, regression analysis, competition materials (≥2 self-test tasks need benchmark).
+
+## Optional examples (`--examples-root`)
+
+From `<examples-root>/README.md`:
+
+```bash
+cd <examples-root>
+pytest -m benchmark
+pytest -m benchmark -k TestMM
+```
+
+⚠️ **User environment action:** `pip install -e .` in the examples repo before pytest there.
+
+## Autotuning warning
+
+`Symbol(..., meta=True)` can make benchmarks **very slow**. For controlled benchmarks:
+
+- Set `constexpr=True` and pass block size at launch, or  
+- Replace `Symbol` with fixed int (see examples README)
+
+Also disable matching Triton autotuning when comparing fairly.
+
+## What to record (competition rubric)
+
+| Field | Example |
+|-------|---------|
+| Baseline | PyTorch `torch.add` / same-kernel fair baseline |
+| Input sizes | e.g. (128,256), (512,512), (2048,2048) |
+| Device | RTX 5070 Ti Laptop, CUDA |
+| Timer | `torch.cuda.Event(enable_timing=True)` |
+| Stats | **median / p10 / p90**; `spread_ratio=p90/median`; stability labels |
+| Fair baseline | same dtype/device/size; disclose `meta=True` / autotuning |
+| Conclusion bounds | what is comparable vs incomparable; never invent numbers |
+| Command | exact verify/`run_benchmark.py` invocation |
+| Raw output | `<repo-root>/logs/benchmark/*.md` + `.json` |
+
+## bench.py helpers
+
+`<examples-root>/bench.py`:
+
+- `assert_match(impls, args)` — correctness across providers before timing  
+- Plotting utilities for manual analysis  
+
+## Compliance
+
+- No fabricated timings  
+- Same input shapes for baseline and candidate  
+- Note if autotuning was disabled (affects absolute numbers)
+
+## Warmup (required for fair timing)
+
+Before recording benchmark numbers:
+
+1. Run the kernel **≥5 times** with the same shapes (JIT + cache warmup).
+2. When sweeping `BLOCK_SIZE`, warmup **each** block size separately.
+3. Document `WARMUP_ITERS` in test or script when embedding micro-benchmarks in pytest.

--- a/skills/competition/ninetoothed-op-dev-skill/references/08_generated_source_aot_debugging.md
+++ b/skills/competition/ninetoothed-op-dev-skill/references/08_generated_source_aot_debugging.md
@@ -1,0 +1,54 @@
+# 08 — Generated source / AOT debugging
+
+## When to use
+
+Tasks mentioning generated source, Triton output, AOT build, compile artifacts, performance regression at codegen level.
+
+## Generated source (JIT)
+
+**Reference:** `tests/test_generation.py`
+
+```python
+kernel = ninetoothed.make(...)
+source_file = kernel._source
+with open(source_file) as f:
+    contents = f.read()
+```
+
+Look for: redundant loads/stores, unexpected broadcasts, wrong block sizes.
+
+Also: `import ninetoothed.generation` — `generation.CACHE_DIR` used in `test_aot.py`.
+
+## AOT build
+
+**Docs:** `<repo-root>/docs/source/build.rst`  
+**Tests:** `<repo-root>/tests/test_aot.py`, `<repo-root>/tests/test_aot_auto_tuning.py`
+
+Pattern:
+
+- `ninetoothed.make(..., kernel_name=..., output_dir=...)`
+- `ninetoothed.aot` module for compile/load steps (read test file for current API)
+
+## Toolchain requirements
+
+- **nvcc / CUDA toolkit** may be required for native AOT artifacts  
+- If `nvcc` missing (`env_check.md`), report:
+
+  > AOT compile not run — nvcc not available; documented config and expected steps only.
+
+Do not fake `.so` files or compile logs.
+
+## Debugging module
+
+`tests/test_debugging.py`, `src/ninetoothed/debugging.py` — visualization / debug hooks.
+
+## Report template
+
+```markdown
+## Generated source / AOT
+- Kernel: ...
+- Source path or build dir: ...
+- Observation: (e.g. extra load in loop)
+- Action taken: ...
+- Re-verify command: ...
+```

--- a/skills/competition/ninetoothed-op-dev-skill/references/09_failure_diagnosis_playbook.md
+++ b/skills/competition/ninetoothed-op-dev-skill/references/09_failure_diagnosis_playbook.md
@@ -1,0 +1,44 @@
+# 09 — Failure diagnosis playbook
+
+## Loop (mandatory on any fail)
+
+```text
+1. Symptom     — command + error / wrong output
+2. Reproduce   — minimal shape/dtype/device
+3. Hypothesis  — arrangement vs application vs layout vs dtype
+4. Minimal fix — smallest patch
+5. Re-verify   — same pytest command
+6. Log         — save to logs/ and reference in report
+```
+
+## Symptom → likely cause
+
+| Symptom | Check first |
+|---------|-------------|
+| `CUDA error` / no kernel image | PyTorch build vs GPU arch (sm_120 → nightly cu128) |
+| `allclose` fail, small drift | fp16 tolerance; softmax stability |
+| `allclose` fail, large error | wrong broadcast tile; wrong dim for reduce; wrong op in application (`*` vs `+`) |
+| misleading "broadcast" in assert | read kernel `application` — message may be stale comment |
+| shape mismatch | arrangement `expand` / `squeeze` on dtype meta |
+| pass on contiguous, fail on view | stride/offset — see `05_layout_stride_offset_patterns.md` |
+| first run very slow | JIT compile or autotuning — not necessarily bug |
+| AOT fail | nvcc missing; read `test_aot.py` for required env |
+
+## Commands for diagnosis
+
+```bash
+pytest <file>::<test> -v --tb=long
+python -c "import torch; print(torch.cuda.is_available(), torch.__version__)"
+```
+
+Optional: inspect `kernel._source` after JIT (`08_generated_source_aot_debugging.md`).
+
+## When to declare unsupported
+
+- No CUDA and task requires GPU kernel execution  
+- nvcc missing and task requires AOT binary proof  
+- Autotuning timeout — report with suggestion to fix block sizes, not silent skip
+
+## Scorecard reminder (0–10)
+
+Fix correctness before claiming performance points. Document diagnosis for partial credit on process/compliance.

--- a/skills/competition/ninetoothed-op-dev-skill/references/10_patch_minimality_checklist.md
+++ b/skills/competition/ninetoothed-op-dev-skill/references/10_patch_minimality_checklist.md
@@ -1,0 +1,35 @@
+# 10 — Patch minimality checklist
+
+Before submitting or claiming task complete:
+
+## Diff scope
+
+- [ ] Only files required for the operator/test/benchmark  
+- [ ] No reformatting unrelated files  
+- [ ] No mass rename / import reorder in `<repo-root>/src/ninetoothed/` unless task demands  
+- [ ] No deleted tests or `@pytest.mark.skip` without documented unsupported case  
+
+## git checks (user runs manually)
+
+```bash
+git status
+git diff --stat
+```
+
+Red flags:
+
+- `third_party/` bulk changes  
+- `.venv/`, `.pip-cache/` committed  
+- `logs/` with fabricated numbers (logs OK if real command output)
+
+## Style alignment
+
+- [ ] Test names match `test_<feature>.py`  
+- [ ] Uses `get_available_devices()` and parametrize like neighbors  
+- [ ] Kernel uses `# noqa: F841` on output assignment if matching repo style  
+
+## Competition compliance
+
+- [ ] No hidden task names hardcoded  
+- [ ] No “comment out assertion” patterns  
+- [ ] README/report lists exact commands run

--- a/skills/competition/ninetoothed-op-dev-skill/references/11_unsupported_cases.md
+++ b/skills/competition/ninetoothed-op-dev-skill/references/11_unsupported_cases.md
@@ -1,0 +1,49 @@
+# 11 — Unsupported cases
+
+Declare explicitly in every task report when applicable.
+
+## Environment
+
+| Condition | Statement template |
+|-----------|-------------------|
+| No CUDA | GPU kernel tests not executed; logic documented only |
+| sm_120 GPU + wrong torch | Requires PyTorch nightly `cu128`; stable cu124 insufficient |
+| `nvcc` not found | AOT compile skipped; analysis limited to generated source / docs |
+| WSL GPU passthrough fail | `nvidia-smi` in WSL must work before GPU tests |
+
+## Operator / dtype
+
+| Condition | Notes |
+|-----------|-------|
+| CPU-only execution | Most ninetoothed tests use `get_available_devices()` → CUDA only |
+| `mlu` | Only if `torch_mlu` installed — rare in competition env |
+| Dynamic shape beyond test patterns | State fixed shapes used; no claim of full dynamic support |
+| dtypes not in nearest test | Do not invent; extend from closest `parametrize` list |
+
+## Performance
+
+| Condition | Notes |
+|-----------|-------|
+| Autotuning disabled for time | Benchmark numbers are **not** peak performance |
+| Examples not installed | `<examples-root>` benchmarks require `pip install -e .` |
+
+## Skill boundaries
+
+- Does not modify NineToothed compiler core by default  
+- Does not provide hidden evaluation answers or task-specific bypasses  
+- Does not run network installs automatically — user controls `pip`/`git`
+
+## Example report snippet
+
+```markdown
+## Unsupported
+- nvcc: not installed — AOT build not executed
+- dtypes: int64 elementwise not implemented; float32/float16 only
+```
+
+## float16 correctness
+
+- Covered by `examples/01_elementwise_broadcast_add/tests/test_example_broadcast_add.py::test_broadcast_add_float16_matches_torch`
+- Uses explicit `atol=1e-2`, `rtol=1e-2`
+- Benchmark evidence remains **float32 only**; do not extend performance claims to float16
+

--- a/skills/competition/ninetoothed-op-dev-skill/scripts/_paths.py
+++ b/skills/competition/ninetoothed-op-dev-skill/scripts/_paths.py
@@ -1,0 +1,205 @@
+"""Shared path helpers for skill scripts.
+
+Target layout: a NineToothed repository root that contains ``src/ninetoothed/``.
+Legacy competition layout ``third_party/ninetoothed`` remains a fallback.
+
+All path-aware CLIs should call :func:`add_repo_root_args` and
+:func:`resolve_repo_root`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+_ENV_REPO = "NINETOOTHED_REPO_ROOT"
+_ENV_SKILL = "NINETOOTHED_SKILL_ROOT"
+_ENV_EXAMPLES = "NINETOOTHED_EXAMPLES_ROOT"
+
+
+def skill_root(explicit: Path | str | None = None) -> Path:
+    """Return the skill package root (directory that contains SKILL.md)."""
+    if explicit is not None:
+        root = Path(explicit).expanduser().resolve()
+        if not (root / "SKILL.md").is_file():
+            raise FileNotFoundError(f"SKILL.md not found under --skill-root: {root}")
+        return root
+    env = os.environ.get(_ENV_SKILL)
+    if env:
+        return skill_root(Path(env))
+    start = Path(__file__).resolve().parent
+    for candidate in (start, *start.parents):
+        if (candidate / "SKILL.md").is_file() and (candidate / "scripts").is_dir():
+            return candidate
+    raise FileNotFoundError(
+        "Skill root not found (expected a directory containing SKILL.md). "
+        "Pass --skill-root or set NINETOOTHED_SKILL_ROOT."
+    )
+
+
+def is_ninetoothed_repo(path: Path) -> bool:
+    """Return True if *path* looks like a NineToothed repository root."""
+    p = path.resolve()
+    if (p / "src" / "ninetoothed").is_dir():
+        return True
+    # Editable install / nested package without src/ layout
+    if (p / "ninetoothed" / "__init__.py").is_file() and (p / "tests").is_dir():
+        return True
+    return False
+
+
+def ninetoothed_repo_root(explicit: Path | str | None = None) -> Path:
+    """Resolve the target NineToothed repository root.
+
+    Recognition order for auto-detect:
+    1. ``--repo-root`` / ``NINETOOTHED_REPO_ROOT``
+    2. Walk upward for ``src/ninetoothed/``
+    3. Legacy: ``third_party/ninetoothed`` (competition workspace)
+    """
+    if explicit is not None:
+        root = Path(explicit).expanduser().resolve()
+        if is_ninetoothed_repo(root):
+            return root
+        nested = root / "third_party" / "ninetoothed"
+        if is_ninetoothed_repo(nested):
+            return nested
+        raise FileNotFoundError(
+            f"Not a NineToothed repo root (missing src/ninetoothed/): {root}"
+        )
+
+    env = os.environ.get(_ENV_REPO)
+    if env:
+        return ninetoothed_repo_root(Path(env))
+
+    start = Path.cwd().resolve()
+    for candidate in (start, *start.parents):
+        if is_ninetoothed_repo(candidate):
+            return candidate
+        legacy = candidate / "third_party" / "ninetoothed"
+        if is_ninetoothed_repo(legacy):
+            return legacy
+
+    # Also search from skill location (skill may live under skills/... inside the fork)
+    try:
+        sk = skill_root()
+    except FileNotFoundError:
+        sk = Path(__file__).resolve()
+    for candidate in (sk, *sk.parents):
+        if is_ninetoothed_repo(candidate):
+            return candidate
+        legacy = candidate / "third_party" / "ninetoothed"
+        if is_ninetoothed_repo(legacy):
+            return legacy
+
+    raise FileNotFoundError(
+        "NineToothed repository root not found. "
+        "Pass --repo-root pointing at a clone that contains src/ninetoothed/, "
+        "or set NINETOOTHED_REPO_ROOT."
+    )
+
+
+def examples_repo_root(explicit: Path | str | None = None) -> Path | None:
+    """Return optional ninetoothed-examples root (may be absent)."""
+    if explicit is not None:
+        path = Path(explicit).expanduser().resolve()
+        return path if path.is_dir() else None
+    env = os.environ.get(_ENV_EXAMPLES)
+    if env:
+        return examples_repo_root(Path(env))
+    try:
+        repo = ninetoothed_repo_root()
+    except FileNotFoundError:
+        return None
+    # Sibling clone
+    sibling = repo.parent / "ninetoothed-examples"
+    if sibling.is_dir():
+        return sibling
+    # Competition layout
+    for candidate in (repo, *repo.parents):
+        legacy = candidate / "third_party" / "ninetoothed-examples"
+        if legacy.is_dir():
+            return legacy
+    return None
+
+
+def workspace_root(explicit: Path | str | None = None) -> Path:
+    """Workspace used for logs/reports.
+
+    Prefer the NineToothed repo root. Falls back to competition workspace
+    (directory that contains ``third_party/ninetoothed``) when present.
+    """
+    if explicit is not None:
+        return Path(explicit).expanduser().resolve()
+    try:
+        return ninetoothed_repo_root()
+    except FileNotFoundError:
+        pass
+    start = Path(__file__).resolve().parent
+    for candidate in (start, *start.parents):
+        if (candidate / "third_party" / "ninetoothed").is_dir():
+            return candidate
+    # Last resort: skill's parent chain (fork with skills/ under repo)
+    try:
+        sk = skill_root()
+        for candidate in sk.parents:
+            if (candidate / "src" / "ninetoothed").is_dir() or (
+                candidate / "skills"
+            ).is_dir():
+                return candidate
+        return sk.parents[2] if len(sk.parents) >= 3 else sk.parent
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(
+            "Workspace root not found. Pass --repo-root to a NineToothed clone."
+        ) from exc
+
+
+def logs_dir(repo: Path | None = None) -> Path:
+    """Default log directory: ``<repo-root>/logs``."""
+    base = repo if repo is not None else workspace_root()
+    return Path(base) / "logs"
+
+
+def add_skill_root_arg(parser: argparse.ArgumentParser) -> None:
+    """Attach ``--skill-root`` for tools that only need the skill package path."""
+    parser.add_argument(
+        "--skill-root",
+        type=Path,
+        default=None,
+        help=f"Skill package root (directory containing SKILL.md). Env: {_ENV_SKILL}",
+    )
+
+
+def add_repo_root_args(parser: argparse.ArgumentParser) -> None:
+    """Attach path flags for scripts that access a NineToothed repository."""
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="NineToothed repository root (directory containing src/ninetoothed/). "
+        f"Env: {_ENV_REPO}",
+    )
+    add_skill_root_arg(parser)
+    parser.add_argument(
+        "--examples-root",
+        type=Path,
+        default=None,
+        help=f"Optional ninetoothed-examples root (--examples-root). Env: {_ENV_EXAMPLES}",
+    )
+
+
+def resolve_repo_root(args: argparse.Namespace) -> Path:
+    return ninetoothed_repo_root(getattr(args, "repo_root", None))
+
+
+def resolve_skill_root(args: argparse.Namespace) -> Path:
+    return skill_root(getattr(args, "skill_root", None))
+
+
+def resolve_examples_root(args: argparse.Namespace) -> Path | None:
+    return examples_repo_root(getattr(args, "examples_root", None))
+
+
+def resolve_logs_dir(args: argparse.Namespace) -> Path:
+    repo = resolve_repo_root(args)
+    return logs_dir(repo)

--- a/skills/competition/ninetoothed-op-dev-skill/scripts/_task_spec.py
+++ b/skills/competition/ninetoothed-op-dev-skill/scripts/_task_spec.py
@@ -49,7 +49,10 @@ class TaskSpec:
         }
 
 
-_NUMBERED_HEADING = re.compile(r"^## (\d+)\.\s+(.+)$", re.MULTILINE)
+_SECTION_HEADING = re.compile(
+    r"^##\s+(?:(\d+)[.)]\s*)?(.+?)\s*$",
+    re.MULTILINE,
+)
 _SEMANTICS = re.compile(r"semantics\s*=\s*`([^`]+)`", re.IGNORECASE)
 _OUTPUT_EQ = re.compile(r"output\s*=\s*`([^`]+)`", re.IGNORECASE)
 _IO_TENSOR = re.compile(r"`?(\w+)`?\s*\(([^)]+)\)")
@@ -85,7 +88,7 @@ _KNOWN_OPS = frozenset(
 
 
 def _section_map(text: str) -> dict[str, str]:
-    matches = list(_NUMBERED_HEADING.finditer(text))
+    matches = list(_SECTION_HEADING.finditer(text))
     sections: dict[str, str] = {}
     for i, match in enumerate(matches):
         title = match.group(2).strip().lower()
@@ -223,6 +226,11 @@ def _parse_md_io_tables(text: str) -> tuple[list[str], list[str]]:
         if i < len(lines) and re.match(r"^\|?\s*-+", lines[i]):
             i += 1
         has_layout = any("layout" in h for h in headers)
+        direction_headers = {
+            h
+            for h in headers
+            if h in {"role", "direction", "io", "i/o", "kind"} or "direction" in h
+        }
         while (
             i < len(lines) and "|" in lines[i] and not re.match(r"^\|?\s*-+", lines[i])
         ):
@@ -259,7 +267,18 @@ def _parse_md_io_tables(text: str) -> tuple[list[str], list[str]]:
                 r"\bbool\b", dtype_cell, re.IGNORECASE
             ):
                 dtype = "bool"
-            if has_layout:
+            direction = ""
+            for header in direction_headers:
+                value = row.get(header, "").strip().lower()
+                if re.search(r"\b(output|result|return|returns)\b", value):
+                    direction = "output"
+                    break
+                if re.search(r"\b(input|operand|argument|arg)\b", value):
+                    direction = "input"
+                    break
+            if direction == "output":
+                outputs.append(f"| {name} | {shape} | {dtype} |")
+            elif direction == "input" or has_layout:
                 layout_cell = ""
                 for h, v in row.items():
                     if "layout" in h:
@@ -286,6 +305,8 @@ def _parse_bullet_io(text: str) -> tuple[list[str], list[str]]:
         low = body.lower()
         is_output = (
             low.startswith("output")
+            or low.startswith("result")
+            or low.startswith("return")
             or low.startswith("out ")
             or re.match(r"out\b", low) is not None
         )
@@ -339,13 +360,22 @@ def _parse_inline_tensors(text: str) -> tuple[list[str], list[str]]:
     for i, match in enumerate(matches):
         name = match.group(1)
         shape = match.group(2).replace(" ", "")
+        prefix_start = matches[i - 1].end() if i > 0 else 0
+        prefix = scrubbed[prefix_start : match.start()]
+        has_output_label = bool(
+            re.search(
+                r"(?:^|[.;]\s*)(?:outputs?|results?|returns?)\s*:?[\s`]*$",
+                prefix,
+                re.IGNORECASE,
+            )
+        )
         # Attribute span: current match → next tensor match (exclusive).
         span_end = matches[i + 1].start() if i + 1 < len(matches) else len(scrubbed)
         local = scrubbed[match.start() : span_end]
         # Also trim at sentence / bullet boundaries inside the span.
         local = re.split(r"(?<=[.])\s+(?=[A-Z`])", local, maxsplit=1)[0]
         dtype, layout = _attrs_from_local(name, local)
-        if name.lower() in {"output", "out"}:
+        if name.lower() in {"output", "out"} or has_output_label:
             outputs.append(f"| {name} | ({shape}) | {dtype} |")
         else:
             inputs.append(f"| {name} | ({shape}) | {dtype} | {layout} |")
@@ -386,7 +416,11 @@ def _parse_io_table(
             inputs, outputs = _parse_inline_tensors(contract)
 
     if not outputs:
-        m = re.search(r"output\s*\(([^)]+)\)", contract, re.IGNORECASE)
+        m = re.search(
+            r"(?:output|result|returns?)\s*\(([^)]+)\)",
+            contract,
+            re.IGNORECASE,
+        )
         if m:
             local = _local_clause(contract, m.start(), m.end())
             dtype = _explicit_dtype(local) or TODO_VERIFY

--- a/skills/competition/ninetoothed-op-dev-skill/scripts/_task_spec.py
+++ b/skills/competition/ninetoothed-op-dev-skill/scripts/_task_spec.py
@@ -1,0 +1,687 @@
+"""Load operator task specs from task.md or structured task.yaml (generic)."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    yaml = None  # type: ignore
+
+TODO_VERIFY = "TODO: verify"
+
+
+@dataclass
+class TaskSpec:
+    task_id: str
+    operator: str
+    math: str
+    inputs_rows: str
+    outputs_rows: str
+    broadcast: str
+    layout: str
+    boundaries: str
+    reference: str
+    tests: str
+    benchmark: str
+    benchmark_required: bool
+    risks: str
+    source_label: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "operator": self.operator,
+            "math": self.math,
+            "inputs_rows": self.inputs_rows,
+            "outputs_rows": self.outputs_rows,
+            "broadcast": self.broadcast,
+            "layout": self.layout,
+            "boundaries": self.boundaries,
+            "reference": self.reference,
+            "tests": self.tests,
+            "benchmark": self.benchmark,
+            "benchmark_required": self.benchmark_required,
+            "risks": self.risks,
+        }
+
+
+_NUMBERED_HEADING = re.compile(r"^## (\d+)\.\s+(.+)$", re.MULTILINE)
+_SEMANTICS = re.compile(r"semantics\s*=\s*`([^`]+)`", re.IGNORECASE)
+_OUTPUT_EQ = re.compile(r"output\s*=\s*`([^`]+)`", re.IGNORECASE)
+_IO_TENSOR = re.compile(r"`?(\w+)`?\s*\(([^)]+)\)")
+_IMPLEMENT = re.compile(r"implement \*\*([^*]+)\*\*", re.IGNORECASE)
+_INCOMPLETE = re.compile(
+    r"\bTBD\b|TODO:\s*verify|see contract|see task\.md|pytest per task\.md",
+    re.IGNORECASE,
+)
+_KNOWN_OPS = frozenset(
+    {
+        "mul",
+        "add",
+        "sub",
+        "div",
+        "where",
+        "relu",
+        "softmax",
+        "gelu",
+        "silu",
+        "amin",
+        "amax",
+        "cast",
+        "float",
+        "empty",
+        "zeros",
+        "ones",
+        "leaky_relu",
+        "input",
+        "output",
+        "out",
+    }
+)
+
+
+def _section_map(text: str) -> dict[str, str]:
+    matches = list(_NUMBERED_HEADING.finditer(text))
+    sections: dict[str, str] = {}
+    for i, match in enumerate(matches):
+        title = match.group(2).strip().lower()
+        start = match.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        body = text[start:end].strip()
+        sections[title] = body
+    return sections
+
+
+def _first_line(block: str) -> str:
+    for line in block.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            return stripped
+    return block.strip()
+
+
+def _benchmark_not_required(block: str) -> bool:
+    """Return True when the task explicitly says benchmark is not required / N/A."""
+    low = block.lower().strip()
+    if not low:
+        return False
+    if re.search(r"\bnot required\b", low):
+        return True
+    if re.search(r"\bn/?a\b", low) or low in {"na", "na.", "n/a", "n/a."}:
+        return True
+    return False
+
+
+def _benchmark_required(block: str) -> bool:
+    low = block.lower()
+    if _benchmark_not_required(block):
+        return False
+    if "required" in low:
+        return True
+    return False
+
+
+def _explicit_dtype(text: str) -> str | None:
+    low = text.lower()
+    if "float16" in low or "fp16" in low:
+        return "float16"
+    if "bfloat16" in low or "bf16" in low:
+        return "bfloat16"
+    if "float64" in low or "fp64" in low:
+        return "float64"
+    if "float32" in low or "fp32" in low:
+        return "float32"
+    if re.search(r"\bbool\b", low):
+        return "bool"
+    if "int64" in low or "int32" in low or "int16" in low or "int8" in low:
+        for tok in ("int64", "int32", "int16", "int8"):
+            if tok in low:
+                return tok
+    return None
+
+
+def _explicit_layout(text: str) -> str | None:
+    low = text.lower()
+    if "non-contiguous" in low or "noncontiguous" in low or "strided" in low:
+        return "non-contiguous"
+    if "contiguous" in low:
+        return "contiguous"
+    return None
+
+
+def _local_clause(text: str, match_start: int, match_end: int) -> str:
+    """Return the local statement/table-row/clause around a tensor match.
+
+    Never use the whole contract: dtype/layout must come from this local span.
+    Prefer span limited by separators (; . newline bullet table).
+    """
+    line_start = text.rfind("\n", 0, match_start) + 1
+    line_end = text.find("\n", match_end)
+    if line_end < 0:
+        line_end = len(text)
+    line = text[line_start:line_end]
+    relative_start = match_start - line_start
+    # Split on ';' or '.' (sentence end before next tensor / Output).
+    parts = re.split(r"\s*[;.]\s*", line)
+    if len(parts) > 1:
+        pos = 0
+        for part in parts:
+            idx = line.find(part, pos)
+            if idx < 0:
+                continue
+            if idx <= relative_start < idx + len(part):
+                return part.strip()
+            pos = idx + len(part)
+    if "|" in line:
+        return line.strip()
+    comma_parts = re.split(r"\s*,\s*(?=`?\w+`?\s*\()", line)
+    if len(comma_parts) > 1:
+        pos = 0
+        for part in comma_parts:
+            idx = line.find(part, pos)
+            if idx < 0:
+                continue
+            if idx <= relative_start < idx + len(part):
+                return part.strip()
+            pos = idx + len(part)
+    return line.strip()
+
+
+def _attrs_from_local(name: str, local: str) -> tuple[str, str]:
+    """Extract dtype/layout from a tensor-local span only."""
+    dtype = _explicit_dtype(local) or TODO_VERIFY
+    layout = _explicit_layout(local) or TODO_VERIFY
+    # mask: explicit bool in local span must win over later float leakage.
+    if name.lower() == "mask" and re.search(r"\bbool\b", local, re.IGNORECASE):
+        dtype = "bool"
+    return dtype, layout
+
+
+def _parse_md_io_tables(text: str) -> tuple[list[str], list[str]]:
+    """Parse markdown I/O tables; dtype/layout come from each row only."""
+    inputs: list[str] = []
+    outputs: list[str] = []
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if "|" not in line:
+            i += 1
+            continue
+        headers = [c.strip().lower() for c in line.strip().strip("|").split("|")]
+        if not any("tensor" in h or h == "name" for h in headers):
+            i += 1
+            continue
+        if not any("shape" in h for h in headers):
+            i += 1
+            continue
+        i += 1
+        if i < len(lines) and re.match(r"^\|?\s*-+", lines[i]):
+            i += 1
+        has_layout = any("layout" in h for h in headers)
+        while (
+            i < len(lines) and "|" in lines[i] and not re.match(r"^\|?\s*-+", lines[i])
+        ):
+            cells = [c.strip() for c in lines[i].strip().strip("|").split("|")]
+            row = {
+                headers[j]: (cells[j] if j < len(cells) else "")
+                for j in range(len(headers))
+            }
+            name = ""
+            for key in ("tensor", "name"):
+                for h, v in row.items():
+                    if key in h and v:
+                        name = v.strip("`")
+                        break
+                if name:
+                    break
+            if not name or name.lower() in {"tensor", "name"}:
+                i += 1
+                continue
+            shape = TODO_VERIFY
+            for h, v in row.items():
+                if "shape" in h and v:
+                    shape = v
+                    break
+            dtype_cell = ""
+            for h, v in row.items():
+                if "dtype" in h:
+                    dtype_cell = v
+                    break
+            dtype = _explicit_dtype(dtype_cell) or (
+                dtype_cell if dtype_cell.strip() else TODO_VERIFY
+            )
+            if name.lower() == "mask" and re.search(
+                r"\bbool\b", dtype_cell, re.IGNORECASE
+            ):
+                dtype = "bool"
+            if has_layout:
+                layout_cell = ""
+                for h, v in row.items():
+                    if "layout" in h:
+                        layout_cell = v
+                        break
+                layout = _explicit_layout(layout_cell) or TODO_VERIFY
+                inputs.append(f"| {name} | {shape} | {dtype} | {layout} |")
+            else:
+                outputs.append(f"| {name} | {shape} | {dtype} |")
+            i += 1
+        continue
+    return inputs, outputs
+
+
+def _parse_bullet_io(text: str) -> tuple[list[str], list[str]]:
+    """Parse bullet I/O lines; dtype/layout from that bullet only."""
+    inputs: list[str] = []
+    outputs: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("-"):
+            continue
+        body = stripped[1:].strip()
+        low = body.lower()
+        is_output = (
+            low.startswith("output")
+            or low.startswith("out ")
+            or re.match(r"out\b", low) is not None
+        )
+        # Prefer explicit output/out label; bare `out` name handled below.
+        m_shape = re.search(r"\(([^)]+)\)", body)
+        shape = (
+            "(" + m_shape.group(1).replace(" ", "") + ")" if m_shape else TODO_VERIFY
+        )
+        names = re.findall(r"`(\w+)`", body)
+        if not names:
+            m_name = re.match(r"(?:input|output)?\s*`?([A-Za-z_]\w*)`?\s*\(", body)
+            if m_name and m_name.group(1).lower() not in _KNOWN_OPS - {
+                "input",
+                "output",
+                "out",
+            }:
+                names = [m_name.group(1)]
+        if is_output or (names and names[0].lower() in {"output", "out"}):
+            name = names[0] if names else "output"
+            dtype, _layout = _attrs_from_local(name, body)
+            outputs.append(f"| {name} | {shape} | {dtype} |")
+        elif "scalar" in low and names:
+            dtype, layout = _attrs_from_local(names[0], body)
+            inputs.append(f"| {names[0]} | scalar | {dtype} | {layout} |")
+        else:
+            for name in names or []:
+                if name.lower() in _KNOWN_OPS - {"input"}:
+                    continue
+                dtype, layout = _attrs_from_local(name, body)
+                inputs.append(f"| {name} | {shape} | {dtype} | {layout} |")
+    return inputs, outputs
+
+
+def _parse_inline_tensors(text: str) -> tuple[list[str], list[str]]:
+    """Parse `name (shape)` mentions; attrs from [match, next_match) only."""
+    inputs: list[str] = []
+    outputs: list[str] = []
+    # Strip math/semantics so operator calls are less likely to leak.
+    scrubbed = re.sub(r"semantics\s*=\s*`[^`]+`", "", text, flags=re.IGNORECASE)
+    scrubbed = re.sub(r"torch\.\w+\([^)]*\)", "", scrubbed, flags=re.IGNORECASE)
+
+    matches: list[re.Match[str]] = []
+    for match in _IO_TENSOR.finditer(scrubbed):
+        name, shape = match.group(1), match.group(2).replace(" ", "")
+        if "e.g" in shape.lower() or name.lower() in {"configs", "config", "e"}:
+            continue
+        if name.lower() in _KNOWN_OPS - {"input", "output", "out"}:
+            continue
+        matches.append(match)
+
+    for i, match in enumerate(matches):
+        name = match.group(1)
+        shape = match.group(2).replace(" ", "")
+        # Attribute span: current match → next tensor match (exclusive).
+        span_end = matches[i + 1].start() if i + 1 < len(matches) else len(scrubbed)
+        local = scrubbed[match.start() : span_end]
+        # Also trim at sentence / bullet boundaries inside the span.
+        local = re.split(r"(?<=[.])\s+(?=[A-Z`])", local, maxsplit=1)[0]
+        dtype, layout = _attrs_from_local(name, local)
+        if name.lower() in {"output", "out"}:
+            outputs.append(f"| {name} | ({shape}) | {dtype} |")
+        else:
+            inputs.append(f"| {name} | ({shape}) | {dtype} | {layout} |")
+    return inputs, outputs
+
+
+def _parse_io_table(
+    contract: str, background: str, operator: str
+) -> tuple[str, str, str]:
+    del operator  # operator name must not drive invented I/O fallbacks
+    math = ""
+    sem = _SEMANTICS.search(contract)
+    out_eq = _OUTPUT_EQ.search(contract)
+    if sem:
+        math = sem.group(1).strip()
+    elif out_eq:
+        math = f"output = {out_eq.group(1).strip()}"
+    elif "`where(" in contract:
+        math = contract.strip()
+    elif "out=a+b" in contract.replace(" ", "").lower():
+        math = "out = a + b (elementwise)"
+    elif "=" in contract:
+        math = contract.split(";", 1)[0].strip()
+
+    inputs: list[str] = []
+    outputs: list[str] = []
+
+    table_in, table_out = _parse_md_io_tables(contract)
+    if table_in or table_out:
+        inputs = table_in
+        outputs = table_out
+    else:
+        bullet_in, bullet_out = _parse_bullet_io(contract)
+        if bullet_in or bullet_out:
+            inputs = bullet_in
+            outputs = bullet_out
+        else:
+            inputs, outputs = _parse_inline_tensors(contract)
+
+    if not outputs:
+        m = re.search(r"output\s*\(([^)]+)\)", contract, re.IGNORECASE)
+        if m:
+            local = _local_clause(contract, m.start(), m.end())
+            dtype = _explicit_dtype(local) or TODO_VERIFY
+            outputs.append(f"| output | {m.group(1).replace(' ', '')} | {dtype} |")
+    if not inputs:
+        m = re.search(r"input\s*\(([^)]+)\)", contract, re.IGNORECASE)
+        if m:
+            local = _local_clause(contract, m.start(), m.end())
+            dtype = _explicit_dtype(local) or TODO_VERIFY
+            layout = _explicit_layout(local) or TODO_VERIFY
+            inputs.append(
+                f"| input | {m.group(1).replace(' ', '')} | {dtype} | {layout} |"
+            )
+
+    inputs_rows = (
+        "\n".join(inputs)
+        if inputs
+        else f"| input | {TODO_VERIFY} | {TODO_VERIFY} | {TODO_VERIFY} |"
+    )
+    outputs_rows = (
+        "\n".join(outputs) if outputs else f"| output | {TODO_VERIFY} | {TODO_VERIFY} |"
+    )
+    if not math:
+        impl = _IMPLEMENT.search(background)
+        math = impl.group(1).strip() if impl else (contract.strip() or TODO_VERIFY)
+    return inputs_rows, outputs_rows, math
+
+
+def _operator_name(background: str, contract: str, *, task_id: str = "") -> str:
+    del task_id  # never infer operator semantics from task_id prefixes
+    impl = _IMPLEMENT.search(background)
+    if impl:
+        return impl.group(1).strip()
+    line = _first_line(contract)
+    return line if line else TODO_VERIFY
+
+
+def _resolve_benchmark(benchmark_block: str, deliverables: str) -> tuple[str, bool]:
+    """Return (benchmark_text, benchmark_required)."""
+    if _benchmark_not_required(benchmark_block) or _benchmark_not_required(
+        deliverables
+    ):
+        return "Not required.", False
+    if not benchmark_block.strip():
+        return TODO_VERIFY, False
+    required = _benchmark_required(benchmark_block) or _benchmark_required(deliverables)
+    return _first_line(benchmark_block), required
+
+
+def load_task_spec_from_markdown(
+    text: str, *, source_label: str, task_id: str = ""
+) -> TaskSpec:
+    sections = _section_map(text)
+    math_block = sections.get("math definition", "")
+    io_block = sections.get("inputs and outputs", "")
+    constraints_block = sections.get("constraints", "")
+    deliverables = sections.get("deliverables", "")
+
+    background = sections.get("background", math_block)
+    contract = sections.get("operator contract", "")
+    if not contract and io_block:
+        contract = f"{io_block}\n{math_block}".strip()
+    layout_block = sections.get(
+        "layout / broadcast / dtype",
+        sections.get("layout", constraints_block),
+    )
+    correctness = deliverables or sections.get("correctness requirements", "")
+    # Prefer dedicated correctness section when present.
+    if sections.get("correctness requirements"):
+        correctness = sections["correctness requirements"]
+    benchmark_block = sections.get("benchmark requirements", "")
+    if not benchmark_block:
+        for ln in deliverables.splitlines():
+            if "benchmark" in ln.lower():
+                benchmark_block = ln.strip()
+                break
+
+    operator = _operator_name(background, contract or math_block, task_id=task_id)
+    io_source = io_block.strip() if io_block.strip() else contract
+    inputs_rows, outputs_rows, parsed_math = _parse_io_table(
+        io_source, background, operator
+    )
+    math = _first_line(math_block) if math_block else parsed_math
+    if not math or math == operator:
+        math = parsed_math or _first_line(math_block) or TODO_VERIFY
+    reference = ""
+    if math and math != TODO_VERIFY:
+        reference = math
+    elif "torch." in (contract or math_block or io_block):
+        reference = _first_line(math_block or contract or io_block)
+
+    tests_lines = [
+        ln.strip()
+        for ln in correctness.splitlines()
+        if ln.strip() and not ln.strip().startswith("```")
+    ]
+    tests = "\n".join(tests_lines[:6]) if tests_lines else TODO_VERIFY
+
+    boundaries = (
+        sections.get("boundary cases")
+        or sections.get("boundaries")
+        or sections.get("boundary conditions")
+        or sections.get("constraints")
+        or sections.get("likely failure modes")
+        or TODO_VERIFY
+    )
+    if not str(boundaries).strip():
+        boundaries = TODO_VERIFY
+    layout = layout_block.strip() if layout_block.strip() else TODO_VERIFY
+
+    broadcast_src = ""
+    if any("broadcast" in title for title in sections):
+        broadcast_src = _first_line(layout_block or constraints_block or "")
+    if not broadcast_src:
+        for block in (layout_block, constraints_block, contract, io_block):
+            if block and "broadcast" in block.lower():
+                broadcast_src = _first_line(block)
+                break
+    broadcast = broadcast_src if broadcast_src else TODO_VERIFY
+
+    benchmark, benchmark_required = _resolve_benchmark(benchmark_block, deliverables)
+
+    return TaskSpec(
+        task_id=task_id,
+        operator=operator,
+        math=math or operator,
+        inputs_rows=inputs_rows,
+        outputs_rows=outputs_rows,
+        broadcast=broadcast,
+        layout=layout,
+        boundaries=boundaries,
+        reference=reference or TODO_VERIFY,
+        tests=tests,
+        benchmark=benchmark,
+        benchmark_required=benchmark_required,
+        risks=boundaries if boundaries != TODO_VERIFY else TODO_VERIFY,
+        source_label=source_label,
+    )
+
+
+def load_task_spec_from_yaml(data: dict[str, Any], *, source_label: str) -> TaskSpec:
+    def _rows(items: list[dict[str, Any]], *, with_layout: bool) -> str:
+        lines = []
+        for item in items:
+            shape = str(item.get("shape") or TODO_VERIFY)
+            dtype = str(item.get("dtype") or TODO_VERIFY)
+            if with_layout:
+                layout = str(item.get("layout") or TODO_VERIFY)
+                lines.append(f"| {item['name']} | {shape} | {dtype} | {layout} |")
+            else:
+                lines.append(f"| {item['name']} | {shape} | {dtype} |")
+        return "\n".join(lines)
+
+    inputs = data.get("inputs", [])
+    outputs = data.get("outputs", [])
+    bench_raw = data.get("benchmark")
+    if bench_raw is None:
+        benchmark, benchmark_required = TODO_VERIFY, False
+    else:
+        benchmark, benchmark_required = _resolve_benchmark(
+            str(bench_raw), str(data.get("deliverables", ""))
+        )
+        if "benchmark_required" in data:
+            benchmark_required = bool(data["benchmark_required"])
+    return TaskSpec(
+        task_id=str(data.get("task_id", "")),
+        operator=str(data.get("operator") or TODO_VERIFY),
+        math=str(data.get("math") or data.get("operator") or TODO_VERIFY),
+        inputs_rows=_rows(inputs, with_layout=True)
+        if inputs
+        else f"| input | {TODO_VERIFY} | {TODO_VERIFY} | {TODO_VERIFY} |",
+        outputs_rows=_rows(outputs, with_layout=False)
+        if outputs
+        else f"| output | {TODO_VERIFY} | {TODO_VERIFY} |",
+        broadcast=str(data.get("broadcast") or TODO_VERIFY),
+        layout=str(data.get("layout") or TODO_VERIFY),
+        boundaries=str(data.get("boundaries") or TODO_VERIFY),
+        reference=str(data.get("reference") or TODO_VERIFY),
+        tests=str(data.get("tests") or TODO_VERIFY),
+        benchmark=benchmark,
+        benchmark_required=benchmark_required,
+        risks=str(data.get("risks") or TODO_VERIFY),
+        source_label=source_label,
+    )
+
+
+def load_task_spec(path: Path) -> TaskSpec:
+    yaml_path = path.with_suffix(".yaml")
+    if yaml_path.is_file():
+        if yaml is None:
+            raise RuntimeError("PyYAML required to read task.yaml")
+        data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError(f"invalid YAML root in {yaml_path}")
+        return load_task_spec_from_yaml(data, source_label=str(yaml_path))
+
+    text = path.read_text(encoding="utf-8")
+    task_id = path.parent.name if path.name == "task.md" else path.stem
+    return load_task_spec_from_markdown(text, source_label=str(path), task_id=task_id)
+
+
+REQUIRED_CARD_FIELDS = (
+    "operator",
+    "math",
+    "inputs_rows",
+    "outputs_rows",
+    "broadcast",
+    "layout",
+    "boundaries",
+    "reference",
+    "tests",
+    "benchmark",
+)
+
+
+def validate_card_text(card: str) -> list[str]:
+    bad: list[str] = []
+    for line in card.splitlines():
+        if _INCOMPLETE.search(line):
+            bad.append(f"incomplete field in line: {line.strip()}")
+    _bogus_inputs = re.compile(
+        r"^\|\s*(mul|add|sub|div|where|relu|softmax|gelu|silu)\s*\|",
+        re.IGNORECASE,
+    )
+    in_inputs = False
+    for line in card.splitlines():
+        if line.strip().startswith("## Inputs"):
+            in_inputs = True
+            continue
+        if in_inputs and line.strip().startswith("## "):
+            in_inputs = False
+        if in_inputs and _bogus_inputs.match(line.strip()):
+            bad.append(f"bogus input tensor parsed from math expr: {line.strip()}")
+    return bad
+
+
+def find_tbd_fields(spec: TaskSpec) -> list[str]:
+    bad: list[str] = []
+    data = spec.as_dict()
+    for key in REQUIRED_CARD_FIELDS:
+        value = str(data[key])
+        if not value.strip():
+            bad.append(key)
+        elif _INCOMPLETE.search(value):
+            bad.append(key)
+    return bad
+
+
+# Capability-family probes keyed by operator text in the *spec*, never by task_id.
+OPERATOR_PROBES: dict[str, dict[str, list[str]]] = {
+    "gelu": {
+        "required_any": ["gelu", "libdevice.erf", "F.gelu"],
+        "forbidden": ["def silu", "F.silu", "ntl.sigmoid(ntl.cast"],
+    },
+    "broadcast_add": {
+        "required_any": ["broadcast_add", ".expand("],
+        "forbidden": [".expand(m, n).contiguous()", "expand(m, n).contiguous()"],
+    },
+}
+
+
+def _probes_from_spec(spec: TaskSpec | None) -> dict[str, list[str]]:
+    if spec is None:
+        return {}
+    blob = f"{spec.operator}\n{spec.math}\n{spec.reference}".lower()
+    if "gelu" in blob:
+        return OPERATOR_PROBES["gelu"]
+    if "broadcast" in blob and ("add" in blob or "+" in blob):
+        return OPERATOR_PROBES["broadcast_add"]
+    return {}
+
+
+def operator_contract_violations(
+    task_id: str, test_source: str, spec: TaskSpec | None = None
+) -> list[str]:
+    """Check test source against explicit operator/spec text only (ignore task_id)."""
+    del task_id
+    low = test_source.lower()
+    violations: list[str] = []
+    probes = _probes_from_spec(spec)
+    for token in probes.get("forbidden", []):
+        if token.lower() in low:
+            violations.append(f"forbidden token in test source: {token}")
+    required = probes.get("required_any", [])
+    if required and not any(tok.lower() in low for tok in required):
+        violations.append(f"missing required operator markers: {required}")
+
+    if spec:
+        op_blob = f"{spec.operator} {spec.math}".lower()
+        if "gelu" in op_blob:
+            if "silu" in low and "gelu" not in low:
+                violations.append("spec requires GELU but test implements SiLU")
+        if "broadcast" in op_blob:
+            if "expand(m, n).contiguous()" in low or "expand(m,n).contiguous()" in low:
+                violations.append(
+                    "broadcast materialized via expand().contiguous() in wrapper"
+                )
+    return violations

--- a/skills/competition/ninetoothed-op-dev-skill/scripts/audit_packed_skill.py
+++ b/skills/competition/ninetoothed-op-dev-skill/scripts/audit_packed_skill.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Audit a *packed* runtime skill tree (not the competition source workspace).
+
+Checks:
+- forbidden directories absent
+- banned competition tokens absent from .md / .py
+- example-relative references resolve
+- path-aware CLIs expose --repo-root
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+FORBIDDEN_DIRS = (
+    "evals",
+    "worktree_patches",
+    "submission",
+    ".pytest_cache",
+    ".quick_validate_cache",
+    "__pycache__",
+)
+
+PATH_AWARE_SCRIPTS = (
+    "env_check.py",
+    "run_correctness.py",
+    "run_benchmark.py",
+    "repo_pattern_index.py",
+    "check_patch_minimality.py",
+)
+
+# Backtick paths that look like in-package relative files (not URLs / shell vars).
+_REL_PATH_RE = re.compile(
+    r"`(solution/[^`\s]+|tests/test_example_[^`\s]+|"
+    r"(?:task|task_card|run_prompt|run_log|changed_files|"
+    r"correctness_result|benchmark_result|failure_diagnosis|verify)\.[a-z]+)`"
+)
+
+
+def _fail(msg: str) -> None:
+    raise AssertionError(msg)
+
+
+def audit_forbidden_dirs(root: Path) -> list[str]:
+    errors: list[str] = []
+    for name in FORBIDDEN_DIRS:
+        if (root / name).exists():
+            errors.append(f"forbidden directory present: {name}/")
+    for p in root.rglob("*"):
+        if p.is_dir() and p.name in {
+            ".pytest_cache",
+            ".quick_validate_cache",
+            "__pycache__",
+        }:
+            errors.append(
+                f"forbidden cache directory: {p.relative_to(root).as_posix()}"
+            )
+        if p.is_file() and p.suffix.lower() in {".pyc", ".pyo"}:
+            errors.append(f"forbidden bytecode file: {p.relative_to(root).as_posix()}")
+    return errors
+
+
+def audit_answer_artifacts(root: Path) -> list[str]:
+    """Flag answer-shaped / workspace-only artifacts without competition jargon."""
+    errors: list[str] = []
+    for p in root.rglob("*"):
+        if not p.is_file():
+            continue
+        name = p.name.lower()
+        rel = p.relative_to(root).as_posix()
+        if name.startswith(("bench_", "generate_", "compare_")) and p.suffix == ".py":
+            if p.parent.name == "scripts":
+                errors.append(f"non-runtime script packed: {rel}")
+        # Generic answer-shaped names (not competition study IDs).
+        if name in {"answer_key.md", "grader_secret.py", "sealed_answers.json"}:
+            errors.append(f"answer-shaped artifact: {rel}")
+    return errors
+
+
+def audit_example_relative_refs(root: Path) -> list[str]:
+    errors: list[str] = []
+    examples = root / "examples"
+    if not examples.is_dir():
+        return ["missing examples/"]
+    for ex_dir in sorted(p for p in examples.iterdir() if p.is_dir()):
+        for md in ex_dir.glob("*.md"):
+            text = md.read_text(encoding="utf-8")
+            for match in _REL_PATH_RE.finditer(text):
+                rel = match.group(1)
+                # Skip placeholders / globs
+                if "<" in rel or "*" in rel or rel.endswith("/"):
+                    continue
+                target = ex_dir / rel
+                if not target.exists():
+                    errors.append(
+                        f"example ref missing: {ex_dir.name}/{md.name} -> {rel}"
+                    )
+        # Uniform artifact set must exist for each example
+        for required in ("task.md", "task_card.md", "verify.py"):
+            if not (ex_dir / required).is_file():
+                errors.append(
+                    f"example missing required file: {ex_dir.name}/{required}"
+                )
+    return errors
+
+
+def audit_path_aware_repo_root(root: Path) -> list[str]:
+    errors: list[str] = []
+    scripts = root / "scripts"
+    py = sys.executable
+    for name in PATH_AWARE_SCRIPTS:
+        script = scripts / name
+        if not script.is_file():
+            errors.append(f"missing path-aware script: scripts/{name}")
+            continue
+        proc = subprocess.run(
+            [py, str(script), "--help"],
+            cwd=scripts,
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode != 0:
+            errors.append(f"{name} --help failed: {proc.stderr.strip()}")
+            continue
+        if "--repo-root" not in proc.stdout:
+            errors.append(f"{name} missing --repo-root in --help")
+    return errors
+
+
+def audit_packed_tree(root: Path) -> list[str]:
+    root = root.resolve()
+    if not (root / "SKILL.md").is_file():
+        return [f"not a skill root: {root}"]
+    errors: list[str] = []
+    errors.extend(audit_forbidden_dirs(root))
+    errors.extend(audit_answer_artifacts(root))
+    errors.extend(audit_example_relative_refs(root))
+    errors.extend(audit_path_aware_repo_root(root))
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Audit a packed runtime skill directory."
+    )
+    parser.add_argument(
+        "packed_root",
+        type=Path,
+        help="Path to packed skill root (output of pack_runtime_skill.py)",
+    )
+    args = parser.parse_args()
+    errors = audit_packed_tree(args.packed_root)
+    if errors:
+        print("PACK_POST_AUDIT: FAIL", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+    print(f"PACK_POST_AUDIT: PASS ({args.packed_root})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/competition/ninetoothed-op-dev-skill/scripts/check_patch_minimality.py
+++ b/skills/competition/ninetoothed-op-dev-skill/scripts/check_patch_minimality.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Check git diff for patch minimality and competition compliance warnings."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from _paths import add_repo_root_args, resolve_logs_dir, resolve_repo_root
+
+
+def run_git(args: list[str], cwd: Path) -> tuple[int, str]:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    out = (proc.stdout or "") + (proc.stderr or "")
+    return proc.returncode, out.strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Patch minimality and compliance warnings."
+    )
+    add_repo_root_args(parser)
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        default=None,
+        help="Git repo to inspect (default: --repo-root)",
+    )
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    try:
+        root = resolve_repo_root(args)
+    except FileNotFoundError as exc:
+        print(exc, file=sys.stderr)
+        return 2
+
+    repo = args.repo or root
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out = args.output or resolve_logs_dir(args) / "patch_minimality" / f"check_{ts}.md"
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    warnings: list[str] = []
+    notes: list[str] = []
+
+    code, inside = run_git(["rev-parse", "--is-inside-work-tree"], repo)
+    if code != 0 or inside != "true":
+        body = "# Patch minimality check\n\n**SKIP**: not a git repository.\n"
+        out.write_text(body, encoding="utf-8")
+        print(f"wrote {out} (skip)")
+        return 0
+
+    _, stat = run_git(["diff", "--stat"], repo)
+    _, status = run_git(["status", "--short"], repo)
+    _, names = run_git(["diff", "--name-only"], repo)
+
+    deleted_tests = [n for n in names.splitlines() if "test" in n.lower() and n.strip()]
+    src_core = [
+        n
+        for n in names.splitlines()
+        if n.startswith("src/ninetoothed/")
+        and any(x in n for x in ("generation.py", "cudaifier.py", "build.py"))
+    ]
+    skill_only = [n for n in names.splitlines() if "ninetoothed-op-dev-skill" in n]
+
+    if deleted_tests:
+        # Heuristic only — warn if test files appear in diff names with D status
+        for line in status.splitlines():
+            if line.startswith("D") and "test" in line.lower():
+                warnings.append(f"Deleted test-related path: `{line}`")
+
+    if src_core:
+        warnings.append(
+            "Diff touches compiler-core-ish files under src/ninetoothed/: "
+            + ", ".join(f"`{n}`" for n in src_core[:8])
+        )
+    if skill_only and not names.strip():
+        notes.append("Only skill package paths changed.")
+
+    body = f"""# Patch minimality check
+
+- At (UTC): {datetime.now(timezone.utc).isoformat()}
+- Repo: `{repo}`
+
+## git status --short
+
+```
+{status or "(clean)"}
+```
+
+## git diff --stat
+
+```
+{stat or "(no unstaged diff)"}
+```
+
+## Warnings
+
+{chr(10).join(f"- {w}" for w in warnings) if warnings else "- (none)"}
+
+## Notes
+
+{chr(10).join(f"- {n}" for n in notes) if notes else "- Prefer minimal operator/test patches; avoid unrelated refactors."}
+"""
+    out.write_text(body, encoding="utf-8")
+    print(f"wrote {out}")
+    return 1 if warnings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/competition/ninetoothed-op-dev-skill/scripts/env_check.py
+++ b/skills/competition/ninetoothed-op-dev-skill/scripts/env_check.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Offline environment check for a NineToothed repository + this skill package."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import platform
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from _paths import (
+    add_repo_root_args,
+    is_ninetoothed_repo,
+    resolve_examples_root,
+    resolve_logs_dir,
+    resolve_repo_root,
+    resolve_skill_root,
+)
+from _paths import (
+    skill_root as detect_skill_root,
+)
+
+
+def run_cmd(
+    cmd: list[str], cwd: Path | None = None, timeout: int = 30
+) -> tuple[int, str, str]:
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+    except Exception as exc:  # noqa: BLE001
+        return 1, "", str(exc)
+
+
+def module_status(name: str) -> tuple[bool, str]:
+    spec = importlib.util.find_spec(name)
+    if spec is None:
+        return False, "not installed"
+    try:
+        mod = importlib.import_module(name)
+    except Exception as exc:  # noqa: BLE001
+        return False, f"import error: {exc}"
+    version = getattr(mod, "__version__", "unknown")
+    return True, str(version)
+
+
+def check_torch_cuda() -> list[str]:
+    lines: list[str] = []
+    ok, version = module_status("torch")
+    lines.append(f"- torch: {'OK' if ok else 'MISSING'} ({version})")
+    if not ok:
+        return lines
+    import torch
+
+    cuda_ok = torch.cuda.is_available()
+    lines.append(f"- torch.cuda.is_available: {cuda_ok}")
+    if cuda_ok:
+        lines.append(f"- torch.cuda.device_count: {torch.cuda.device_count()}")
+        lines.append(f"- torch.cuda.device_name(0): {torch.cuda.get_device_name(0)}")
+        cap = torch.cuda.get_device_capability(0)
+        lines.append(f"- torch.cuda.get_device_capability(0): {cap}")
+    return lines
+
+
+def check_paths(repo: Path, skill: Path, examples: Path | None) -> list[str]:
+    lines: list[str] = []
+    checks: list[tuple[str, Path]] = [
+        ("repo src/ninetoothed", repo / "src" / "ninetoothed"),
+        ("repo tests/", repo / "tests"),
+        ("skill SKILL.md", skill / "SKILL.md"),
+        ("skill scripts/", skill / "scripts"),
+    ]
+    if examples is not None:
+        checks.append(("examples root", examples))
+    for label, path in checks:
+        status = "OK" if path.exists() else "MISSING"
+        try:
+            rel = path.relative_to(repo) if path.is_relative_to(repo) else path
+        except (ValueError, AttributeError):
+            rel = path
+        lines.append(f"- [{status}] {label}: `{rel}`")
+    if not is_ninetoothed_repo(repo):
+        lines.append(
+            "- [MISSING] repo does not look like NineToothed (need src/ninetoothed/)"
+        )
+    return lines
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Environment check for NineToothed repo + ninetoothed-op-dev-skill."
+    )
+    add_repo_root_args(parser)
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=None,
+        help="Markdown report path (default: <repo-root>/logs/env_check.md)",
+    )
+    args = parser.parse_args()
+
+    try:
+        repo = resolve_repo_root(args)
+    except FileNotFoundError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+    try:
+        skill = resolve_skill_root(args) if args.skill_root else detect_skill_root()
+    except FileNotFoundError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+    examples = resolve_examples_root(args)
+    log_dir = resolve_logs_dir(args)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    report_path = args.report or (log_dir / "env_check.md")
+
+    code, nvidia_out, nvidia_err = run_cmd(["nvidia-smi"])
+    nvcc_code, nvcc_out, nvcc_err = run_cmd(["nvcc", "--version"])
+    pytest_code, pytest_out, pytest_err = run_cmd(
+        [sys.executable, "-m", "pytest", "--version"]
+    )
+
+    torch_ok, torch_version = module_status("torch")
+    ninetoothed_ok, ninetoothed_version = module_status("ninetoothed")
+
+    lines = [
+        "# Environment Check Report",
+        "",
+        f"- Generated at (UTC): {datetime.now(timezone.utc).isoformat()}",
+        f"- NineToothed repo root: `{repo}`",
+        f"- Skill root: `{skill}`",
+        f"- Examples root: `{examples}`"
+        if examples
+        else "- Examples root: (not found; optional)",
+        "",
+        "## Python",
+        "",
+        f"- executable: `{sys.executable}`",
+        f"- version: `{sys.version.split()[0]}`",
+        f"- platform: `{platform.platform()}`",
+        "",
+        "## GPU / CUDA",
+        "",
+        f"- nvidia-smi exit code: `{code}`",
+    ]
+    if nvidia_out:
+        lines.append("```text")
+        lines.append(nvidia_out)
+        lines.append("```")
+    if nvidia_err:
+        lines.append(f"- nvidia-smi stderr: `{nvidia_err}`")
+
+    lines.extend(["", f"- nvcc exit code: `{nvcc_code}`"])
+    if nvcc_out:
+        lines.append("```text")
+        lines.append(nvcc_out)
+        lines.append("```")
+    elif nvcc_err:
+        lines.append(f"- nvcc: `{nvcc_err}`")
+
+    lines.extend(["", "## Python packages", ""])
+    lines.extend(check_torch_cuda())
+    lines.append(
+        f"- ninetoothed: {'OK' if ninetoothed_ok else 'MISSING'} ({ninetoothed_version})"
+    )
+
+    if pytest_code == 0:
+        lines.append(f"- pytest: OK ({pytest_out})")
+    else:
+        lines.append(f"- pytest: MISSING or error ({pytest_err or pytest_out})")
+
+    lines.extend(["", "## Repository / skill paths", ""])
+    lines.extend(check_paths(repo, skill, examples))
+
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            "- Pass `--repo-root .` when running inside a NineToothed fork/clone.",
+            "- This script does not install packages; it only reports status.",
+            "- Skill package must not require `third_party/` outside the target repo.",
+            "",
+        ]
+    )
+
+    report_path.write_text("\n".join(lines), encoding="utf-8")
+    print(f"Wrote report to {report_path}")
+
+    # Soft exit: missing optional GPU tools is OK; missing repo/skill is not.
+    if not is_ninetoothed_repo(repo):
+        print(
+            "FAIL: --repo-root is not a NineToothed repository (need src/ninetoothed/).",
+            file=sys.stderr,
+        )
+        return 1
+    if not (skill / "SKILL.md").is_file():
+        print("FAIL: skill SKILL.md missing.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/competition/ninetoothed-op-dev-skill/scripts/gate_eval.py
+++ b/skills/competition/ninetoothed-op-dev-skill/scripts/gate_eval.py
@@ -1,0 +1,227 @@
+"""Evidence-based gate evaluation and scorecard scoring (no pytest→10/10 auto map)."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from _task_spec import (
+    TaskSpec,
+    find_tbd_fields,
+    load_task_spec,
+    operator_contract_violations,
+    validate_card_text,
+)
+
+RUBRIC_MAX = {
+    "task_completion": 4,
+    "tests_verification": 2,
+    "performance_awareness": 1,
+    "patch_minimality": 1,
+    "repo_style": 1,
+    "process_compliance": 1,
+}
+
+
+@dataclass
+class GateEvidence:
+    task_id: str
+    task_card: Path | None = None
+    task_spec_path: Path | None = None
+    correctness_log: Path | None = None
+    benchmark_log: Path | None = None
+    test_source: Path | None = None
+    patch_dir: Path | None = None
+    pytest_verdict: str = "UNKNOWN"
+    skill_used: str = "yes"
+
+
+@dataclass
+class GateResult:
+    ok: bool
+    failures: list[str] = field(default_factory=list)
+    scores: dict[str, int] = field(default_factory=dict)
+    total: int = 0
+    max_total: int = 10
+
+    def add_failure(self, reason: str) -> None:
+        self.failures.append(reason)
+        self.ok = False
+
+
+def _read(path: Path | None) -> str:
+    if path is None or not path.is_file():
+        return ""
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def _parse_correctness_verdict(log_text: str) -> str:
+    m = re.search(r"Verdict:\s*\*\*(PASS|FAIL|SKIP)\*\*", log_text, re.IGNORECASE)
+    if m:
+        return m.group(1).upper()
+    if re.search(r"\bSKIPPED\b", log_text, re.IGNORECASE):
+        return "SKIP"
+    if "Exit code: `0`" in log_text:
+        return "PASS"
+    if "Exit code:" in log_text:
+        return "FAIL"
+    return "UNKNOWN"
+
+
+def _benchmark_log_ok(log_text: str) -> bool:
+    if not log_text.strip():
+        return False
+    if re.search(r"\bSKIP\b", log_text, re.IGNORECASE):
+        return False
+    return bool(re.search(r"benchmark|ms/iter|ratio", log_text, re.IGNORECASE))
+
+
+def evaluate_gate(evidence: GateEvidence) -> GateResult:
+    result = GateResult(ok=True, scores={k: 0 for k in RUBRIC_MAX})
+
+    spec: TaskSpec | None = None
+    if evidence.task_spec_path and evidence.task_spec_path.is_file():
+        spec = load_task_spec(evidence.task_spec_path)
+
+    card_text = _read(evidence.task_card)
+    if not card_text:
+        result.add_failure("missing task_card.md")
+    else:
+        tbd = validate_card_text(card_text)
+        if tbd:
+            for item in tbd:
+                result.add_failure(item)
+        if spec:
+            for item in find_tbd_fields(spec):
+                result.add_failure(f"task spec field incomplete: {item}")
+
+    corr_text = _read(evidence.correctness_log)
+    corr_verdict = _parse_correctness_verdict(corr_text)
+    if not corr_text:
+        result.add_failure("missing correctness log")
+    elif corr_verdict == "SKIP":
+        result.add_failure("correctness log indicates SKIP")
+    elif corr_verdict == "FAIL":
+        result.add_failure("correctness log verdict FAIL")
+    elif corr_verdict != "PASS":
+        result.add_failure(f"correctness log verdict not PASS ({corr_verdict})")
+
+    if evidence.pytest_verdict.upper() == "SKIP":
+        result.add_failure("pytest verdict SKIP")
+    elif evidence.pytest_verdict.upper() == "FAIL":
+        result.add_failure("pytest verdict FAIL")
+
+    test_text = _read(evidence.test_source)
+    if not test_text:
+        result.add_failure("missing test source for operator audit")
+    elif spec or evidence.task_id:
+        for v in operator_contract_violations(evidence.task_id, test_text, spec):
+            result.add_failure(v)
+
+    bench_required = spec.benchmark_required if spec else False
+    bench_text = _read(evidence.benchmark_log)
+    if bench_required:
+        if not bench_text:
+            result.add_failure("benchmark required but log missing")
+        elif not _benchmark_log_ok(bench_text):
+            result.add_failure("benchmark log empty or SKIP")
+
+    # Itemized scores — derived from evidence, never pytest alone
+    if not any(
+        "operator" in f or "forbidden" in f or "GELU" in f for f in result.failures
+    ):
+        if test_text and corr_verdict == "PASS":
+            result.scores["task_completion"] = RUBRIC_MAX["task_completion"]
+
+    if corr_text and corr_verdict == "PASS" and evidence.correctness_log:
+        result.scores["tests_verification"] = RUBRIC_MAX["tests_verification"]
+
+    if bench_required:
+        if bench_text and _benchmark_log_ok(bench_text):
+            result.scores["performance_awareness"] = RUBRIC_MAX["performance_awareness"]
+    elif bench_text and _benchmark_log_ok(bench_text):
+        result.scores["performance_awareness"] = RUBRIC_MAX["performance_awareness"]
+    elif bench_text and re.search(r"\bN/A\b", bench_text, re.IGNORECASE):
+        result.scores["performance_awareness"] = RUBRIC_MAX["performance_awareness"]
+    elif corr_text and re.search(
+        r"benchmark.*\bN/A\b|not required", corr_text, re.IGNORECASE
+    ):
+        result.scores["performance_awareness"] = RUBRIC_MAX["performance_awareness"]
+
+    if evidence.patch_dir and evidence.patch_dir.is_dir():
+        files = list(evidence.patch_dir.rglob("*"))
+        nontrivial = [p for p in files if p.is_file() and p.name != "README.md"]
+        if len(nontrivial) <= 6:
+            result.scores["patch_minimality"] = RUBRIC_MAX["patch_minimality"]
+
+    if test_text:
+        has_arr = "def arrangement" in test_text
+        has_app = "def application" in test_text
+        has_make = "ninetoothed.make" in test_text or "ntl." in test_text
+        if has_arr and has_app and has_make:
+            result.scores["repo_style"] = RUBRIC_MAX["repo_style"]
+
+    card_ok = card_text and not validate_card_text(card_text)
+    has_session = bool(
+        evidence.task_card
+        and evidence.task_card.parent.joinpath("session_evidence.json").is_file()
+    )
+    has_patch_gate = bool(evidence.patch_dir and evidence.patch_dir.is_dir())
+    if (
+        card_ok
+        and corr_text
+        and corr_verdict == "PASS"
+        and (has_session or has_patch_gate)
+    ):
+        result.scores["process_compliance"] = RUBRIC_MAX["process_compliance"]
+
+    result.total = sum(result.scores.values())
+    result.max_total = sum(RUBRIC_MAX.values())
+
+    if result.failures:
+        result.ok = False
+    elif result.total < result.max_total:
+        result.ok = False
+        result.failures.append(
+            f"incomplete rubric score {result.total}/{result.max_total}"
+        )
+
+    return result
+
+
+def format_scorecard_markdown(evidence: GateEvidence, result: GateResult) -> str:
+    lines = [
+        f"# Scorecard — {evidence.task_id}",
+        "",
+        f"- Skill used: **{evidence.skill_used}**",
+        f"- Gate: **{'PASS' if result.ok else 'FAIL'}**",
+        f"- Pytest (input only, not auto-scored): `{evidence.pytest_verdict}`",
+        "- Rubric: official 0–10 operator rubric (see SKILL.md)",
+        "",
+        "| Sub-item | Max | Score | Evidence / notes |",
+        "|----------|-----|-------|------------------|",
+        f"| Task completion | 4 | {result.scores['task_completion']} | test source + operator contract |",
+        f"| Tests & verification | 2 | {result.scores['tests_verification']} | correctness log |",
+        f"| Performance awareness | 1 | {result.scores['performance_awareness']} | benchmark log if required |",
+        f"| Patch minimality | 1 | {result.scores['patch_minimality']} | patch dir size |",
+        f"| Repo style consistency | 1 | {result.scores['repo_style']} | ninetoothed patterns in test |",
+        f"| Process & compliance | 1 | {result.scores['process_compliance']} | task_card + logs |",
+        f"| **Total** | **10** | **{result.total}** | evidence-based |",
+        "",
+        "## Gate failures",
+        "",
+    ]
+    if result.failures:
+        lines.extend(f"- {f}" for f in result.failures)
+    else:
+        lines.append("- (none)")
+    lines.extend(["", "## Evidence paths", ""])
+    for label, path in (
+        ("task_card", evidence.task_card),
+        ("correctness", evidence.correctness_log),
+        ("benchmark", evidence.benchmark_log),
+        ("test_source", evidence.test_source),
+    ):
+        lines.append(f"- {label}: `{path}`" if path else f"- {label}: (missing)")
+    return "\n".join(lines) + "\n"

--- a/skills/competition/ninetoothed-op-dev-skill/scripts/make_task_card.py
+++ b/skills/competition/ninetoothed-op-dev-skill/scripts/make_task_card.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Emit a structured operator task card from task.md / task.yaml; fail on TBD."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from _task_spec import (
+    find_tbd_fields,
+    load_task_spec,
+    load_task_spec_from_markdown,
+    validate_card_text,
+)
+
+TEMPLATE = """# Task card
+
+- Generated at (UTC): {timestamp}
+- Source: {source}
+
+## Operator
+
+{operator}
+
+## Math definition
+
+{math}
+
+## Inputs
+
+| Tensor | Shape | dtype | Layout |
+|--------|-------|-------|--------|
+{inputs_rows}
+
+## Outputs
+
+| Tensor | Shape | dtype |
+|--------|-------|-------|
+{outputs_rows}
+
+## Broadcast
+
+{broadcast}
+
+## Layout / stride / offset
+
+{layout}
+
+## Boundary cases
+
+{boundaries}
+
+## Reference implementation
+
+{reference}
+
+## Tests required
+
+{tests}
+
+## Benchmark required
+
+{benchmark}
+
+## Unsupported / risks
+
+{risks}
+"""
+
+
+def build_card_from_spec(spec) -> str:
+    return TEMPLATE.format(
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        source=spec.source_label,
+        operator=spec.operator,
+        math=spec.math,
+        inputs_rows=spec.inputs_rows,
+        outputs_rows=spec.outputs_rows,
+        broadcast=spec.broadcast,
+        layout=spec.layout,
+        boundaries=spec.boundaries,
+        reference=spec.reference,
+        tests=spec.tests,
+        benchmark=spec.benchmark,
+        risks=spec.risks,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate task_card.md from task spec."
+    )
+    parser.add_argument(
+        "--task-file", type=Path, help="Path to task.md (default: stdin)"
+    )
+    parser.add_argument("--output", type=Path, help="Output path (default: stdout)")
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="Only validate an existing task_card.md at --output",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        default=True,
+        help="Exit 1 if any required field is TBD (default: on)",
+    )
+    parser.add_argument(
+        "--no-strict",
+        action="store_false",
+        dest="strict",
+        help="Allow TBD placeholders (not for gates)",
+    )
+    args = parser.parse_args()
+
+    if args.validate_only:
+        if not args.output or not args.output.is_file():
+            print(
+                "validate-only requires --output pointing to task_card.md",
+                file=sys.stderr,
+            )
+            return 1
+        bad = validate_card_text(args.output.read_text(encoding="utf-8"))
+        if bad:
+            for item in bad:
+                print(f"INVALID: {item}", file=sys.stderr)
+            return 1
+        print(f"OK: {args.output}")
+        return 0
+
+    if args.task_file:
+        spec = load_task_spec(args.task_file)
+    else:
+        text = sys.stdin.read()
+        spec = load_task_spec_from_markdown(text, source_label="stdin")
+
+    card = build_card_from_spec(spec)
+    bad = find_tbd_fields(spec) + validate_card_text(card)
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(card, encoding="utf-8")
+        print(f"wrote {args.output}")
+    else:
+        print(card, end="")
+
+    if args.strict and bad:
+        for item in bad:
+            print(f"TBD/invalid: {item}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/competition/ninetoothed-op-dev-skill/scripts/quick_validate.py
+++ b/skills/competition/ninetoothed-op-dev-skill/scripts/quick_validate.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Fast offline validation for the runtime skill package (no self-test task IDs)."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from _paths import (
+    add_skill_root_arg,
+    resolve_skill_root,
+)
+from _paths import (
+    skill_root as detect_skill_root,
+)
+
+REQUIRED_REFERENCES = [
+    "00_repo_map.md",
+    "01_ninetoothed_concepts.md",
+    "02_arrangement_application_patterns.md",
+    "03_elementwise_broadcast_patterns.md",
+    "04_reduction_block_patterns.md",
+    "05_layout_stride_offset_patterns.md",
+    "06_correctness_testing_patterns.md",
+    "07_benchmark_patterns.md",
+    "08_generated_source_aot_debugging.md",
+    "09_failure_diagnosis_playbook.md",
+    "10_patch_minimality_checklist.md",
+    "11_unsupported_cases.md",
+]
+
+# Formal runtime CLIs + private helpers (_paths, _task_spec).
+REQUIRED_SCRIPTS = [
+    "env_check.py",
+    "make_task_card.py",
+    "run_correctness.py",
+    "run_benchmark.py",
+    "repo_pattern_index.py",
+    "check_patch_minimality.py",
+    "score_task.py",
+    "gate_eval.py",
+    "summarize_run.py",
+    "quick_validate.py",
+    "audit_packed_skill.py",
+    "_paths.py",
+    "_task_spec.py",
+]
+
+REQUIRED_CAPABILITY_REFS = {
+    "elementwise_broadcast": "03_elementwise_broadcast_patterns.md",
+    "reduction_block": "04_reduction_block_patterns.md",
+    "layout_sensitive": "05_layout_stride_offset_patterns.md",
+    "performance_diagnosis": "07_benchmark_patterns.md",
+}
+
+
+def _fail(msg: str) -> int:
+    print(msg, file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate ninetoothed-op-dev-skill package structure (runtime)."
+    )
+    add_skill_root_arg(parser)
+    args = parser.parse_args()
+
+    try:
+        root = resolve_skill_root(args) if args.skill_root else detect_skill_root()
+    except FileNotFoundError as exc:
+        return _fail(str(exc))
+
+    skill_md = root / "SKILL.md"
+    if not skill_md.is_file():
+        return _fail("missing SKILL.md")
+
+    text = skill_md.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        return _fail("SKILL.md missing YAML frontmatter")
+    if "name: ninetoothed-op-dev-skill" not in text:
+        return _fail("SKILL.md missing skill name in frontmatter")
+
+    # Packed installs omit the packer; competition-only trees must be absent there.
+    is_packed = not (root / "scripts" / "pack_runtime_skill.py").is_file()
+
+    if "## Execution decision tree (MANDATORY)" not in text:
+        return _fail("SKILL.md missing mandatory Execution decision tree")
+    for token in (
+        "### D1 — Emit task card first",
+        "### D3 — `rg` before code",
+        "### D5 — Layout branch",
+        "### D7 — Failure loop",
+        "### D8 — Performance branch",
+        "assert not inp.is_contiguous()",
+    ):
+        if token not in text:
+            return _fail(f"SKILL.md missing decision-tree constraint: {token}")
+
+    ref = root / "references"
+    for name in REQUIRED_REFERENCES:
+        if not (ref / name).is_file():
+            return _fail(f"missing reference: {name}")
+
+    for family, name in REQUIRED_CAPABILITY_REFS.items():
+        if not (ref / name).is_file():
+            return _fail(f"missing capability reference for {family}: {name}")
+
+    scripts = root / "scripts"
+    for name in REQUIRED_SCRIPTS:
+        if not (scripts / name).is_file():
+            return _fail(f"missing script: {name}")
+
+    forbidden_runtime = [
+        root / ".quick_validate_cache",
+        root / "submission",
+        root / "worktree_patches",
+        root / "evals",
+    ]
+    if is_packed:
+        # Packed trees must not contain competition-only corpora.
+        pass
+    for path in forbidden_runtime:
+        if path.exists():
+            # Source workspace may still have evals/; packed installs must not.
+            if path.name == "evals" and not is_packed:
+                continue
+            return _fail(
+                f"runtime skill must not contain `{path.relative_to(root)}` "
+                "(exclude workspace-only / answer artifacts from the package)"
+            )
+
+    # Generic cache / bytecode artifacts must not ship in runtime trees.
+    for p in root.rglob("*"):
+        if p.is_dir() and p.name in {
+            "__pycache__",
+            ".pytest_cache",
+            ".quick_validate_cache",
+        }:
+            return _fail(f"forbidden cache directory: {p.relative_to(root)}")
+        if p.is_file() and p.suffix.lower() in {".pyc", ".pyo"}:
+            return _fail(f"forbidden bytecode file: {p.relative_to(root)}")
+
+    print("Skill is valid!")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/competition/ninetoothed-op-dev-skill/scripts/repo_pattern_index.py
+++ b/skills/competition/ninetoothed-op-dev-skill/scripts/repo_pattern_index.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Scan a NineToothed repo (and optional examples) and emit a keyword pattern index."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+from _paths import (
+    add_repo_root_args,
+    resolve_examples_root,
+    resolve_repo_root,
+    resolve_skill_root,
+)
+from _paths import (
+    skill_root as detect_skill_root,
+)
+
+KEYWORDS = [
+    "arrangement",
+    "application",
+    "ninetoothed.make",
+    "ninetoothed.jit",
+    "benchmark",
+    "pytest",
+    "generated",
+    "aot",
+    "stride",
+    "contiguous",
+    "softmax",
+    "max_pool",
+    "data_ptr",
+    "ntl.where",
+    "atomic_add",
+]
+
+
+def scan_repo(root: Path) -> dict[str, list[str]]:
+    hits: dict[str, list[str]] = defaultdict(list)
+    if not root.is_dir():
+        return hits
+    for path in sorted(root.rglob("*.py")):
+        if ".git" in path.parts or "__pycache__" in path.parts:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        rel = path.relative_to(root).as_posix()
+        for kw in KEYWORDS:
+            if kw in text:
+                hits[kw].append(rel)
+    return {k: v[:40] for k, v in hits.items()}
+
+
+def render(nt_hits: dict, ex_hits: dict, nt_label: str, ex_label: str) -> str:
+    lines = [
+        "# Generated repo pattern index",
+        "",
+        f"- Generated at (UTC): {datetime.now(timezone.utc).isoformat()}",
+        "- **Auto-generated** by `scripts/repo_pattern_index.py` — re-run after upstream updates.",
+        f"- ninetoothed root label: `{nt_label}`",
+        f"- examples root label: `{ex_label}`",
+        "",
+        "## <repo-root>",
+        "",
+    ]
+    for kw in KEYWORDS:
+        files = nt_hits.get(kw, [])
+        lines.append(f"### `{kw}` ({len(files)} files)")
+        for f in files[:15]:
+            lines.append(f"- `{nt_label}/{f}`")
+        if len(files) > 15:
+            lines.append(f"- … and {len(files) - 15} more")
+        lines.append("")
+
+    lines.extend(["## examples-root (optional)", ""])
+    if not ex_hits:
+        lines.append("_No `--examples-root` / examples tree found._")
+        lines.append("")
+    for kw in KEYWORDS:
+        files = ex_hits.get(kw, [])
+        lines.append(f"### `{kw}` ({len(files)} files)")
+        for f in files[:15]:
+            lines.append(f"- `{ex_label}/{f}`")
+        if len(files) > 15:
+            lines.append(f"- … and {len(files) - 15} more")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build keyword index of NineToothed repos."
+    )
+    add_repo_root_args(parser)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Output markdown (default: <skill>/references/generated_repo_pattern_index.md)",
+    )
+    args = parser.parse_args()
+
+    try:
+        nt_root = resolve_repo_root(args)
+    except FileNotFoundError as exc:
+        print(exc, file=sys.stderr)
+        return 2
+
+    examples = resolve_examples_root(args)
+    try:
+        sk = resolve_skill_root(args) if args.skill_root else detect_skill_root()
+    except FileNotFoundError:
+        sk = Path(__file__).resolve().parents[1]
+
+    out = args.output or (sk / "references" / "generated_repo_pattern_index.md")
+    nt = scan_repo(nt_root)
+    ex = scan_repo(examples) if examples else {}
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(
+        render(
+            nt, ex, nt_label=".", ex_label=str(examples) if examples else "(missing)"
+        ),
+        encoding="utf-8",
+    )
+    print(f"wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/competition/ninetoothed-op-dev-skill/scripts/run_benchmark.py
+++ b/skills/competition/ninetoothed-op-dev-skill/scripts/run_benchmark.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Run a benchmark command and save raw output plus summary markdown."""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from _paths import add_repo_root_args, resolve_logs_dir, resolve_repo_root
+
+
+def _slug(name: str) -> str:
+    return "".join(c if c.isalnum() or c in "-_" else "_" for c in name)[:80]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run benchmark command with logging.")
+    add_repo_root_args(parser)
+    parser.add_argument("--task-id", required=True)
+    parser.add_argument("--baseline", default="torch reference (document in report)")
+    parser.add_argument("--input-sizes", default="document in report")
+    parser.add_argument("--conclusion", default="fill after reviewing raw output")
+    parser.add_argument("--cwd", type=Path, default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+
+    if args.command and args.command[0] == "--":
+        args.command = args.command[1:]
+    if not args.command:
+        parser.error("command required")
+
+    try:
+        root = resolve_repo_root(args)
+    except FileNotFoundError as exc:
+        print(exc, file=sys.stderr)
+        return 2
+
+    cwd = args.cwd or root
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out_md = (
+        args.output
+        or resolve_logs_dir(args) / "benchmark" / f"{_slug(args.task_id)}_{ts}.md"
+    )
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    raw_path = out_md.with_suffix(".raw.txt")
+
+    proc = subprocess.run(args.command, cwd=cwd, capture_output=True, text=True)
+    raw = proc.stdout + ("\n" + proc.stderr if proc.stderr else "")
+    raw_path.write_text(raw, encoding="utf-8")
+
+    try:
+        raw_rel = str(raw_path.relative_to(root))
+    except ValueError:
+        raw_rel = str(raw_path)
+
+    report = f"""# Benchmark run
+
+- Task: `{args.task_id}`
+- At (UTC): {datetime.now(timezone.utc).isoformat()}
+- Working directory: `{cwd}`
+- Command: `{" ".join(shlex.quote(c) for c in args.command)}`
+- Exit code: `{proc.returncode}`
+- Baseline: {args.baseline}
+- Input sizes: {args.input_sizes}
+
+## Raw output
+
+`{raw_rel}`
+
+```
+{raw[-12000:] if len(raw) > 12000 else raw}
+```
+
+## Conclusion
+
+{args.conclusion}
+"""
+    out_md.write_text(report, encoding="utf-8")
+    print(f"benchmark log: {out_md} (exit {proc.returncode})")
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/competition/ninetoothed-op-dev-skill/scripts/run_correctness.py
+++ b/skills/competition/ninetoothed-op-dev-skill/scripts/run_correctness.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Run a correctness command (typically pytest) and save logs under logs/correctness/."""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from _paths import add_repo_root_args, resolve_logs_dir, resolve_repo_root
+
+
+def _slug(name: str) -> str:
+    return "".join(c if c.isalnum() or c in "-_" else "_" for c in name)[:80]
+
+
+def write_report(
+    out_md: Path,
+    *,
+    command: list[str],
+    cwd: Path,
+    returncode: int,
+    stdout: str,
+    stderr: str,
+    task_id: str,
+    repo: Path,
+) -> None:
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    log_base = out_md.with_suffix("")
+    stdout_path = Path(str(log_base) + ".stdout.txt")
+    stderr_path = Path(str(log_base) + ".stderr.txt")
+    stdout_path.write_text(stdout, encoding="utf-8")
+    stderr_path.write_text(stderr, encoding="utf-8")
+
+    def _rel(p: Path) -> str:
+        try:
+            return str(p.relative_to(repo))
+        except ValueError:
+            return str(p)
+
+    verdict = "PASS" if returncode == 0 else "FAIL"
+    body = f"""# Correctness run
+
+- Task: `{task_id}`
+- At (UTC): {datetime.now(timezone.utc).isoformat()}
+- Working directory: `{cwd}`
+- Command: `{" ".join(shlex.quote(c) for c in command)}`
+- Exit code: `{returncode}`
+- Verdict: **{verdict}**
+
+## Logs
+
+- stdout: `{_rel(stdout_path)}`
+- stderr: `{_rel(stderr_path)}`
+
+## stdout (tail)
+
+```
+{stdout[-8000:] if len(stdout) > 8000 else stdout}
+```
+
+## stderr (tail)
+
+```
+{stderr[-4000:] if len(stderr) > 4000 else stderr}
+```
+"""
+    out_md.write_text(body, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run correctness command with logging."
+    )
+    add_repo_root_args(parser)
+    parser.add_argument(
+        "--task-id", required=True, help="Task identifier for log naming"
+    )
+    parser.add_argument(
+        "--cwd",
+        type=Path,
+        default=None,
+        help="Working directory (default: --repo-root)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Markdown report path (default: <repo>/logs/correctness/<task>_<ts>.md)",
+    )
+    parser.add_argument(
+        "command", nargs=argparse.REMAINDER, help="Command after --, e.g. pytest ..."
+    )
+    args = parser.parse_args()
+
+    if args.command and args.command[0] == "--":
+        args.command = args.command[1:]
+    if not args.command:
+        parser.error("command required after optional --")
+
+    try:
+        root = resolve_repo_root(args)
+    except FileNotFoundError as exc:
+        print(exc, file=sys.stderr)
+        return 2
+
+    cwd = args.cwd or root
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out = (
+        args.output
+        or resolve_logs_dir(args) / "correctness" / f"{_slug(args.task_id)}_{ts}.md"
+    )
+
+    proc = subprocess.run(
+        args.command,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    write_report(
+        out,
+        command=args.command,
+        cwd=cwd,
+        returncode=proc.returncode,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+        task_id=args.task_id,
+        repo=root,
+    )
+    print(f"correctness log: {out} (exit {proc.returncode})")
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/competition/ninetoothed-op-dev-skill/scripts/score_task.py
+++ b/skills/competition/ninetoothed-op-dev-skill/scripts/score_task.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Scorecard template generation and evidence-based gate evaluation."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from _paths import add_skill_root_arg
+from gate_eval import GateEvidence, evaluate_gate, format_scorecard_markdown
+
+
+def _cmd_template(args: argparse.Namespace) -> int:
+    if args.output is None:
+        # Default: stdout only — never create evals/scorecards inside the skill tree.
+        out_path: Path | None = None
+    else:
+        out_path = args.output
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+    body = f"""# Scorecard — {args.task_id}
+
+- Run: `{args.run_id}`
+- Skill used: **{args.skill_used}**
+- At (UTC): {datetime.now(timezone.utc).isoformat()}
+- Rubric: official 0–10 operator rubric (see SKILL.md)
+
+| Sub-item | Max | Score | Evidence / notes |
+|----------|-----|-------|------------------|
+| Task completion | 4 | | fill from evidence |
+| Tests & verification | 2 | | fill from evidence |
+| Performance awareness | 1 | | fill from evidence |
+| Patch minimality | 1 | | fill from evidence |
+| Repo style consistency | 1 | | fill from evidence |
+| Process & compliance | 1 | | fill from evidence |
+| **Total** | **10** | | do not copy pytest PASS → 10 |
+
+## Commands
+
+```
+(record exact commands from the run)
+```
+
+## Log paths
+
+- correctness:
+- benchmark:
+- patch check:
+
+## Verdict
+
+- [ ] PASS for self-test gate (requires `score_task.py evaluate`)
+- [ ] Needs iteration
+"""
+    if out_path is None:
+        print(body, end="")
+    else:
+        out_path.write_text(body, encoding="utf-8")
+        print(f"wrote {out_path}")
+    return 0
+
+
+def _cmd_evaluate(args: argparse.Namespace) -> int:
+    evidence = GateEvidence(
+        task_id=args.task_id,
+        task_card=args.task_card,
+        task_spec_path=args.task_spec,
+        correctness_log=args.correctness_log,
+        benchmark_log=args.benchmark_log,
+        test_source=args.test_source,
+        patch_dir=args.patch_dir,
+        pytest_verdict=args.pytest_verdict,
+        skill_used=args.skill_used,
+    )
+    result = evaluate_gate(evidence)
+    body = format_scorecard_markdown(evidence, result)
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(body, encoding="utf-8")
+        print(f"wrote {args.output}")
+    else:
+        print(body, end="")
+
+    if not result.ok:
+        for failure in result.failures:
+            print(f"GATE FAIL: {failure}", file=sys.stderr)
+        return 1
+    print(f"GATE PASS: {result.total}/10", file=sys.stderr)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Scorecard template or evidence gate.")
+    add_skill_root_arg(parser)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_tpl = sub.add_parser("template", help="Emit empty scorecard template")
+    p_tpl.add_argument("--task-id", required=True)
+    p_tpl.add_argument("--run-id", default="run1")
+    p_tpl.add_argument("--skill-used", choices=("yes", "no"), default="yes")
+    p_tpl.add_argument("--output", type=Path, default=None)
+    p_tpl.set_defaults(func=_cmd_template)
+
+    p_ev = sub.add_parser(
+        "evaluate", help="Score from evidence; fail gate on missing/TBD/SKIP"
+    )
+    p_ev.add_argument("--task-id", required=True)
+    p_ev.add_argument("--task-card", type=Path, required=True)
+    p_ev.add_argument(
+        "--task-spec",
+        type=Path,
+        default=None,
+        help="Task specification markdown/YAML (required for operator-contract checks)",
+    )
+    p_ev.add_argument("--correctness-log", type=Path, default=None)
+    p_ev.add_argument("--benchmark-log", type=Path, default=None)
+    p_ev.add_argument("--test-source", type=Path, default=None)
+    p_ev.add_argument("--patch-dir", type=Path, default=None)
+    p_ev.add_argument("--pytest-verdict", default="UNKNOWN")
+    p_ev.add_argument("--skill-used", choices=("yes", "no"), default="yes")
+    p_ev.add_argument("--output", type=Path, default=None)
+    p_ev.set_defaults(func=_cmd_evaluate)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/competition/ninetoothed-op-dev-skill/scripts/summarize_run.py
+++ b/skills/competition/ninetoothed-op-dev-skill/scripts/summarize_run.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Summarize artifacts from a single agent run directory."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+
+ARTIFACTS = [
+    "task.md",
+    "task_card.md",
+    "run_prompt.md",
+    "run_log.md",
+    "changed_files.md",
+    "correctness_result.md",
+    "benchmark_result.md",
+    "failure_diagnosis.md",
+    "scorecard.md",
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Summarize a task run directory.")
+    parser.add_argument("run_dir", type=Path, help="Directory containing run artifacts")
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    run_dir = args.run_dir.resolve()
+    if not run_dir.is_dir():
+        raise SystemExit(f"not a directory: {run_dir}")
+
+    out = args.output or run_dir / "RUN_SUMMARY.md"
+    present = [name for name in ARTIFACTS if (run_dir / name).is_file()]
+    missing = [name for name in ARTIFACTS if name not in present]
+
+    body = f"""# Run summary
+
+- Directory: `{run_dir}`
+- At (UTC): {datetime.now(timezone.utc).isoformat()}
+
+## Present artifacts
+
+{chr(10).join("- " + p for p in present) or "- (none)"}
+
+## Missing (optional unless task requires)
+
+{chr(10).join("- " + m for m in missing)}
+
+## Quick links
+
+"""
+    for name in present:
+        body += f"- [{name}](./{name})\n"
+
+    out.write_text(body, encoding="utf-8")
+    print(f"wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/competition/ninetoothed-op-dev-skill/tests/README.md
+++ b/skills/competition/ninetoothed-op-dev-skill/tests/README.md
@@ -1,0 +1,15 @@
+# Tests
+
+```bash
+pytest skills/competition/ninetoothed-op-dev-skill/tests -q
+```
+
+| File | Purpose |
+|------|---------|
+| `test_skill_structure.py` | SKILL frontmatter, references, scripts, forbidden runtime paths |
+| `test_scripts_smoke.py` | `--help` and score_task write |
+| `test_pack_whitelist.py` | Packer whitelist (source tree only) |
+| `test_pack_post_audit.py` | Post-pack audit of packed output |
+| `test_eval_gate.py` | make_task_card / gate_eval / score_task |
+
+No GPU required for this suite.

--- a/skills/competition/ninetoothed-op-dev-skill/tests/test_pack_post_audit.py
+++ b/skills/competition/ninetoothed-op-dev-skill/tests/test_pack_post_audit.py
@@ -1,0 +1,51 @@
+"""Post-pack audit: must inspect pack *output*, not only the source workspace."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = SKILL_ROOT / "scripts"
+PACKER = SCRIPTS / "pack_runtime_skill.py"
+
+sys.path.insert(0, str(SCRIPTS))
+from audit_packed_skill import audit_packed_tree  # noqa: E402
+
+
+def _pack(dst: Path) -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(PACKER),
+            "--src",
+            str(SKILL_ROOT),
+            "--dst",
+            str(dst),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+
+
+@pytest.mark.skipif(not PACKER.is_file(), reason="packer absent in packed install")
+def test_pack_then_audit_output(tmp_path: Path):
+    """Authoritative source-workspace check: pack → audit the pack output only."""
+    dst = tmp_path / "ninetoothed-op-dev-skill-runtime"
+    _pack(dst)
+    errors = audit_packed_tree(dst)
+    assert not errors, "\n".join(errors)
+
+
+def test_runtime_tree_in_place_audit():
+    """Packed install (no packer): audit the installed skill root itself."""
+    if PACKER.is_file():
+        pytest.skip(
+            "source workspace uses test_pack_then_audit_output against pack output"
+        )
+    errors = audit_packed_tree(SKILL_ROOT)
+    assert not errors, "\n".join(errors)

--- a/skills/competition/ninetoothed-op-dev-skill/tests/test_pack_whitelist.py
+++ b/skills/competition/ninetoothed-op-dev-skill/tests/test_pack_whitelist.py
@@ -1,0 +1,100 @@
+"""Whitelist pack tests (no GPU)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = SKILL_ROOT / "scripts"
+PACKER = SCRIPTS / "pack_runtime_skill.py"
+
+RUNTIME_SCRIPTS = {
+    "_paths.py",
+    "_task_spec.py",
+    "env_check.py",
+    "quick_validate.py",
+    "make_task_card.py",
+    "gate_eval.py",
+    "score_task.py",
+    "run_correctness.py",
+    "run_benchmark.py",
+    "repo_pattern_index.py",
+    "check_patch_minimality.py",
+    "summarize_run.py",
+    "audit_packed_skill.py",
+}
+
+
+@pytest.mark.skipif(not PACKER.is_file(), reason="packer absent in packed install")
+def test_pack_runtime_whitelist_only(tmp_path: Path):
+    dst = tmp_path / "runtime_skill"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(PACKER),
+            "--src",
+            str(SKILL_ROOT),
+            "--dst",
+            str(dst),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert (dst / "SKILL.md").is_file()
+    assert (dst / "pyproject.toml").is_file()
+    assert (dst / "references" / "00_repo_map.md").is_file()
+    assert (dst / "references" / "11_unsupported_cases.md").is_file()
+    assert not (dst / "references" / "generated_repo_pattern_index.md").exists()
+    assert not (dst / "evals").exists()
+    assert not (dst / "submission").exists()
+    assert not (dst / "worktree_patches").exists()
+    assert not (dst / "tests" / "test_eval_gate.py").exists()
+    script_names = {p.name for p in (dst / "scripts").iterdir() if p.is_file()}
+    assert script_names == RUNTIME_SCRIPTS
+    assert "pack_runtime_skill.py" not in script_names
+    assert "task_spec.py" not in script_names
+    for bad_prefix in ("bench_", "generate_", "compare_"):
+        assert not any(n.startswith(bad_prefix) for n in script_names)
+    example_dirs = {p.name for p in (dst / "examples").iterdir() if p.is_dir()}
+    assert example_dirs == {
+        "01_elementwise_broadcast_add",
+        "03_rowwise_softmax_reduce",
+        "05_non_contiguous_transpose_add",
+        "09_performance_regression_fix",
+    }
+    for name in example_dirs:
+        ex = dst / "examples" / name
+        assert (ex / "task.md").is_file()
+        assert (ex / "task_card.md").is_file()
+        assert (ex / "verify.py").is_file()
+        assert not (ex / "scorecard.md").exists()
+        assert not any(ex.rglob("*worktree*"))
+    assert (
+        dst
+        / "examples"
+        / "01_elementwise_broadcast_add"
+        / "solution"
+        / "broadcast_add.py"
+    ).is_file()
+    assert (
+        dst
+        / "examples"
+        / "05_non_contiguous_transpose_add"
+        / "tests"
+        / "test_example_strided_add.py"
+    ).is_file()
+    assert (
+        dst
+        / "examples"
+        / "09_performance_regression_fix"
+        / "solution"
+        / "add_tunable.py"
+    ).is_file()
+    ref_text = (dst / "REFERENCE.md").read_text(encoding="utf-8")
+    assert "Apache-2.0" in ref_text
+    assert "submission/" not in ref_text

--- a/skills/competition/ninetoothed-op-dev-skill/tests/test_scripts_smoke.py
+++ b/skills/competition/ninetoothed-op-dev-skill/tests/test_scripts_smoke.py
@@ -154,6 +154,100 @@ pytest vs `torch.where(mask, x, y)`.
 Benchmark not required.
 """
 
+UNNUMBERED_HEADINGS_TASK = """# Task — unnumbered headings
+
+## Background
+
+Implement **elementwise add**.
+
+## Operator contract
+
+- input `x` (N,) float32 contiguous
+- input `y` (N,) float32 contiguous
+- output `z` (N,) float32
+
+semantics = `torch.add(x, y)`.
+
+## Layout / broadcast / dtype
+
+Contiguous. Broadcast: none.
+
+## Boundary cases
+
+Odd N.
+
+## Correctness requirements
+
+pytest vs `torch.add`.
+
+## Benchmark requirements
+
+Benchmark not required.
+"""
+
+COMBINED_ROLE_TABLE_TASK = """# Task — combined role table
+
+## 1. Background
+
+Implement **masked where**.
+
+## 2. Operator contract
+
+| Role | Tensor | Shape | dtype | Layout |
+|------|--------|-------|-------|--------|
+| input | x | (M,1) | float16 | non-contiguous |
+| input | y | (1,N) | float16 | contiguous |
+| input | mask | (M,N) | bool | contiguous |
+| output | z | (M,N) | float16 | contiguous |
+
+semantics = `torch.where(mask, x, y)`.
+
+## 3. Layout / broadcast / dtype
+
+Per-tensor layouts as listed. Broadcast: x over N and y over M.
+
+## 4. Boundary cases
+
+Odd M,N and all-false mask.
+
+## 5. Correctness requirements
+
+pytest vs `torch.where(mask, x, y)`.
+
+## 6. Benchmark requirements
+
+Benchmark not required.
+"""
+
+INLINE_NAMED_OUTPUT_TASK = """# Task — inline named output
+
+## 1. Background
+
+Implement **elementwise add**.
+
+## 2. Operator contract
+
+Inputs: `x` (N,) float32 contiguous; `y` (N,) float32 contiguous. Output `z` (N,) float32.
+
+semantics = `torch.add(x, y)`.
+
+## 3. Layout / broadcast / dtype
+
+Contiguous. Broadcast: none.
+
+## 4. Boundary cases
+
+Odd N.
+
+## 5. Correctness requirements
+
+pytest vs `torch.add`.
+
+## 6. Benchmark requirements
+
+Benchmark not required.
+"""
+
 
 def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
@@ -442,3 +536,50 @@ Implement **masked where**.
     assert results[0]["y"] == ("float16", "contiguous")
     assert results[0]["mask"] == ("bool", "contiguous")
     assert results[0]["out"] == ("float16",)
+
+
+def _strict_card(tmp_path: Path, name: str, body: str) -> str:
+    task = tmp_path / f"{name}.md"
+    out = tmp_path / f"{name}_card.md"
+    task.write_text(body, encoding="utf-8")
+    proc = _run(
+        [
+            "make_task_card.py",
+            "--task-file",
+            str(task),
+            "--output",
+            str(out),
+            "--strict",
+        ]
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    text = out.read_text(encoding="utf-8")
+    assert "TODO: verify" not in text
+    return text
+
+
+def test_task_card_accepts_unnumbered_headings(tmp_path: Path):
+    text = _strict_card(tmp_path, "unnumbered", UNNUMBERED_HEADINGS_TASK)
+    by_name = _io_rows_by_name(text)
+    assert by_name["x"][2:] == ["float32", "contiguous"]
+    assert by_name["y"][2:] == ["float32", "contiguous"]
+    assert by_name["z"][1:] == ["(N,)", "float32"]
+    assert "Odd N" in text
+
+
+def test_task_card_combined_role_table_routes_output(tmp_path: Path):
+    text = _strict_card(tmp_path, "role_table", COMBINED_ROLE_TABLE_TASK)
+    by_name = _io_rows_by_name(text)
+    assert by_name["x"][2:] == ["float16", "non-contiguous"]
+    assert by_name["y"][2:] == ["float16", "contiguous"]
+    assert by_name["mask"][2:] == ["bool", "contiguous"]
+    assert by_name["z"][1:] == ["(M,N)", "float16"]
+    assert "Odd M,N and all-false mask" in text
+
+
+def test_task_card_inline_named_output_routes_output(tmp_path: Path):
+    text = _strict_card(tmp_path, "inline_output", INLINE_NAMED_OUTPUT_TASK)
+    by_name = _io_rows_by_name(text)
+    assert by_name["x"][2:] == ["float32", "contiguous"]
+    assert by_name["y"][2:] == ["float32", "contiguous"]
+    assert by_name["z"][1:] == ["(N,)", "float32"]

--- a/skills/competition/ninetoothed-op-dev-skill/tests/test_scripts_smoke.py
+++ b/skills/competition/ninetoothed-op-dev-skill/tests/test_scripts_smoke.py
@@ -1,0 +1,444 @@
+"""Smoke tests for helper scripts (--help and no-GPU paths)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+REPO_ACCESS_SCRIPTS = {
+    "env_check.py",
+    "run_correctness.py",
+    "run_benchmark.py",
+    "repo_pattern_index.py",
+    "check_patch_minimality.py",
+}
+
+TEXT_ONLY_SCRIPTS = {
+    "make_task_card.py",
+    "score_task.py",
+    "summarize_run.py",
+    "quick_validate.py",
+}
+
+MIXED_LAYOUT_TASK = """# Task — mixed_layout_probe
+
+## 1. Background
+
+Implement **masked where** with mixed layouts.
+
+## 2. Operator contract
+
+- input `x` (M, N) float16 non-contiguous
+- input `y` (M, N) float16 contiguous
+- input `mask` (M, N) bool contiguous
+- output `out` (M, N) float16
+
+## 3. Layout / broadcast / dtype
+
+Per-tensor layouts as listed in inputs. Broadcast: none.
+
+## 4. Constraints
+
+M,N ≥ 1; mask must be bool.
+
+## 5. Correctness requirements
+
+pytest vs `torch.where(mask, x, y)`.
+
+## 6. Benchmark requirements
+
+Benchmark not required.
+"""
+
+MISSING_FIELDS_TASK = """# Task — missing_fields_probe
+
+## 1. Background
+
+Implement **elementwise add**.
+
+## 2. Operator contract
+
+Two tensors; details omitted on purpose.
+"""
+
+EXPLICIT_BENCH_NA_TASK = """# Task — bench_na_probe
+
+## 1. Background
+
+Implement **elementwise add**.
+
+## 2. Operator contract
+
+| Tensor | Shape | dtype | Layout |
+|--------|-------|-------|--------|
+| a | (N,) | float32 | contiguous |
+| b | (N,) | float32 | contiguous |
+
+| Tensor | Shape | dtype |
+|--------|-------|-------|
+| output | (N,) | float32 |
+
+semantics = `torch.add(a, b)`.
+
+## 3. Layout / broadcast / dtype
+
+Contiguous. Broadcast: none.
+
+## 4. Constraints
+
+N ≥ 1.
+
+## 5. Correctness requirements
+
+pytest vs `torch.add`.
+
+## 6. Benchmark requirements
+
+Benchmark not required.
+"""
+
+OPERATOR_NOT_INPUT_TASK = """# Task — op_name_not_input
+
+## 1. Background
+
+Implement **elementwise mul**.
+
+## 2. Operator contract
+
+semantics = `mul(x, y)`; `x` (N,) float32 contiguous; `y` (N,) float32 contiguous; output (N,) float32.
+
+## 3. Layout / broadcast / dtype
+
+Contiguous. Broadcast: none.
+
+## 4. Constraints
+
+N ≥ 1.
+
+## 5. Correctness requirements
+
+pytest vs `torch.mul`.
+
+## 6. Benchmark requirements
+
+Benchmark not required.
+"""
+
+INLINE_MIXED_BOUNDARY_TASK = """# Task — inline_mixed_boundary
+
+## 1. Background
+
+Implement **masked where** with mixed layouts.
+
+## 2. Operator contract
+
+Inputs: `x` (M,1) float16 non-contiguous; `y` (1,N) float16 contiguous; `mask` (M,N) bool contiguous. Output `out` (M,N) float16.
+
+## 3. Layout / broadcast / dtype
+
+Per-tensor layouts as listed. Broadcast: none.
+
+## 4. Boundary cases
+
+Odd M,N and all-false mask.
+
+## 5. Correctness requirements
+
+pytest vs `torch.where(mask, x, y)`.
+
+## 6. Benchmark requirements
+
+Benchmark not required.
+"""
+
+
+def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, *args],
+        cwd=SCRIPTS,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_scripts_help():
+    for name in sorted(REPO_ACCESS_SCRIPTS | TEXT_ONLY_SCRIPTS):
+        proc = _run([name, "--help"])
+        assert proc.returncode == 0, f"{name}: {proc.stderr}"
+        if name in REPO_ACCESS_SCRIPTS:
+            assert "--repo-root" in proc.stdout, name
+        if name in TEXT_ONLY_SCRIPTS:
+            assert "--repo-root" not in proc.stdout, name
+
+
+def test_score_task_writes(tmp_path: Path):
+    out = tmp_path / "sc.md"
+    proc = _run(
+        [
+            "score_task.py",
+            "template",
+            "--task-id",
+            "demo_elementwise_add",
+            "--output",
+            str(out),
+        ]
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert out.is_file()
+    assert "do not copy pytest PASS" in out.read_text(encoding="utf-8")
+
+
+def test_make_task_card_mixed_layout_per_tensor(tmp_path: Path):
+    task = tmp_path / "task.md"
+    task.write_text(MIXED_LAYOUT_TASK, encoding="utf-8")
+    out = tmp_path / "task_card.md"
+    proc = _run(
+        [
+            "make_task_card.py",
+            "--task-file",
+            str(task),
+            "--output",
+            str(out),
+            "--strict",
+        ]
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    text = out.read_text(encoding="utf-8")
+    assert "| x | (M,N) | float16 | non-contiguous |" in text.replace(" ", "") or (
+        "| x |" in text and "float16" in text and "non-contiguous" in text
+    )
+    # Per-tensor layouts must not be collapsed to one global value.
+    assert "non-contiguous" in text
+    assert "| y |" in text and "contiguous" in text
+    assert "| mask |" in text and "bool" in text
+    # y and mask contiguous; x non-contiguous — all present
+    lines = [
+        ln
+        for ln in text.splitlines()
+        if ln.startswith("| x ") or ln.startswith("| y ") or ln.startswith("| mask ")
+    ]
+    by_name = {}
+    for ln in lines:
+        cells = [c.strip() for c in ln.strip("|").split("|")]
+        if len(cells) >= 4:
+            by_name[cells[0]] = cells
+    assert by_name["x"][2] == "float16" and by_name["x"][3] == "non-contiguous"
+    assert by_name["y"][2] == "float16" and by_name["y"][3] == "contiguous"
+    assert by_name["mask"][2] == "bool" and by_name["mask"][3] == "contiguous"
+    assert "Not required" in text
+
+
+def test_make_task_card_missing_fields_strict_fails(tmp_path: Path):
+    task = tmp_path / "task.md"
+    task.write_text(MISSING_FIELDS_TASK, encoding="utf-8")
+    out = tmp_path / "task_card.md"
+    proc = _run(
+        [
+            "make_task_card.py",
+            "--task-file",
+            str(task),
+            "--output",
+            str(out),
+            "--strict",
+        ]
+    )
+    assert proc.returncode == 1, proc.stdout
+    assert (
+        "TBD" in proc.stderr
+        or "TODO" in proc.stderr
+        or "invalid" in proc.stderr.lower()
+    )
+
+
+def test_make_task_card_explicit_benchmark_not_required(tmp_path: Path):
+    task = tmp_path / "task.md"
+    task.write_text(EXPLICIT_BENCH_NA_TASK, encoding="utf-8")
+    out = tmp_path / "task_card.md"
+    proc = _run(
+        [
+            "make_task_card.py",
+            "--task-file",
+            str(task),
+            "--output",
+            str(out),
+            "--strict",
+        ]
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert "Not required" in out.read_text(encoding="utf-8")
+
+
+def test_make_task_card_operator_name_not_input_tensor(tmp_path: Path):
+    task = tmp_path / "task.md"
+    task.write_text(OPERATOR_NOT_INPUT_TASK, encoding="utf-8")
+    out = tmp_path / "task_card.md"
+    proc = _run(
+        [
+            "make_task_card.py",
+            "--task-file",
+            str(task),
+            "--output",
+            str(out),
+            "--strict",
+        ]
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    text = out.read_text(encoding="utf-8")
+    assert "| mul |" not in text.lower().replace(" ", "") or "| mul |" not in text
+    in_inputs = False
+    for ln in text.splitlines():
+        if ln.strip().startswith("## Inputs"):
+            in_inputs = True
+            continue
+        if in_inputs and ln.strip().startswith("## "):
+            break
+        if in_inputs and ln.strip().startswith("|"):
+            assert not ln.strip().lower().startswith("| mul |"), ln
+    assert "| x |" in text and "| y |" in text
+
+
+def _io_rows_by_name(card_text: str) -> dict[str, list[str]]:
+    by_name: dict[str, list[str]] = {}
+    for ln in card_text.splitlines():
+        if not ln.startswith("|"):
+            continue
+        cells = [c.strip() for c in ln.strip("|").split("|")]
+        if len(cells) < 3:
+            continue
+        if cells[0].lower() in {"tensor", "--------", ""}:
+            continue
+        by_name[cells[0]] = cells
+    return by_name
+
+
+def test_make_task_card_inline_mixed_layout_and_boundary(tmp_path: Path):
+    task = tmp_path / "task.md"
+    task.write_text(INLINE_MIXED_BOUNDARY_TASK, encoding="utf-8")
+    out = tmp_path / "task_card.md"
+    proc = _run(
+        [
+            "make_task_card.py",
+            "--task-file",
+            str(task),
+            "--output",
+            str(out),
+            "--strict",
+        ]
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    text = out.read_text(encoding="utf-8")
+    by_name = _io_rows_by_name(text)
+    assert by_name["x"][2] == "float16" and by_name["x"][3] == "non-contiguous"
+    assert by_name["y"][2] == "float16" and by_name["y"][3] == "contiguous"
+    assert by_name["mask"][2] == "bool" and by_name["mask"][3] == "contiguous"
+    assert by_name["out"][2] == "float16"
+    assert "Odd M,N and all-false mask" in text
+    assert "Not required" in text
+
+
+def test_make_task_card_three_formats_same_per_tensor_attrs(tmp_path: Path):
+    """Bullet / inline / markdown table must agree on per-tensor dtype/layout."""
+    common_tail = """
+## 3. Layout / broadcast / dtype
+
+Per-tensor layouts as listed. Broadcast: none.
+
+## 4. Boundary cases
+
+Odd M,N and all-false mask.
+
+## 5. Correctness requirements
+
+pytest vs reference.
+
+## 6. Benchmark requirements
+
+Benchmark not required.
+"""
+    bullet = (
+        """# Task — fmt_bullet
+
+## 1. Background
+
+Implement **masked where**.
+
+## 2. Operator contract
+
+- input `x` (M,1) float16 non-contiguous
+- input `y` (1,N) float16 contiguous
+- input `mask` (M,N) bool contiguous
+- output `out` (M,N) float16
+"""
+        + common_tail
+    )
+    inline = (
+        """# Task — fmt_inline
+
+## 1. Background
+
+Implement **masked where**.
+
+## 2. Operator contract
+
+Inputs: `x` (M,1) float16 non-contiguous; `y` (1,N) float16 contiguous; `mask` (M,N) bool contiguous. Output `out` (M,N) float16.
+"""
+        + common_tail
+    )
+    table = (
+        """# Task — fmt_table
+
+## 1. Background
+
+Implement **masked where**.
+
+## 2. Operator contract
+
+| Tensor | Shape | dtype | Layout |
+|--------|-------|-------|--------|
+| x | (M,1) | float16 | non-contiguous |
+| y | (1,N) | float16 | contiguous |
+| mask | (M,N) | bool | contiguous |
+
+| Tensor | Shape | dtype |
+|--------|-------|-------|
+| out | (M,N) | float16 |
+"""
+        + common_tail
+    )
+
+    results = []
+    for label, body in (
+        ("bullet", bullet),
+        ("inline", inline),
+        ("table", table),
+    ):
+        task = tmp_path / f"{label}.md"
+        out = tmp_path / f"{label}_card.md"
+        task.write_text(body, encoding="utf-8")
+        proc = _run(
+            [
+                "make_task_card.py",
+                "--task-file",
+                str(task),
+                "--output",
+                str(out),
+                "--strict",
+            ]
+        )
+        assert proc.returncode == 0, f"{label}: {proc.stderr}"
+        by_name = _io_rows_by_name(out.read_text(encoding="utf-8"))
+        key = {
+            "x": (by_name["x"][2], by_name["x"][3]),
+            "y": (by_name["y"][2], by_name["y"][3]),
+            "mask": (by_name["mask"][2], by_name["mask"][3]),
+            "out": (by_name["out"][2],),
+        }
+        results.append(key)
+    assert results[0] == results[1] == results[2]
+    assert results[0]["x"] == ("float16", "non-contiguous")
+    assert results[0]["y"] == ("float16", "contiguous")
+    assert results[0]["mask"] == ("bool", "contiguous")
+    assert results[0]["out"] == ("float16",)

--- a/skills/competition/ninetoothed-op-dev-skill/tests/test_skill_structure.py
+++ b/skills/competition/ninetoothed-op-dev-skill/tests/test_skill_structure.py
@@ -1,0 +1,137 @@
+"""Skill package structure tests (no GPU, no fixed competition task IDs)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED_REFERENCES = [
+    "00_repo_map.md",
+    "01_ninetoothed_concepts.md",
+    "02_arrangement_application_patterns.md",
+    "03_elementwise_broadcast_patterns.md",
+    "04_reduction_block_patterns.md",
+    "05_layout_stride_offset_patterns.md",
+    "06_correctness_testing_patterns.md",
+    "07_benchmark_patterns.md",
+    "08_generated_source_aot_debugging.md",
+    "09_failure_diagnosis_playbook.md",
+    "10_patch_minimality_checklist.md",
+    "11_unsupported_cases.md",
+]
+
+CAPABILITY_REFERENCES = {
+    "elementwise_broadcast": "03_elementwise_broadcast_patterns.md",
+    "reduction_block": "04_reduction_block_patterns.md",
+    "layout_sensitive": "05_layout_stride_offset_patterns.md",
+    "performance_diagnosis": "07_benchmark_patterns.md",
+}
+
+REQUIRED_SCRIPTS = [
+    "env_check.py",
+    "make_task_card.py",
+    "run_correctness.py",
+    "run_benchmark.py",
+    "repo_pattern_index.py",
+    "check_patch_minimality.py",
+    "score_task.py",
+    "gate_eval.py",
+    "summarize_run.py",
+    "quick_validate.py",
+    "audit_packed_skill.py",
+    "_paths.py",
+    "_task_spec.py",
+]
+
+FORBIDDEN_RUNTIME_PATHS = [
+    ".quick_validate_cache",
+    "worktree_patches",
+]
+
+
+def test_skill_md_frontmatter():
+    text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    assert "name: ninetoothed-op-dev-skill" in text
+    assert "description:" in text
+
+
+def test_skill_md_no_answer_artifact_paths():
+    text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+    for token in (
+        "worktree_patches",
+        "evals/",
+        "submission/",
+    ):
+        assert token not in text, f"SKILL.md must not hardcode {token}"
+
+
+def test_skill_md_has_mandatory_decision_tree():
+    text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+    assert "## Execution decision tree (MANDATORY)" in text
+    required = [
+        "### D1 — Emit task card first",
+        "### D2 — Route by family",
+        "### D3 — `rg` before code",
+        "### D5 — Layout branch",
+        "assert not inp.is_contiguous()",
+        ".contiguous()",
+        "### D7 — Failure loop",
+        "### D8 — Performance branch",
+        "Correctness first",
+        "Warmup",
+    ]
+    for token in required:
+        assert token in text, f"missing decision-tree constraint: {token}"
+
+
+def test_references_complete():
+    ref = SKILL_ROOT / "references"
+    for name in REQUIRED_REFERENCES:
+        assert (ref / name).is_file(), name
+
+
+def test_capability_categories_documented():
+    ref = SKILL_ROOT / "references"
+    for family, name in CAPABILITY_REFERENCES.items():
+        assert (ref / name).is_file(), family
+
+
+def test_scripts_exist():
+    scripts = SKILL_ROOT / "scripts"
+    for name in REQUIRED_SCRIPTS:
+        assert (scripts / name).is_file(), name
+
+
+def test_runtime_excludes_answer_artifacts():
+    for rel in FORBIDDEN_RUNTIME_PATHS:
+        assert not (SKILL_ROOT / rel).exists(), f"runtime skill must not contain {rel}"
+
+
+def test_paths_helper_detects_src_layout(tmp_path: Path):
+    import sys
+
+    scripts = SKILL_ROOT / "scripts"
+    sys.path.insert(0, str(scripts))
+    import _paths  # noqa: E402
+
+    fake = tmp_path / "ninetoothed"
+    (fake / "src" / "ninetoothed").mkdir(parents=True)
+    (fake / "tests").mkdir()
+    assert _paths.is_ninetoothed_repo(fake)
+    assert _paths.ninetoothed_repo_root(fake) == fake.resolve()
+
+
+def test_reference_md_is_runtime_only():
+    text = (SKILL_ROOT / "REFERENCE.md").read_text(encoding="utf-8")
+    for token in (
+        "submission/",
+        "logs/run_all_gates",
+        "worktrees/",
+    ):
+        assert token not in text, (
+            f"REFERENCE.md must not keep workspace evidence: {token}"
+        )
+    assert "Apache-2.0" in text
+    assert "external evidence bundle" in text.lower() or "PR description" in text


### PR DESCRIPTION
## Competition submission

- Track: **T3-1-1 NineToothed .skill Innovation**
- Participant: **胡家瑞** (`hutou666`)
- Skill path: `skills/competition/ninetoothed-op-dev-skill/`
- Base revision used for final acceptance: `c9ebd4950a185beed8d4c1db9ff4a1fd133934ae`
- Packed runtime: 78 whitelist files
- Runtime tree hash: `56f23f0daaa3113feabf46502dfbce360ab65ab19b2974dfd3492e42f608b8fd`

## Summary

This PR adds a reusable agent skill for implementing, testing, benchmarking, debugging, and reporting NineToothed operator-development tasks. The runtime provides:

- a mandatory D1-D9 decision workflow;
- task-card extraction for tensor shape, dtype, broadcasting, layout, boundary cases, and reference behavior;
- numbered and unnumbered Markdown headings, mixed-role I/O tables, and arbitrary named outputs;
- routing for elementwise/broadcast, reduction/blocking, stride/offset, and performance/diagnostic tasks;
- repository-pattern search before implementation;
- explicit non-contiguous-layout checks and guarded use of `.contiguous()`;
- correctness-first benchmarking with fixed inputs, warmup, repeated CUDA-event measurements, fair baselines, and bounded conclusions;
- four runnable example families covering broadcast, reduction, non-contiguous layout, and performance diagnosis.

The submitted tree is the packed runtime only. Development evaluations, generated outputs, caches, and prewritten patches are excluded.

## Applicable scope and boundaries

Use this skill for NineToothed arrangement/application implementation, correctness testing, elementwise and broadcast operators, reductions and blocking, stride/offset-sensitive layouts, benchmark and generated-source diagnosis, AOT guidance, and minimal failing-test repair.

The skill does not authorize unrelated compiler-core changes, hidden-answer logic, test bypasses, irreversible workspace operations, or unapproved layout materialization. Local AOT execution requires a Linux `nvcc` toolchain; all other documented fallbacks remain available without network services.

## Installation and use

Copy the packed directory into a NineToothed fork or clone that contains `src/ninetoothed/`:

```text
skills/competition/ninetoothed-op-dev-skill/
```

From the NineToothed repository root, run:

```bash
python skills/competition/ninetoothed-op-dev-skill/scripts/quick_validate.py
pytest skills/competition/ninetoothed-op-dev-skill/tests -q
python skills/competition/ninetoothed-op-dev-skill/scripts/env_check.py --repo-root .
```

For an operator task, load `SKILL.md`, complete D1-D3 before editing, then follow the selected family route through correctness, diagnosis, performance when required, and the D9 report.

## Test results

`pytest` output:

```text
Source Skill package: 33 passed, 1 skipped
Packed Skill package: 21 passed, 2 skipped
Four example families: 14 passed
Upstream non-AOT suite: 200 passed
```

### Skill package

```text
Source tree: 33 passed, 1 skipped
Packed runtime: 21 passed, 2 skipped
```

### Four example families

```text
14 passed
```

### Formatting and lint

```text
ruff format --check: PASS
ruff check: PASS
```

### Upstream NineToothed test scope

```text
Non-AOT suite: 200 passed
```

AOT tests require a Linux `nvcc` toolchain, which was unavailable on this host. AOT is therefore outside the locally validated scope. The environment limitation and raw run log remain available in the evidence bundle; this PR does **not** claim a full-suite pass.

## Benchmark disclosure

- Final measurements use preallocated outputs and steady-state CUDA execution.
- Protocol: 30 warmups, 30 repeats, and 100 inner iterations.
- Broadcast results are reported only as same-size comparisons because a size-inversion warning prevents cross-size throughput claims.
- `BLOCK_SIZE` results are size-dependent; no configuration is claimed to be universally optimal.
- Historical no-skill/with-skill results are an old proxy record, not evidence of final-runtime improvement.

## Historical no-skill / with-skill comparison

The archived old-skill study completed 12 paired tasks (24 independent sessions). Both arms passed correctness. The mean paired score difference was −0.08 and with-skill scored higher on 0/12 tasks, so the preregistered gain criterion was not met. This result guided the final runtime's parser, layout, failure-loop, and packaging revisions; it is not presented as final-runtime gain evidence.

## Submission documents

Review-facing attachments:

- [Proposal PDF](https://github.com/user-attachments/files/29926831/_.skill._proposal.pdf)
- [Midterm report PDF](https://github.com/user-attachments/files/29926835/_.skill._.pdf)
- [Final report PDF (8 pages)](https://github.com/user-attachments/files/29926833/_.skill._T3-1-1_.pdf)
- [Evidence bundle final-11](https://github.com/user-attachments/files/29926828/evidence-final-11.zip)
- [Packed runtime release final-08](https://github.com/user-attachments/files/29926830/runtime-release-final-08.zip)

## Compliance

- [x] No API keys, hidden answers, or test bypasses
- [x] No hardcoded evaluation task IDs
- [x] No compiler-core changes
- [x] `HONOR_CODE.md` signed
- [x] `REFERENCE.md` included
- [x] Packed runtime contains no caches or submission-only material
- [x] Hidden competition tasks remain unknown; no prize or hidden-score claim is made

Signed disclosures:

- [HONOR_CODE.md](https://github.com/hutou666/ninetoothed/blob/2026-spring-hutou666-t3-1-1/skills/competition/ninetoothed-op-dev-skill/HONOR_CODE.md)
- [REFERENCE.md](https://github.com/hutou666/ninetoothed/blob/2026-spring-hutou666-t3-1-1/skills/competition/ninetoothed-op-dev-skill/REFERENCE.md)
