### PR TITLE
[2026春季][T1-2-1] goog00

### DIFF
--- a/bench/results.json
+++ b/bench/results.json
@@ -1,0 +1,204 @@
+{
+  "results": [
+    {
+      "scenario": "add_hit_4096_f32",
+      "op": "add",
+      "shape": [
+        4096
+      ],
+      "block": [
+        256
+      ],
+      "dtype": "torch.float32",
+      "expected_specialization_hit": true,
+      "specialization_hit": true,
+      "selected_variant": "divisibility_16_16_16_contiguity_1_1_1_size_i32_stride_i32",
+      "baseline_runtime_ms": 0.01423359990119934,
+      "submitted_runtime_ms": 0.01405120015144348,
+      "speedup": 1.012981079750481,
+      "mask_expr_count": 0,
+      "stride_expr_count": 0
+    },
+    {
+      "scenario": "add_hit_65536_f32",
+      "op": "add",
+      "shape": [
+        65536
+      ],
+      "block": [
+        256
+      ],
+      "dtype": "torch.float32",
+      "expected_specialization_hit": true,
+      "specialization_hit": true,
+      "selected_variant": "divisibility_16_16_16_contiguity_1_1_1_size_i32_stride_i32",
+      "baseline_runtime_ms": 0.014172159433364868,
+      "submitted_runtime_ms": 0.013863680362701416,
+      "speedup": 1.0222508787416493,
+      "mask_expr_count": 0,
+      "stride_expr_count": 0
+    },
+    {
+      "scenario": "add_hit_16M_f32",
+      "op": "add",
+      "shape": [
+        16777216
+      ],
+      "block": [
+        256
+      ],
+      "dtype": "torch.float32",
+      "expected_specialization_hit": true,
+      "specialization_hit": true,
+      "selected_variant": "divisibility_16_16_16_contiguity_1_1_1_size_i32_stride_i32",
+      "baseline_runtime_ms": 0.21727231979370118,
+      "submitted_runtime_ms": 0.21635072708129882,
+      "speedup": 1.004259716271053,
+      "mask_expr_count": 0,
+      "stride_expr_count": 0
+    },
+    {
+      "scenario": "copy_hit_512x512_f32",
+      "op": "copy",
+      "shape": [
+        512,
+        512
+      ],
+      "block": [
+        64,
+        64
+      ],
+      "dtype": "torch.float32",
+      "expected_specialization_hit": true,
+      "specialization_hit": true,
+      "selected_variant": "divisibility_1_16_1_16_contiguity_0_1_0_1_size_i32_stride_i32",
+      "baseline_runtime_ms": 0.013025280237197876,
+      "submitted_runtime_ms": 0.012844159603118896,
+      "speedup": 1.0141014001441557,
+      "mask_expr_count": 2,
+      "stride_expr_count": 2
+    },
+    {
+      "scenario": "copy_hit_1024x1024_f32",
+      "op": "copy",
+      "shape": [
+        1024,
+        1024
+      ],
+      "block": [
+        64,
+        64
+      ],
+      "dtype": "torch.float32",
+      "expected_specialization_hit": true,
+      "specialization_hit": true,
+      "selected_variant": "divisibility_1_16_1_16_contiguity_0_1_0_1_size_i32_stride_i32",
+      "baseline_runtime_ms": 0.011939840316772461,
+      "submitted_runtime_ms": 0.011530239582061768,
+      "speedup": 1.0355240436935873,
+      "mask_expr_count": 2,
+      "stride_expr_count": 2
+    },
+    {
+      "scenario": "copy_hit_4096x4096_f32",
+      "op": "copy",
+      "shape": [
+        4096,
+        4096
+      ],
+      "block": [
+        64,
+        64
+      ],
+      "dtype": "torch.float32",
+      "expected_specialization_hit": true,
+      "specialization_hit": true,
+      "selected_variant": "divisibility_1_16_1_16_contiguity_0_1_0_1_size_i32_stride_i32",
+      "baseline_runtime_ms": 0.14796799659729004,
+      "submitted_runtime_ms": 0.14768128395080565,
+      "speedup": 1.001941428451962,
+      "mask_expr_count": 2,
+      "stride_expr_count": 2
+    },
+    {
+      "scenario": "add_fb_4097_f32",
+      "op": "add",
+      "shape": [
+        4097
+      ],
+      "block": [
+        256
+      ],
+      "dtype": "torch.float32",
+      "expected_specialization_hit": true,
+      "specialization_hit": true,
+      "selected_variant": "divisibility_1_1_1_contiguity_1_1_1_size_i32_stride_i32",
+      "baseline_runtime_ms": 0.013967360258102418,
+      "submitted_runtime_ms": 0.013824000358581542,
+      "speedup": 1.0103703628329177,
+      "mask_expr_count": 3,
+      "stride_expr_count": 0
+    },
+    {
+      "scenario": "add_fb_45327_f32",
+      "op": "add",
+      "shape": [
+        45327
+      ],
+      "block": [
+        256
+      ],
+      "dtype": "torch.float32",
+      "expected_specialization_hit": true,
+      "specialization_hit": true,
+      "selected_variant": "divisibility_1_1_1_contiguity_1_1_1_size_i32_stride_i32",
+      "baseline_runtime_ms": 0.013719040155410766,
+      "submitted_runtime_ms": 0.013598719835281372,
+      "speedup": 1.0088479152145797,
+      "mask_expr_count": 3,
+      "stride_expr_count": 0
+    },
+    {
+      "scenario": "copy_fb_512x500_f32",
+      "op": "copy",
+      "shape": [
+        512,
+        500
+      ],
+      "block": [
+        64,
+        64
+      ],
+      "dtype": "torch.float32",
+      "expected_specialization_hit": true,
+      "specialization_hit": true,
+      "selected_variant": "divisibility_1_1_1_1_contiguity_0_1_0_1_size_i32_stride_i32",
+      "baseline_runtime_ms": 0.013107199668884278,
+      "submitted_runtime_ms": 0.012840960025787353,
+      "speedup": 1.0207336244768506,
+      "mask_expr_count": 2,
+      "stride_expr_count": 2
+    },
+    {
+      "scenario": "copy_fb_strided_512x512_f32",
+      "op": "copy_strided",
+      "shape": [
+        512,
+        512
+      ],
+      "block": [
+        64,
+        64
+      ],
+      "dtype": "torch.float32",
+      "expected_specialization_hit": true,
+      "specialization_hit": true,
+      "selected_variant": "divisibility_1_16_1_16_contiguity_0_0_0_0_size_i32_stride_i32",
+      "baseline_runtime_ms": 0.011857919692993164,
+      "submitted_runtime_ms": 0.011857919692993164,
+      "speedup": 1.0,
+      "mask_expr_count": 2,
+      "stride_expr_count": 4
+    }
+  ]
+}

--- a/bench/run_specialization_bench.py
+++ b/bench/run_specialization_bench.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""T1-2-1 specialization benchmark harness.
+
+Emits a JSON report with per-scenario:
+
+* ``baseline_runtime_ms`` — runtime of a kernel built from a freshly
+  reimported NineToothed with ``specialization_hints`` disabled.
+* ``submitted_runtime_ms`` — runtime under this submission (hints on).
+* ``speedup`` — ``baseline_runtime_ms / submitted_runtime_ms``.
+* ``specialization_hit`` — True iff the dispatcher routed the input
+  to one of the specialized variants (not the int64 fallback).
+* ``mask_expr_count`` / ``stride_expr_count`` — counts in the
+  generated source of the selected variant.
+
+The scenarios mix hit / fallback cases so the report covers both
+sides of the specialization boundary. Run::
+
+    python -m bench.run_specialization_bench --output bench/results.json
+
+on a CUDA host with triton installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+import pathlib
+import re
+import sys
+import time
+import typing as t
+
+import torch
+
+# Make ``src/ninetoothed`` importable when running from a checkout.
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+import ninetoothed  # noqa: E402
+import ninetoothed.generation  # noqa: E402
+from ninetoothed import Tensor  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Scenario definitions
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class Scenario:
+    name: str
+    op: str
+    shape: tuple
+    block: tuple
+    dtype: torch.dtype
+    expected_hit: bool
+
+    def make_inputs(self, device):
+        if self.op == "add":
+            (n,) = self.shape
+            x = torch.randn((n,), dtype=self.dtype, device=device)
+            y = torch.randn((n,), dtype=self.dtype, device=device)
+            out = torch.empty_like(x)
+            ref = x + y
+            return (x, y, out), ref, out
+        if self.op == "copy":
+            m, n = self.shape
+            x = torch.randn((m, n), dtype=self.dtype, device=device)
+            out = torch.empty_like(x)
+            return (x, out), x.clone(), out
+        if self.op == "copy_strided":
+            m, n = self.shape
+            base = torch.randn((m, n * 2), dtype=self.dtype, device=device)
+            x = base[:, ::2]
+            out = torch.empty_like(x).contiguous()
+            return (x, out), x.contiguous(), out
+        raise ValueError(self.op)
+
+
+def _make_kernel(op, block, dtype, kernel_name, device):
+    if op == "add":
+        (block_n,) = block
+
+        def _arrange(input, other, output):
+            return (
+                input.tile((block_n,)),
+                other.tile((block_n,)),
+                output.tile((block_n,)),
+            )
+
+        def _apply(input, other, output):
+            output = input + other  # noqa: F841
+
+        tensors = tuple(Tensor(1, dtype=dtype) for _ in range(3))
+    elif op in ("copy", "copy_strided"):
+        block_m, block_n = block
+
+        def _arrange(input, output):
+            return input.tile((block_m, block_n)), output.tile((block_m, block_n))
+
+        def _apply(input, output):
+            output = input  # noqa: F841
+
+        tensors = (Tensor(2, dtype=dtype), Tensor(2, dtype=dtype))
+    else:
+        raise ValueError(op)
+
+    return ninetoothed.make(
+        _arrange,
+        _apply,
+        tensors,
+        caller=device,
+        kernel_name=kernel_name,
+        output_dir=ninetoothed.generation.CACHE_DIR,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Source-structure inspection
+# ---------------------------------------------------------------------------
+
+
+_VARIANT_SUFFIX_RE = re.compile(
+    r"\bdivisibility[_\d]+contiguity[_\d]+size_i\d+_stride_i\d+\b"
+)
+
+
+def _variant_sources(kernel_name):
+    sources = {}
+    cache_dir = pathlib.Path(ninetoothed.generation.CACHE_DIR)
+    for py in cache_dir.glob(f"{kernel_name}.*.py"):
+        suffix = py.name[len(kernel_name) + 1 : -len(".py")]
+        if not _VARIANT_SUFFIX_RE.search(suffix):
+            continue
+        sources[suffix] = py.read_text()
+    return sources
+
+
+def _is_fallback(suffix):
+    return "size_i64_stride_i64" in suffix
+
+
+def _count_masks(source):
+    return len(re.findall(r"\bmask\s*=", source))
+
+
+def _count_strides(source):
+    return len(re.findall(r"\*\s*\w+_stride_\d+", source))
+
+
+# Dispatcher inspection -----------------------------------------------------
+
+
+def _dispatch_branches(kernel_name):
+    """Return ordered (suffix, [(name, op, threshold_or_value)...]) parsed
+    from the dispatcher .cpp. ``op`` is either ``%`` or ``stride==``."""
+
+    cache_dir = pathlib.Path(ninetoothed.generation.CACHE_DIR)
+    text = (cache_dir / f"{kernel_name}.cpp").read_text()
+
+    branches = []
+    prefix = f"launch_{kernel_name}_"
+    pattern = re.compile(
+        r"^\s*(?:if\s*\(([^)]+)\)\s*)?return\s+"
+        + re.escape(prefix)
+        + r"(\w+)\(",
+        re.MULTILINE,
+    )
+
+    for match in pattern.finditer(text):
+        cond, suffix = match.groups()
+        constraints = []
+        unrecognized = False
+        if cond:
+            recognized_any = False
+            for c in cond.split("&&"):
+                c = c.strip()
+                m = re.match(r"(\w+)\.shape\[(\d+)\]\s*%\s*(\d+)\s*==\s*0", c)
+                if m:
+                    constraints.append(
+                        (m.group(1), int(m.group(2)), "div", int(m.group(3)))
+                    )
+                    recognized_any = True
+                    continue
+                m = re.match(r"(\w+)\.strides\[(\d+)\]\s*==\s*1", c)
+                if m:
+                    constraints.append((m.group(1), int(m.group(2)), "cont", 1))
+                    recognized_any = True
+                    continue
+            if not recognized_any:
+                unrecognized = True
+        branches.append((suffix, constraints, unrecognized))
+
+    return branches
+
+
+def _dispatcher_arg_names(kernel_name):
+    """Parse the dispatcher entry-function signature to get the ordered
+    list of NineToothedTensor arg names (e.g. ``ninetoothed_tensor_45``)."""
+
+    cache_dir = pathlib.Path(ninetoothed.generation.CACHE_DIR)
+    text = (cache_dir / f"{kernel_name}.cpp").read_text()
+
+    pattern = re.compile(
+        r'extern\s+"C"\s+NineToothedResult\s+'
+        + re.escape(f"launch_{kernel_name}")
+        + r"\s*\(([^)]*)\)\s*\{"
+    )
+    m = pattern.search(text)
+    if not m:
+        return []
+
+    params = m.group(1)
+    names = re.findall(r"NineToothedTensor\s+(\w+)", params)
+    return names
+
+
+def _predict_specialization_hit(kernel_name, op, inputs):
+    """Return (hit_bool, matched_suffix). Mirrors the dispatcher
+    logic: walk branches top-to-bottom, picking the first whose
+    constraints are all satisfied by the input tensors."""
+
+    arg_names = _dispatcher_arg_names(kernel_name)
+    tensors = {name: inputs[i] for i, name in enumerate(arg_names) if i < len(inputs)}
+
+    branches = _dispatch_branches(kernel_name)
+
+    for suffix, constraints, unrecognized in branches:
+        if unrecognized:
+            continue
+        ok = True
+        for name, dim, kind, threshold in constraints:
+            tensor = tensors.get(name)
+            if tensor is None:
+                ok = False
+                break
+            if kind == "div":
+                if tensor.shape[dim] % threshold != 0:
+                    ok = False
+                    break
+            elif kind == "cont":
+                if tensor.stride(dim) != 1:
+                    ok = False
+                    break
+        if ok:
+            return (not _is_fallback(suffix)), suffix
+
+    return False, None
+
+
+# ---------------------------------------------------------------------------
+# Timing
+# ---------------------------------------------------------------------------
+
+
+def _time_kernel(kernel, args, warmup=10, iters=50):
+    for _ in range(warmup):
+        kernel(*args)
+
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+        starter = torch.cuda.Event(enable_timing=True)
+        ender = torch.cuda.Event(enable_timing=True)
+        starter.record()
+        for _ in range(iters):
+            kernel(*args)
+        ender.record()
+        torch.cuda.synchronize()
+        return starter.elapsed_time(ender) / iters
+
+    start = time.perf_counter()
+    for _ in range(iters):
+        kernel(*args)
+    end = time.perf_counter()
+    return (end - start) * 1000.0 / iters
+
+
+# ---------------------------------------------------------------------------
+# Baseline kernel (hints disabled)
+# ---------------------------------------------------------------------------
+
+
+def _build_baseline_kernel(op, block, dtype, kernel_name, device):
+    """Build a kernel that mimics the pre-submission baseline by
+    monkey-patching SpecializationHints.empty() in for all variants."""
+
+    from ninetoothed import generation as gen_mod
+    from ninetoothed import aot as aot_mod
+    from ninetoothed.specialization import SpecializationHints
+
+    original = aot_mod._hints_from_spec
+
+    aot_mod._hints_from_spec = (
+        lambda div_spec, cont_spec, block_sizes: SpecializationHints.empty()
+    )
+
+    try:
+        return _make_kernel(op, block, dtype, kernel_name, device)
+    finally:
+        aot_mod._hints_from_spec = original
+
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+
+
+SCENARIOS = (
+    # Full-specialization scenarios: input is both divisible and contiguous,
+    # so dispatcher routes to the most specialized variant (mask=0, stride=0
+    # for 1D; mask/stride reduced for 2D).
+    Scenario("add_hit_4096_f32", "add", (4096,), (256,), torch.float32, True),
+    Scenario("add_hit_65536_f32", "add", (65536,), (256,), torch.float32, True),
+    # Larger inputs where compute dominates launch overhead and the
+    # specialization speedup becomes clearly measurable.
+    Scenario(
+        "add_hit_16M_f32", "add", (16 * 1024 * 1024,), (256,), torch.float32, True
+    ),
+    Scenario("copy_hit_512x512_f32", "copy", (512, 512), (64, 64), torch.float32, True),
+    Scenario(
+        "copy_hit_1024x1024_f32",
+        "copy",
+        (1024, 1024),
+        (64, 64),
+        torch.float32,
+        True,
+    ),
+    Scenario(
+        "copy_hit_4096x4096_f32",
+        "copy",
+        (4096, 4096),
+        (64, 64),
+        torch.float32,
+        True,
+    ),
+    # Partial-specialization scenarios: input is contiguous but not
+    # divisible by BLOCK_SIZE. Dispatcher routes to a contiguity-only
+    # variant (still hit=True; not the int64 fallback).
+    Scenario("add_fb_4097_f32", "add", (4097,), (256,), torch.float32, True),
+    Scenario("add_fb_45327_f32", "add", (45327,), (256,), torch.float32, True),
+    Scenario(
+        "copy_fb_512x500_f32", "copy", (512, 500), (64, 64), torch.float32, True
+    ),
+    # Strided input: innermost stride != 1, so no contiguity hit. The
+    # dispatcher still avoids the int64 fallback by routing to an
+    # int32-but-unconstrained variant; stride folding does not apply.
+    Scenario(
+        "copy_fb_strided_512x512_f32",
+        "copy_strided",
+        (512, 512),
+        (64, 64),
+        torch.float32,
+        True,
+    ),
+)
+
+
+def run_scenarios(device, output_path):
+    results = []
+
+    for i, sc in enumerate(SCENARIOS):
+        baseline_name = f"bench_baseline_{i}_{sc.name}"
+        submitted_name = f"bench_submitted_{i}_{sc.name}"
+
+        baseline_kernel = _build_baseline_kernel(
+            sc.op, sc.block, _torch_dtype_to_nt(sc.dtype), baseline_name, device
+        )
+        submitted_kernel = _make_kernel(
+            sc.op, sc.block, _torch_dtype_to_nt(sc.dtype), submitted_name, device
+        )
+
+        inputs, expected, out = sc.make_inputs(device)
+        submitted_kernel(*inputs)
+        if not torch.allclose(out, expected, atol=1e-5, rtol=1e-5):
+            raise RuntimeError(f"correctness failure on {sc.name}")
+
+        hit, suffix = _predict_specialization_hit(submitted_name, sc.op, inputs)
+
+        sources = _variant_sources(submitted_name)
+        sel_source = sources.get(suffix) if suffix else None
+        mask_count = _count_masks(sel_source) if sel_source else None
+        stride_count = _count_strides(sel_source) if sel_source else None
+
+        # Re-run for fresh inputs to avoid stale GPU caching effects.
+        inputs_b, _, _ = sc.make_inputs(device)
+        inputs_s, _, _ = sc.make_inputs(device)
+
+        baseline_ms = _time_kernel(baseline_kernel, inputs_b)
+        submitted_ms = _time_kernel(submitted_kernel, inputs_s)
+
+        results.append(
+            {
+                "scenario": sc.name,
+                "op": sc.op,
+                "shape": list(sc.shape),
+                "block": list(sc.block),
+                "dtype": str(sc.dtype),
+                "expected_specialization_hit": sc.expected_hit,
+                "specialization_hit": hit,
+                "selected_variant": suffix,
+                "baseline_runtime_ms": baseline_ms,
+                "submitted_runtime_ms": submitted_ms,
+                "speedup": baseline_ms / submitted_ms if submitted_ms > 0 else 0.0,
+                "mask_expr_count": mask_count,
+                "stride_expr_count": stride_count,
+            }
+        )
+
+    output_path = pathlib.Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps({"results": results}, indent=2))
+
+    return results
+
+
+def _torch_dtype_to_nt(dtype):
+    if dtype == torch.float32:
+        return ninetoothed.float32
+    if dtype == torch.float16:
+        return ninetoothed.float16
+    if dtype == torch.bfloat16:
+        return ninetoothed.bfloat16
+    raise ValueError(dtype)
+
+
+def _pretty_print(results):
+    header = (
+        "scenario", "hit", "expect", "baseline_ms", "submitted_ms",
+        "speedup", "mask", "stride",
+    )
+    rows = [header]
+    for r in results:
+        rows.append((
+            r["scenario"],
+            str(r["specialization_hit"]),
+            str(r["expected_specialization_hit"]),
+            f"{r['baseline_runtime_ms']:.4f}",
+            f"{r['submitted_runtime_ms']:.4f}",
+            f"{r['speedup']:.3f}",
+            str(r["mask_expr_count"]),
+            str(r["stride_expr_count"]),
+        ))
+    widths = [max(len(row[i]) for row in rows) for i in range(len(header))]
+    for row in rows:
+        print("  ".join(f"{cell:<{w}}" for cell, w in zip(row, widths)))
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--device",
+        default="cuda" if torch.cuda.is_available() else "cpu",
+        help="torch device to run on (default: cuda if available)",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(_REPO_ROOT / "bench" / "results.json"),
+        help="output JSON path",
+    )
+    args = parser.parse_args(argv)
+
+    if args.device == "cpu":
+        raise SystemExit(
+            "specialization benchmark requires a GPU; pass --device cuda"
+        )
+
+    results = run_scenarios(args.device, args.output)
+    _pretty_print(results)
+    print(f"\nwrote {len(results)} scenarios to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ninetoothed/aot.py
+++ b/src/ninetoothed/aot.py
@@ -1,4 +1,5 @@
 import ast
+import copy
 import ctypes
 import pathlib
 import re
@@ -11,6 +12,8 @@ import uuid
 import ninetoothed.dtype
 import ninetoothed.naming as naming
 from ninetoothed.generation import CACHE_DIR, CodeGenerator
+from ninetoothed.specialization import SpecializationHints
+from ninetoothed.symbol import Symbol
 from ninetoothed.tensor import Tensor
 from ninetoothed.utils import calculate_default_configs
 
@@ -57,24 +60,36 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
     if not _HEADER_PATH.exists() or _HEADER_PATH.read_text() != _HEADER_CONTENT:
         _HEADER_PATH.write_text(_HEADER_CONTENT)
 
-    code_generator = CodeGenerator()
-    source_file = code_generator(
-        func,
-        caller=caller,
-        kernel_name=kernel_name,
-        num_warps=num_warps,
-        num_stages=num_stages,
-        max_num_configs=None,
-        prettify=False,
+    original_annotations = copy.deepcopy(func.__annotations__)
+
+    def _generate_for_variant(hints):
+        func.__annotations__ = copy.deepcopy(original_annotations)
+
+        code_generator = CodeGenerator()
+        source_file = code_generator(
+            func,
+            caller=caller,
+            kernel_name=kernel_name,
+            num_warps=num_warps,
+            num_stages=num_stages,
+            max_num_configs=None,
+            prettify=False,
+            specialization_hints=hints,
+        )
+
+        return code_generator, source_file
+
+    initial_code_generator, initial_source_file = _generate_for_variant(
+        SpecializationHints.empty()
     )
 
-    tensors = code_generator.tensors
-    kernel_func = code_generator.kernel_func
-    launch_func = code_generator.launch_func
+    tensors = initial_code_generator.tensors
+    kernel_func = initial_code_generator.kernel_func
+    launch_func = initial_code_generator.launch_func
 
     grid_extractor = _GridExtractor()
     launch_func = grid_extractor.visit(launch_func)
-    grid_extractor.visit(code_generator.raw_grid)
+    grid_extractor.visit(initial_code_generator.raw_grid)
     grid = f"{ast.unparse(grid_extractor.grid[0])}, 1, 1"
 
     launch_arg_names = tuple(arg.arg for arg in launch_func.args.args)
@@ -82,6 +97,10 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
         launch_arg_names, tensors, _find_tensor_by_source_name
     )
     _, tensor_ndims, _ = _per_tensor_dim_options(
+        launch_arg_names, tensors, _find_tensor_by_source_name
+    )
+
+    block_sizes = _innermost_block_sizes(
         launch_arg_names, tensors, _find_tensor_by_source_name
     )
 
@@ -94,11 +113,28 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
         size_type,
         stride_type,
     ) in variant_specs:
+        hints = _hints_from_spec(
+            divisibility_spec, contiguity_spec, block_sizes
+        )
+
+        if hints.any():
+            variant_code_generator, variant_source_file = _generate_for_variant(hints)
+            variant_kernel_func = variant_code_generator.kernel_func
+            variant_launch_func = grid_extractor.visit(
+                variant_code_generator.launch_func
+            )
+            variant_tensors = variant_code_generator.tensors
+        else:
+            variant_source_file = initial_source_file
+            variant_kernel_func = kernel_func
+            variant_launch_func = launch_func
+            variant_tensors = tensors
+
         variant_outputs = _build_variant(
-            source_file,
-            kernel_func,
-            launch_func,
-            tensors,
+            variant_source_file,
+            variant_kernel_func,
+            variant_launch_func,
+            variant_tensors,
             _find_tensor_by_source_name,
             func,
             kernel_name=kernel_name,
@@ -113,17 +149,114 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
         )
         output_contents.update(variant_outputs)
 
+        output_contents[f"{kernel_name}.{variant_suffix}.py"] = pathlib.Path(
+            variant_source_file
+        ).read_text()
+
     dispatcher_source, dispatcher_header = _generate_dispatcher(
-        kernel_name, launch_arg_names, variant_specs, tensor_ndims
+        kernel_name, launch_arg_names, variant_specs, tensor_ndims, block_sizes
     )
 
     output_contents[f"{kernel_name}.cpp"] = dispatcher_source
     output_contents[f"{kernel_name}.h"] = dispatcher_header
 
+    func.__annotations__ = original_annotations
+
     return output_contents
 
 
-def _generate_dispatcher(kernel_name, launch_arg_names, variant_specs, tensor_ndims):
+def _hints_from_spec(divisibility_spec, contiguity_spec, block_sizes):
+    divisible_dims = frozenset(
+        (naming.remove_prefixes(name), dim)
+        for name, dim in divisibility_spec
+        if block_sizes.get((name, dim)) is not None
+    )
+    contiguous_dims = frozenset(
+        (naming.remove_prefixes(name), dim) for name, dim in contiguity_spec
+    )
+
+    return SpecializationHints(
+        divisible_dims=divisible_dims,
+        contiguous_dims=contiguous_dims,
+    )
+
+
+def _innermost_block_sizes(launch_arg_names, tensors, find_tensor):
+    sizes = {}
+
+    for name in launch_arg_names:
+        tensor = find_tensor(tensors, name)
+
+        if tensor is None or tensor.source.ndim == 0:
+            continue
+
+        try:
+            innermost = tensor.innermost()
+        except Exception:
+            continue
+
+        if innermost.ndim != tensor.source.ndim:
+            continue
+
+        if not _is_divisibility_safe(tensor):
+            continue
+
+        for dim in range(tensor.source.ndim):
+            value = _static_int(innermost.shape[dim])
+
+            if value is not None:
+                sizes[(name, dim)] = value
+
+    return sizes
+
+
+def _is_divisibility_safe(tensor):
+    history = getattr(tensor, "_history", None)
+
+    if not history:
+        return False
+
+    unsafe = {"pad", "_slice_dim"}
+    has_tile = False
+
+    for func, _, _ in history:
+        name = getattr(func, "__name__", None)
+
+        if name in unsafe:
+            return False
+
+        if name == "tile":
+            has_tile = True
+
+    return has_tile
+
+
+def _static_int(value):
+    if isinstance(value, bool):
+        return None
+
+    if isinstance(value, int):
+        return value
+
+    if isinstance(value, Symbol):
+        node = value._node
+
+        if (
+            isinstance(node, ast.Constant)
+            and isinstance(node.value, int)
+            and not isinstance(node.value, bool)
+        ):
+            return node.value
+
+    return None
+
+
+def _generate_dispatcher(
+    kernel_name, launch_arg_names, variant_specs, tensor_ndims, block_sizes=None
+):
+    if block_sizes is None:
+        block_sizes = {}
+
     tensor_params = ", ".join(f"NineToothedTensor {name}" for name in launch_arg_names)
     signature_params = (
         f"NineToothedStream stream, {tensor_params}"
@@ -174,7 +307,8 @@ def _generate_dispatcher(kernel_name, launch_arg_names, variant_specs, tensor_nd
             continue
 
         checks = tuple(
-            f"{name}.shape[{dim}] % 16 == 0" for name, dim in divisibility_spec
+            f"{name}.shape[{dim}] % {_divisibility_threshold(name, dim, block_sizes)} == 0"
+            for name, dim in divisibility_spec
         ) + tuple(f"{name}.strides[{dim}] == 1" for name, dim in contiguity_spec)
 
         if checks:
@@ -423,6 +557,15 @@ def _enumerate_variant_specs(launch_arg_names, tensors, find_tensor):
     )
 
     return specs
+
+
+def _divisibility_threshold(name, dim, block_sizes):
+    block_size = block_sizes.get((name, dim))
+
+    if block_size is None or block_size <= 16:
+        return 16
+
+    return block_size
 
 
 def _per_tensor_dim_options(launch_arg_names, tensors, find_tensor):

--- a/src/ninetoothed/generation.py
+++ b/src/ninetoothed/generation.py
@@ -17,6 +17,7 @@ from triton.language.extra import libdevice
 import ninetoothed.naming as naming
 from ninetoothed.cudaifier import Cudaifier
 from ninetoothed.language import attribute, call
+from ninetoothed.specialization import SpecializationHints
 from ninetoothed.symbol import Symbol
 from ninetoothed.tensor import Tensor
 from ninetoothed.torchifier import Torchifier
@@ -52,7 +53,13 @@ class CodeGenerator(ast.NodeTransformer):
         num_stages,
         max_num_configs,
         prettify,
+        specialization_hints=None,
     ):
+        self._specialization_hints = (
+            specialization_hints
+            if specialization_hints is not None
+            else SpecializationHints.empty()
+        )
         def _get_tree(func):
             func_def = ast.parse(textwrap.dedent(inspect.getsource(func)))
 
@@ -640,12 +647,19 @@ class CodeGenerator(ast.NodeTransformer):
             return Symbol(tensor.source.name).node
 
         pointers, mask = self._generate_pointers_and_mask(tensor, indices)
+
+        if isinstance(mask, Symbol) and mask.is_constant_true():
+            return call("load", pointers).node
+
         other = type(self)._generate_other(tensor)
 
         return call("load", pointers, mask=mask, other=other).node
 
     def _generate_store(self, tensor, value, indices=()):
         pointers, mask = self._generate_pointers_and_mask(tensor, indices)
+
+        if isinstance(mask, Symbol) and mask.is_constant_true():
+            return call("store", pointers, value).node
 
         return call("store", pointers, value, mask=mask).node
 
@@ -659,7 +673,7 @@ class CodeGenerator(ast.NodeTransformer):
         self._invariants[name_for_pointers] = Symbol(tensor.source.pointer_string())
 
         overall_offsets, mask = type(self)._generate_overall_offsets_and_mask(
-            tensor, indices
+            tensor, indices, self._specialization_hints
         )
 
         pointers = name_for_pointers + overall_offsets
@@ -722,15 +736,30 @@ class CodeGenerator(ast.NodeTransformer):
         )
 
     @staticmethod
-    def _generate_overall_offsets_and_mask(tensor, indices):
+    def _generate_overall_offsets_and_mask(tensor, indices, hints=None):
+        if hints is None:
+            hints = SpecializationHints.empty()
+
         indices = list(indices)
 
-        offsets, mask = CodeGenerator._generate_offsets_and_mask(tensor, indices)
+        offsets, mask = CodeGenerator._generate_offsets_and_mask(
+            tensor, indices, hints
+        )
 
         tensor._last_generated_offsets = offsets
 
+        bare_source_name = naming.remove_prefixes(tensor.source.name)
+
+        def _offset_term(source_dim):
+            offset = offsets[source_dim]
+
+            if hints.is_contiguous(bare_source_name, source_dim):
+                return offset
+
+            return offset * Symbol(tensor.source.stride_string(source_dim))
+
         overall_offsets = sum(
-            offsets[source_dim] * Symbol(tensor.source.stride_string(source_dim))
+            _offset_term(source_dim)
             for source_dim in range(tensor.source.ndim)
         )
 
@@ -744,38 +773,45 @@ class CodeGenerator(ast.NodeTransformer):
         return overall_offsets, mask
 
     @staticmethod
-    def _generate_offsets_and_mask(tensor, indices):
+    def _generate_offsets_and_mask(tensor, indices, hints=None):
+        if hints is None:
+            hints = SpecializationHints.empty()
+
         offsets = [Symbol(0) for _ in range(tensor.source.ndim)]
 
         tensor.source._mask = Symbol(True)
+        tensor.source._specialization_hints = hints
 
-        curr = tensor
-        start = 0
+        try:
+            curr = tensor
+            start = 0
 
-        while isinstance(curr, type(tensor)):
-            stop = start + curr.ndim
-            curr_indices = indices[start:stop]
+            while isinstance(curr, type(tensor)):
+                stop = start + curr.ndim
+                curr_indices = indices[start:stop]
 
-            curr._inputs = [curr_indices]
+                curr._inputs = [curr_indices]
 
-            start = stop
-            curr = curr.dtype
+                start = stop
+                curr = curr.dtype
 
-        for level in reversed(tensor._levels):
-            for tensor_ in level:
-                tensor_.offsets()
+            for level in reversed(tensor._levels):
+                for tensor_ in level:
+                    tensor_.offsets()
 
-        for dim, offset in enumerate(tensor.source._outputs[0]):
-            offsets[dim] += offset
+            for dim, offset in enumerate(tensor.source._outputs[0]):
+                offsets[dim] += offset
 
-        curr = tensor
+            curr = tensor
 
-        while isinstance(curr, type(tensor)):
-            curr._inputs.clear()
+            while isinstance(curr, type(tensor)):
+                curr._inputs.clear()
 
-            curr = curr.dtype
+                curr = curr.dtype
 
-        return offsets, tensor.source._mask
+            return offsets, tensor.source._mask
+        finally:
+            tensor.source._specialization_hints = None
 
     @staticmethod
     def _generate_innermost_indices(tensor, use_power_of_2_sizes=True):

--- a/src/ninetoothed/specialization.py
+++ b/src/ninetoothed/specialization.py
@@ -1,0 +1,43 @@
+"""Specialization hints for NineToothed code generation.
+
+This module defines the data structures that carry per-(tensor, dim)
+specialization hints from the AOT/JIT entry point down through the
+code generator. When a hint is set, the generator emits a more
+compact Triton source for that case; when no hint is set, the
+generator falls back to the original generic path.
+"""
+
+import dataclasses
+
+
+@dataclasses.dataclass(frozen=True)
+class SpecializationHints:
+    """Per-(source_name, source_dim) specialization hints.
+
+    :param divisible_dims: Set of ``(source_name, source_dim)`` for which
+        the innermost tile is guaranteed to evenly divide
+        ``shape[source_dim]``. The generator may skip the upper-bound
+        mask term for these dims.
+    :param contiguous_dims: Set of ``(source_name, source_dim)`` for
+        which ``stride[source_dim] == 1`` is guaranteed. The generator
+        may fold ``offsets * stride`` into ``offsets`` for these dims.
+
+    Both sets use **bare** source names (i.e., naming.remove_prefixes
+    already applied), matching what AOT spec sets store.
+    """
+
+    divisible_dims: frozenset = dataclasses.field(default_factory=frozenset)
+    contiguous_dims: frozenset = dataclasses.field(default_factory=frozenset)
+
+    @staticmethod
+    def empty():
+        return SpecializationHints(frozenset(), frozenset())
+
+    def is_divisible(self, source_name, source_dim):
+        return (source_name, source_dim) in self.divisible_dims
+
+    def is_contiguous(self, source_name, source_dim):
+        return (source_name, source_dim) in self.contiguous_dims
+
+    def any(self):
+        return bool(self.divisible_dims) or bool(self.contiguous_dims)

--- a/src/ninetoothed/symbol.py
+++ b/src/ninetoothed/symbol.py
@@ -196,12 +196,21 @@ class Symbol:
     def __and__(self, other):
         other = type(self)(other)
 
+        if self.is_constant_true():
+            return other
+
+        if other.is_constant_true():
+            return self
+
         return type(self)(
             ast.BinOp(left=self._node, op=ast.BitAnd(), right=other._node)
         )
 
     def __rand__(self, other):
         return self.__and__(other)
+
+    def is_constant_true(self):
+        return isinstance(self._node, ast.Constant) and self._node.value is True
 
     def __getitem__(self, key):
         return type(self)(ast.Subscript(value=self._node, slice=type(self)(key)._node))

--- a/src/ninetoothed/tensor.py
+++ b/src/ninetoothed/tensor.py
@@ -573,7 +573,18 @@ class Tensor:
 
         outputs = self._offsets(indices)
 
-        for index, size in zip(indices, self.shape):
+        hints = getattr(self.source, "_specialization_hints", None)
+        bare_source_name = naming.remove_prefixes(self.source.name)
+        dim_preserved = self.ndim == self.source.ndim
+
+        for dim, (index, size) in enumerate(zip(indices, self.shape)):
+            if (
+                dim_preserved
+                and hints is not None
+                and hints.is_divisible(bare_source_name, dim)
+            ):
+                continue
+
             index = Symbol(index)
 
             self.source._mask &= index < size

--- a/tests/test_aot.py
+++ b/tests/test_aot.py
@@ -56,7 +56,7 @@ def test_add(test_multi_device, size, dtype, device, ninetoothed_dtype):
         devices = (device,)
 
     for device in devices:
-        with torch.cuda.Stream(device=device):
+        with torch.cuda.stream(torch.cuda.Stream(device=device)):
             input = torch.randn(shape, dtype=dtype, device=device)
             other = torch.randn(shape, dtype=dtype, device=device)
             output = torch.empty_like(input)

--- a/tests/test_specialization.py
+++ b/tests/test_specialization.py
@@ -1,0 +1,353 @@
+"""Tests for the T1-2-1 specialization enhancements.
+
+Each test exercises one of the three required categories:
+
+* specialization-hit: an input that the dispatcher routes to the
+  specialized variant, and we assert the generated source for that
+  variant is more compact than the fallback.
+* fallback-correctness: an input that the dispatcher routes to the
+  generic variant, and we assert numerical results match the
+  reference.
+* generated-source-structure: directly inspects the generated ``.cpp``
+  / ``.py`` files for the kernel under ``CACHE_DIR``, counting mask /
+  stride / pointer expressions across variants.
+"""
+
+import functools
+import pathlib
+import re
+
+import pytest
+import torch
+
+import ninetoothed
+import ninetoothed.generation
+from ninetoothed import Tensor
+from tests.utils import get_available_devices
+
+
+_OUTPUT_DIR = ninetoothed.generation.CACHE_DIR
+
+
+def _make_kernel_name(prefix):
+    """Return a fresh kernel name. Test isolation across runs."""
+
+    _make_kernel_name._counter += 1
+    return f"{prefix}_spec_{_make_kernel_name._counter}"
+
+
+_make_kernel_name._counter = 0
+
+
+def _read_variant_sources(kernel_name):
+    """Return a dict mapping variant_suffix → triton kernel python source.
+
+    ``_aot`` writes per-variant Python sources to
+    ``{kernel_name}.{variant_suffix}.py`` alongside each compiled .cpp.
+    """
+
+    output_dir = pathlib.Path(_OUTPUT_DIR)
+    sources = {}
+
+    for py in output_dir.glob(f"{kernel_name}.*.py"):
+        suffix = py.name[len(kernel_name) + 1 : -len(".py")]
+        sources[suffix] = py.read_text()
+
+    return sources
+
+
+def _read_dispatcher(kernel_name):
+    return (pathlib.Path(_OUTPUT_DIR) / f"{kernel_name}.cpp").read_text()
+
+
+def _count_mask_arguments(source):
+    """Count occurrences of ``mask=`` in tl.load / tl.store calls."""
+
+    return len(re.findall(r"\bmask\s*=", source))
+
+
+def _count_stride_multiplications(source):
+    """Count expressions that multiply by a ``..._stride_N`` name."""
+
+    return len(re.findall(r"\*\s*\w+_stride_\d+", source))
+
+
+def _count_pointer_arith(source):
+    """Count add expressions involving a tensor ``..._pointer`` name."""
+
+    return len(re.findall(r"\w+_pointer\s*\+", source))
+
+
+# ---------------------------------------------------------------------------
+# Specialization hit + fallback correctness
+# ---------------------------------------------------------------------------
+
+
+def _arrange_add(input, other, output):
+    def _arrange(tensor):
+        return tensor.tile((256,))
+
+    return _arrange(input), _arrange(other), _arrange(output)
+
+
+def _apply_add(input, other, output):
+    output = input + other  # noqa: F841
+
+
+def _build_add_kernel(name, device):
+    tensors = tuple(Tensor(1, dtype=ninetoothed.float32) for _ in range(3))
+
+    return ninetoothed.make(
+        _arrange_add,
+        _apply_add,
+        tensors,
+        caller=device,
+        kernel_name=name,
+        output_dir=_OUTPUT_DIR,
+    )
+
+
+@pytest.mark.parametrize("device", get_available_devices())
+def test_specialization_hit_add_divisible(device):
+    """A size that is divisible by BLOCK_SIZE (256) routes to the
+    specialized variant; the variant source must omit mask=."""
+
+    name = _make_kernel_name("add_hit_div")
+    kernel = _build_add_kernel(name, device)
+
+    size = 4096  # exactly divisible by 256
+
+    x = torch.randn((size,), dtype=torch.float32, device=device)
+    y = torch.randn((size,), dtype=torch.float32, device=device)
+    z = torch.empty_like(x)
+
+    kernel(x, y, z)
+
+    assert torch.allclose(z, x + y)
+
+    sources = _read_variant_sources(name)
+    specialized = [
+        src
+        for suffix, src in sources.items()
+        if "divisibility_16_16_16" in suffix
+        and "size_i32_stride_i32" in suffix
+    ]
+    assert specialized, "no fully-divisibility-specialized variant emitted"
+
+    for src in specialized:
+        assert _count_mask_arguments(src) == 0, (
+            f"specialized add variant still contains mask=:\n{src}"
+        )
+
+
+@pytest.mark.parametrize("device", get_available_devices())
+def test_specialization_fallback_add_non_divisible(device):
+    """A non-divisible size routes to the fallback (or a partially
+    specialized) variant; correctness must hold and fallback source
+    must still contain mask=."""
+
+    name = _make_kernel_name("add_fb_non_div")
+    kernel = _build_add_kernel(name, device)
+
+    size = 4097  # NOT divisible by 256
+
+    x = torch.randn((size,), dtype=torch.float32, device=device)
+    y = torch.randn((size,), dtype=torch.float32, device=device)
+    z = torch.empty_like(x)
+
+    kernel(x, y, z)
+
+    assert torch.allclose(z, x + y)
+
+    sources = _read_variant_sources(name)
+    fallback = [
+        src
+        for suffix, src in sources.items()
+        if "size_i64_stride_i64" in suffix
+    ]
+    assert fallback, "no fallback variant emitted"
+
+    for src in fallback:
+        assert _count_mask_arguments(src) > 0, (
+            "fallback add variant unexpectedly has no mask= — "
+            "specialization may have leaked into fallback"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Contiguous fast path (stride folding)
+# ---------------------------------------------------------------------------
+
+
+def _build_copy_kernel(name, device):
+    def _arrange(input, output):
+        return input.tile((64, 64)), output.tile((64, 64))
+
+    def _apply(input, output):
+        output = input  # noqa: F841
+
+    tensors = (
+        Tensor(2, dtype=ninetoothed.float32),
+        Tensor(2, dtype=ninetoothed.float32),
+    )
+
+    return ninetoothed.make(
+        _arrange,
+        _apply,
+        tensors,
+        caller=device,
+        kernel_name=name,
+        output_dir=_OUTPUT_DIR,
+    )
+
+
+@pytest.mark.parametrize("device", get_available_devices())
+def test_specialization_hit_copy_contiguous(device):
+    """Contiguous row-major 2-D copy hits the contiguity-specialized
+    variant; that variant must not contain ``* ..._stride_N``
+    expressions for the contiguous innermost stride."""
+
+    name = _make_kernel_name("copy_hit_cont")
+    kernel = _build_copy_kernel(name, device)
+
+    m, n = 512, 512  # both divisible by 64; row-major default stride
+
+    x = torch.randn((m, n), dtype=torch.float32, device=device)
+    y = torch.empty_like(x)
+
+    kernel(x, y)
+
+    assert torch.allclose(y, x)
+
+    sources = _read_variant_sources(name)
+
+    # Maximally specialized variant for 2 row-major 2D tensors:
+    #   divisibility on innermost dim only (per-tensor) → "_1_16_1_16"
+    #   contiguity on innermost dim only             → "_0_1_0_1"
+    specialized = [
+        src
+        for suffix, src in sources.items()
+        if "_size_i32_stride_i32" in suffix
+        and re.search(r"divisibility_1_16_1_16_contiguity_0_1_0_1_", suffix)
+    ]
+    fallback = [
+        src
+        for suffix, src in sources.items()
+        if "size_i64_stride_i64" in suffix
+    ]
+    assert specialized, (
+        f"no fully-contiguous-specialized variant emitted; "
+        f"available suffixes: {list(sources)}"
+    )
+    assert fallback, "no fallback variant emitted"
+
+    for src in specialized:
+        assert _count_stride_multiplications(src) < _count_stride_multiplications(
+            fallback[0]
+        ), (
+            "contiguity-specialized copy variant did not reduce stride "
+            "multiplications relative to fallback"
+        )
+
+
+@pytest.mark.parametrize("device", get_available_devices())
+def test_specialization_fallback_copy_strided(device):
+    """A transposed (non-contiguous innermost stride) input falls back
+    to the generic variant; correctness must hold."""
+
+    name = _make_kernel_name("copy_fb_strided")
+    kernel = _build_copy_kernel(name, device)
+
+    m, n = 512, 512
+
+    # Use a transposed view so strides are NOT (n, 1) anymore.
+    base = torch.randn((n, m), dtype=torch.float32, device=device)
+    x = base.T.contiguous().T  # forces non-contiguous innermost
+    y = torch.empty_like(x)
+    if x.stride(-1) == 1:
+        # Fallback platform may have realigned strides; create strided manually.
+        x = torch.randn((m, n * 2), dtype=torch.float32, device=device)[:, ::2]
+        y = torch.empty_like(x).contiguous()
+
+    kernel(x, y)
+
+    assert torch.allclose(y, x)
+
+
+# ---------------------------------------------------------------------------
+# Generated source structure metrics (≥2 cases)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", get_available_devices())
+def test_generated_source_mask_reduction_add(device):
+    """Source-structure assertion: the specialized add variant
+    contains strictly fewer mask expressions than the fallback."""
+
+    name = _make_kernel_name("add_metric")
+    _build_add_kernel(name, device)
+
+    sources = _read_variant_sources(name)
+    fallback = next(
+        src for suffix, src in sources.items() if "size_i64_stride_i64" in suffix
+    )
+    specialized = [
+        src
+        for suffix, src in sources.items()
+        if "divisibility_16_16_16" in suffix
+        and "size_i32_stride_i32" in suffix
+    ]
+    assert specialized
+
+    fallback_masks = _count_mask_arguments(fallback)
+
+    for src in specialized:
+        assert _count_mask_arguments(src) < fallback_masks
+
+
+@pytest.mark.parametrize("device", get_available_devices())
+def test_generated_source_stride_reduction_copy(device):
+    """Source-structure assertion: the contiguity-specialized copy
+    variant contains strictly fewer ``* stride`` expressions than the
+    fallback."""
+
+    name = _make_kernel_name("copy_metric")
+    _build_copy_kernel(name, device)
+
+    sources = _read_variant_sources(name)
+    fallback = next(
+        src for suffix, src in sources.items() if "size_i64_stride_i64" in suffix
+    )
+    specialized = [
+        src
+        for suffix, src in sources.items()
+        if "_size_i32_stride_i32" in suffix
+        and re.search(r"divisibility_1_16_1_16_contiguity_0_1_0_1_", suffix)
+    ]
+    assert specialized
+
+    fallback_strides = _count_stride_multiplications(fallback)
+
+    for src in specialized:
+        assert _count_stride_multiplications(src) < fallback_strides
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", get_available_devices())
+def test_dispatcher_uses_strict_divisibility_check(device):
+    """The dispatcher must check ``% BLOCK_SIZE`` for tensors whose
+    innermost tile size is statically known, not the old ``% 16``."""
+
+    name = _make_kernel_name("add_dispatch")
+    _build_add_kernel(name, device)
+
+    dispatcher = _read_dispatcher(name)
+
+    # BLOCK_SIZE was 256, threshold should be 256 (since 256 > 16)
+    assert "shape[0] % 256 == 0" in dispatcher, (
+        f"dispatcher did not strengthen divisibility check:\n{dispatcher}"
+    )


### PR DESCRIPTION
# justdoit\_九齿编译优化\_T1\-2\-1\_总结报告



---

## 一、概括
在 NineToothed 现有 AOT variant 特化基础上，新增两类代码生成特化，把可靠识别的弱势场景下沉到生成阶段，生成更精简的源；不满足条件时字节级回退原路径。

1. **Divisible tile fast path**：当内层 tile 可整除对应维度时，静态消除恒为真的上界 mask；当整条 mask 折叠为 `True` 时，在 `tl.load/tl.store` 中省去 `mask=` / `other=` 参数。

2. **Contiguous fast path**：当某维 stride == 1 时，将 `offsets * stride` 折叠为 `offsets`，消除冗余指针算术。

**弱势场景根因**：现有特化只影响 Triton 侧签名，Python 端生成源对所有 variant 共用一份——命中 divisibility 后 mask 仍写在源里、命中 contiguity 后 `offset * stride` 仍展开，靠下游编译器折叠。

---

## 二、实现

**提示通道**：新增 `src/ninetoothed/specialization.py`，定义 `SpecializationHints(divisible_dims, contiguous_dims)`，键为 `(source_name, dim)`，把 AOT variant 的 `divisibility_spec` / `contiguity_spec` 下沉到代码生成阶段。

**per\-variant 重跑 codegen**：`aot.py` 不再让所有 variant 共用一份 `make()` 的源，而是对每个 variant 用其自身 spec 调 `_hints_from_spec` 生成 hints，再跑 `CodeGenerator(specialization_hints=hints)` 产出**专属源**；JIT 路径与 fallback variant 用 `hints.empty()`，行为不变。

**保守启用条件（宁缺毋滥）**：

- mask 消除仅作用于**恒为真的上界项**（`tensor.py::offsets`）；额外护栏 `_is_divisibility_safe`：算子历史必须含 `tile`、且不含 `pad`/`_slice_dim`，排除 padding/slice 误命中；

- dispatcher 整除检查由 `shape[dim] % 16 == 0` 强化为 `shape[dim] % BLOCK_SIZE == 0`；

- stride 折叠仅作用于 `stride == 1` 的维度（`generation.py::_generate_overall_offsets_and_mask`）。

**正确性**：mask 消除只针对整除保证下无越界的恒真项，stride 折叠只针对 stride==1 维——两者与原表达式数学等价，不改变计算语义。

**变更文件**：`specialization.py`\(新增\) · `generation.py` · `tensor.py` · `aot.py` · `symbol.py` · `tests/test_specialization.py`\(新增\) · `bench/run_specialization_bench.py`\(新增\)。

---

## 三、实验数据

**环境**：RTX 4090D（24GB, sm\_89）/ CUDA 12\.8 / driver 570\.124\.06 / NGC PyTorch \(torch 2\.6\) / Triton 3\.1\.0 / Python 3\.12。

### 3\.1 正确性
<img width="1288" height="290" alt="image" src="https://github.com/user-attachments/assets/77b58940-87f9-40d7-ac05-59aac067ac8f" />

### 3\.2 生成代码指标（同内核内 命中 variant vs int64 fallback variant）
<img width="1130" height="306" alt="image" src="https://github.com/user-attachments/assets/f20eb65f-5e33-434e-bbc2-9c678413ae0e" />


均超 ≥0\.25 门槛。由 `test_generated_source_mask_reduction_add` / `test_generated_source_stride_reduction_copy` 断言「命中 variant 严格少于 fallback」。

benchmark 各命中变体所选源计数（10 场景，f32）：
<img width="942" height="630" alt="image" src="https://github.com/user-attachments/assets/e1d10875-ac14-41b7-92ca-16099eeaf81b" />


特化只在安全时触发：非整除仍保留 mask、非连续仍保留 stride 乘法。

### 3\.3 运行时（baseline = hints 置空的同内核）
<img width="1138" height="808" alt="image" src="https://github.com/user-attachments/assets/4e5c454d-7839-46cc-9926-847ae75f0f9e" />


- 命中场景 1\.00–1\.04×；回退场景 1\.00–1\.03×（均 ≥1\.0，无退化）。

- speedup 接近 1\.0 的原因：消除的是**生成源层面**的恒真 mask 与 `stride×1`，Triton/LLVM 编译期本就会折叠这些冗余；且 add/copy 为访存受限算子，运行时由带宽决定。定位为「**结构改善 \+ 运行时零回退**」。

*数据可复现：**`pytest tests/test_specialization.py`**、**`pytest -q`**、**`python bench/run_specialization_bench.py`**。*



> 实测原始输出\(RTX 4090D\):
> 
> 



<img width="1280" height="333" alt="image" src="https://github.com/user-attachments/assets/a216d338-8fa1-4098-a469-78c2e8c0ad3b" />


[Honor Code.pdf](https://github.com/user-attachments/files/29941186/2026.Honor.Code.1.pdf)


