### PR TITLE
Add [2026春季][T3-1-1] CearX

### DIFF
--- a/skills/competition/ntops-dev/SKILL.md
+++ b/skills/competition/ntops-dev/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: "ntops-dev"
+description: "Use this skill for any NineToothed/ntops operator task: implementing or integrating kernels, wrappers, exports, and tests; debugging correctness, broadcasting, dtype, non-contiguous stride/offset, generated source, AOT build, or performance regressions; and running fixed-configuration CUDA benchmarks. Trigger even when the user only names an operator, failing test, or benchmark problem."
+---
+
+# ntops 算子开发
+
+目标是在 `ntops` 中完成可运行、可测试、改动范围清晰的算子补丁。默认只修改算子仓库；`ninetoothed` 用于查阅 DSL 和编译机制，除非任务明确要求，否则不改编译器核心。
+
+## 默认范围
+
+- 实现目录：`ntops/src/ntops/kernels/`、`ntops/src/ntops/torch/`、`ntops/tests/`。
+- 参考目录：`ninetoothed/src/ninetoothed/`、`ninetoothed/docs/source/`。
+- 不删除测试，不伪造 benchmark，不针对隐藏用例写死输入，不依赖私有服务。
+- 算子开发任务必须由 NineToothed kernel 执行核心计算；不得用 wrapper 直接调用同名 `torch.*`、`Tensor.*` 或 PyTorch functional API 伪装成 ntops 实现。PyTorch 只作为测试参考实现，除非任务明确是 wrapper/fallback 集成而非 NineToothed 算子开发。
+- 不为了让一个算子通过而修改 NineToothed 编译器核心；如果证据指向编译器限制，先记录最小复现、支持边界和规避方案。
+
+## 任务分类与必查项
+
+在修改文件前，将任务标记为下列一类或多类，并执行对应检查：
+
+- 逐元素/广播：同 shape、标量/0 维 tensor、非规则 shape、广播方向、dtype promotion 和 mask。
+- 归约/分块：归约维、非末维、单元素维、非 2 的幂长度、accumulation dtype 和数值稳定性。
+- 布局敏感：`is_contiguous()`、stride、storage offset、transpose/slice 输入、输出布局契约和地址 mask。
+- 性能/诊断/集成：正式 benchmark 协议、generated source、AOT build/导入、失败最小复现和候选保留/回退。
+
+## 关键陷阱
+
+- pytest 通过不能证明完成 NineToothed 实现；确认核心计算确实进入 kernel，而非 PyTorch 透传。
+- 0 维 tensor 的 `.item()` 会触发 host sync。把它当作有明确性能限制的最后 correctness 规避，先验证 tensor/view 路径；`expand_as` 产生零 stride view，必须用真实 CUDA 用例验证。
+- 不向零 stride 的 expanded **输出** view 写入多个逻辑结果；这会产生地址别名，且可能使 NineToothed 的 pointer/mask lowering 失败。输出 descriptor 与物理输出 rank/shape 对齐，并证明每个 program 只写一个明确的逻辑输出位置。
+- 归约先比较两种架构：wrapper 将目标维移动到末维并规范化为固定 rank，或 arrangement 直接表达任意 rank/维度。只要契约允许，先实现 DSL 变换更少、可独立验证的固定-rank 方案；不要因参考算子更复杂就默认选择复杂映射。
+- 布局测试必须比较输出；只断言 `not input.is_contiguous()` 不能证明算子正确。
+- `git diff` 默认不包含未跟踪文件。封存补丁前检查 `git status --short`，并用 `git add -N <new-files>` 或工作树归档保留新文件。
+- 最终摘要必须与最后一次命令日志一致；早期失败和后续成功都保留，但不把旧状态写成最终状态。
+
+## 工作流程
+
+1. 写清算子契约：输入、输出、shape、dtype、device、广播、非连续布局、stride/offset、边界条件、异常语义、不支持范围和性能目标。契约不清时先用 PyTorch 小实验确认，不边猜边实现。
+2. 先找仓库中的相近实现：
+   - 逐元素：`relu`、`silu`、`gelu`、`add`、`mul`。
+   - 归约/分块：`softmax`、`max_pool2d`、`avg_pool2d`、`rms_norm`。
+   - 布局敏感：`addmm`、`mm`、`bmm`、`conv2d`、`matmul`。
+   - 性能/诊断：`scaled_dot_product_attention`、`matmul` 及其测试。
+   - 打开相近算子的真实 kernel、wrapper 和测试；历史 example 只提供已观察到的证据，不能代替源码，也不能据其复杂度推断新算子的实现结构。
+3. 只补任务需要的文件：
+   - `src/ntops/kernels/<op>.py`
+   - `src/ntops/torch/<op>.py`
+   - 两个 `__init__.py` 中的导出
+   - `tests/test_<op>.py`
+   - 完成后用全新 Python 进程执行 `import ntops; getattr(ntops.torch, "<op>")`，防止只在当前进程注册成功而遗漏导出。
+4. 优先复用仓库模式：
+   - 普通逐元素算子使用 `ntops.kernels.element_wise.arrangement`。
+   - wrapper 使用 `ntops.torch.utils._cached_make`。
+   - 合适时使用 `tests.utils.generate_arguments()` 和 `skip_if_cuda_not_available`。
+   - 归约先把“逻辑契约”与“kernel 物理布局”分开：在 wrapper 中规范化维度/shape，在 kernel 中只表达最小必要的 tile/reduce/store。只有 wrapper 规范化会破坏任务要求或带来不可接受复制时，才升级为任意维 stride-aware arrangement。
+5. 先验证 correctness：
+   - 参数化全量测试前，分别用 fresh process smoke：全归约、一个非末维归约、一个 non-contiguous/offset 输入。任何分支失败时先缩小到最小布局并与已通过分支比较，不在未理解地址映射时继续叠加 `permute`/`unsqueeze`/`expand`/`tile`。
+   - 再跑 `python3 -m pytest tests/test_<op>.py -q`。
+   - 修改公共辅助代码后，再跑相邻算子测试。
+   - 参考结果使用 PyTorch API，并用 `torch.allclose`、`torch.testing.assert_close` 或精确比较。
+   - 布局任务至少加入一个由 transpose 构造的 non-contiguous 用例。
+   - 归约任务检查单元素归约维、非末维归约、大值和 dtype 敏感场景。
+   - 数值失败先固定随机种子，不先放宽容差。
+   - 先运行最小定向用例，再运行参数化用例和相邻回归；不用 `skip`/`xfail` 隐藏任务要求范围内的失败。
+   - 除数值外检查 shape、dtype、device 和任务指定的 layout/异常语义。
+6. Correctness 通过后再 benchmark：
+   - 正式评测统一 `max_num_configs=1`，`premake()` 显式传入所评估的 `block_size`，不依赖自动调优隐式选配置。
+   - 使用同一张 CUDA GPU、固定 shape、dtype、warmup 和重复迭代；基线与候选至少各运行 3 轮并比较 median。
+   - 为减少温度和时序影响，最终复测使用基线/候选交错顺序；记录设备、环境、dtype、shape、命令、双方延迟和相对性能。
+   - 改善不足 5% 或波动区间重叠时不宣称有效优化。
+   - 没有 CUDA 时只记录待执行命令，不填写结果。
+7. 性能明显落后时检查 generated source：
+   - 运行 `scripts/inspect_generated_source.py <op>`。
+   - 先在空或独立缓存中触发当前算子，或用 `--source` 指定本次生成文件；`--no-trigger` 返回的低/零匹配缓存不能作为当前算子的 generated-source 证据。
+   - 记录源码路径、load/store、cast、autotune、tile/constexpr 等信号。
+   - 给出一个有证据的瓶颈假设；没有复测结果时，不写“已优化”。
+   - 每次只做一个可归因的最小候选修改。候选先通过 correctness，再按同协议复测；无收益、不稳定或破坏正确性时回退候选并记录拒绝原因。
+8. AOT build/集成任务单独验收：
+   - 记录完整 build 命令、环境变量、生成路径和导入/调用命令。
+   - 区分 Python 注册、generated source 生成、AOT 编译、动态库加载和运行时错误，不用一个模糊的“build 失败”概括。
+   - 若任务只要求修复配置或文档，保持最小补丁，不顺手改编译器核心。
+9. 遇到失败时保存最小闭环：
+   - 记录命令、报错、shape/dtype/device。
+   - 说明根因判断和最小改动。
+   - 重跑原失败用例和相邻回归。
+10. 修改前检查常见 NineToothed 风险：
+   - shape 派生的 block size 使用 `Symbol(..., constexpr=True)` 或调用参数，不按单一 shape 写死。
+   - `broadcast`、`expand`、`.offsets()`、`.data_ptr()`、scatter/store 等任务先核对 arrangement、地址和 mask。
+   - `eval(subs)` 失败时，将其作为诊断线索，并补一个小型 CUDA reference。
+   - `torch.compile` 任务应稳定 custom-op schema，并尽量在图外预编译或缓存 kernel。
+
+## 按需资料
+
+- 文件布局和补丁格式：`references/ntops_operator_workflow.md`
+- DSL 与 arrangement：`references/ninetoothed_dsl_quick_reference.md`
+- Correctness 和 benchmark 记录：`references/validation_and_benchmark.md`
+- Generated source 排查：`references/generated_source_diagnosis.md`
+- 已知九齿问题模式：`references/feishu_ninetoothed_fix_notes.md`
+
+## 可复用脚本
+
+- 聚焦 correctness：`scripts/run_correctness_test.py --help`
+- 通用 3 轮交错计时与 promotion 判定：在任务 benchmark 中导入 `scripts/benchmark_protocol.py`
+- 已支持算子的快速 benchmark：`scripts/run_operator_benchmark.py --help`
+- generated source 生成/指定文件/最新缓存检查：`scripts/inspect_generated_source.py --help`
+- 布局、归约和数值复现：`scripts/run_coverage_checks.py --help`
+
+## 历史案例路由
+
+不要默认扫描所有 examples。先读当前仓库真实源码；仅在需要同类失败证据时再读取一个最相关案例。案例是历史证据，不是实现模板或待复制答案：
+
+- 0 维/标量失败：`examples/maximum_new_operator/`
+- 归约与 generated source：`examples/softmax_reduce_selftest/`
+- non-contiguous/布局：`examples/addmm_layout_selftest/`
+- 数值与环境失败：`examples/matmul_sdpa_diagnosis/`
+- 多算子性能差距：`examples/official_ntops_benchmark/`
+
+## 完成条件
+
+- 算子契约和不支持范围已写清。
+- 已检查相近实现。
+- kernel、wrapper、导出和测试齐全。
+- 核心计算由 NineToothed kernel 完成，没有同名 PyTorch API 透传。
+- 已记录 correctness 命令和真实结果。
+- 性能敏感任务已在 `max_num_configs=1` 下记录正式 benchmark；无法执行时明确标为待验证。
+- 性能回退有 generated-source 分析或可检验的原因判断。
+- 候选修改有接受/回退证据，无收益候选已回退。
+- dtype、边界、布局或固定种子用例与任务风险相匹配。
+- 补丁没有无关重构，失败和性能差距没有被隐藏。
+
+最终交付按以下顺序摘要，并确保每个结果都能在原始日志中找到：
+
+```text
+Files changed:
+Correctness command/result:
+Adjacent regression command/result:
+Benchmark protocol/result:
+Generated-source finding:
+Candidate accepted/reverted and why:
+Known limitations or unresolved failures:
+```

--- a/skills/competition/ntops-dev/agents/openai.yaml
+++ b/skills/competition/ntops-dev/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "NineToothed 算子开发"
+  short_description: "开发、验证、优化和诊断 NineToothed/ntops 算子"
+  default_prompt: "使用 $ntops-dev 完成一个可复现、经过正确性与性能验证的 NineToothed 算子任务。"

--- a/skills/competition/ntops-dev/examples/addmm_layout_selftest/execution_log.md
+++ b/skills/competition/ntops-dev/examples/addmm_layout_selftest/execution_log.md
@@ -1,0 +1,58 @@
+# AddMM 执行记录
+
+环境：NVIDIA GeForce RTX 4090 D，Python 3.10.8，PyTorch 2.1.2+cu121，CUDA 12.1，Triton 3.0.0。
+
+## Correctness
+
+```bash
+cd ntops
+python3 -m pytest tests/test_addmm.py -q
+```
+
+```text
+..                                                                       [100%]
+2 passed in 10.46s
+```
+
+## Benchmark
+
+```bash
+cd <ntskill-repository>
+python3 \
+  skills/competition/ntops-dev/scripts/run_operator_benchmark.py \
+  addmm --shape 512,512,512 --dtype float16 --warmup 10 --iters 50
+```
+
+```text
+ntops_ms=0.1276
+torch_ms=0.0272
+relative_to_torch=4.6976
+```
+
+## Generated source
+
+关键统计：
+
+```text
+language_load=3
+language_store=1
+language_dot=1
+language_arange=40
+autotune=True
+```
+
+后续检查目标是 tile/block、precision mode 和 autotune 对 `(512, 512, 512)` 的选择。当前记录没有声称已经修复性能。
+
+## 非连续输入
+
+```text
+contiguous ok=True
+input_stride=(48, 1) mat1_stride=(80, 1) mat2_stride=(48, 1)
+max_abs=0.03125
+
+all_non_contiguous_transpose ok=True
+input_stride=(1, 64) mat1_stride=(1, 64) mat2_stride=(1, 80)
+max_abs=0.0
+```
+
+已覆盖 transpose 产生的非连续 `input`、`mat1`、`mat2`。尚未覆盖任意 `as_strided`、negative stride 和广播矩阵输入。性能未达到 Proposal 目标。

--- a/skills/competition/ntops-dev/examples/addmm_layout_selftest/task_description.md
+++ b/skills/competition/ntops-dev/examples/addmm_layout_selftest/task_description.md
@@ -1,0 +1,20 @@
+# 任务说明：AddMM 布局检查
+
+检查 `ntops.torch.addmm(input, mat1, mat2, beta=1, alpha=1, out=None)`：
+
+- 与 `torch.addmm` 对齐；
+- 覆盖 float16/float32；
+- 增加 transpose 构造的 non-contiguous 输入；
+- 运行 benchmark 和 generated-source 检查。
+
+相关文件：
+
+- `src/ntops/kernels/addmm.py`
+- `src/ntops/torch/addmm.py`
+- `tests/test_addmm.py`
+- `tests/test_mm.py`
+
+```bash
+cd ntops
+python3 -m pytest tests/test_addmm.py -q
+```

--- a/skills/competition/ntops-dev/examples/matmul_sdpa_diagnosis/diagnosis_log.md
+++ b/skills/competition/ntops-dev/examples/matmul_sdpa_diagnosis/diagnosis_log.md
@@ -1,0 +1,55 @@
+# Matmul / SDPA 诊断记录
+
+环境：NVIDIA GeForce RTX 4090 D，Python 3.10.8，PyTorch 2.1.2+cu121，CUDA 12.1，Triton 3.0.0。
+
+## SDPA 收集失败
+
+```bash
+cd ntops
+python3 -m pytest \
+  tests/test_scaled_dot_product_attention.py -q
+```
+
+```text
+ModuleNotFoundError: No module named 'torch.nn.attention'
+```
+
+测试引用 `torch.nn.attention.bias.causal_lower_right`，当前 PyTorch 2.1.2 没有该模块路径。初赛材料将其标记为环境兼容失败；后续应使用支持该 API 的 PyTorch，或在任务允许时增加 reference fallback。
+
+## Matmul 数值失败
+
+```bash
+python3 -m pytest tests/test_matmul.py -q
+```
+
+```text
+1 failed, 7 passed in 28.79s
+```
+
+失败 shape：
+
+```text
+(1, 394, 724) @ (1, 724, 388), float16
+```
+
+`torch.allclose` 在 `rtol=0.01, atol=0.01` 下失败。该问题不是导入或 CUDA 可用性问题，需要先固定输入再判断 accumulation/precision 差异。
+
+## 固定种子复现
+
+```bash
+cd <ntskill-repository>
+timeout 180 python3 -u \
+  skills/competition/ntops-dev/scripts/run_coverage_checks.py matmul
+```
+
+```text
+seed=0
+shape_a=(1, 394, 724)
+shape_b=(1, 724, 388)
+ok=False
+max_abs=0.0625
+max_rel=18800.0
+max_ref=142.5
+```
+
+`max_abs=0.0625` 高于 `atol=0.01`，说明失败可以稳定复现。`max_rel` 受接近零的参考值放大，后续应检查误差分布和 accumulation dtype，在查清原因前不放宽容差。

--- a/skills/competition/ntops-dev/examples/matmul_sdpa_diagnosis/task_description.md
+++ b/skills/competition/ntops-dev/examples/matmul_sdpa_diagnosis/task_description.md
@@ -1,0 +1,22 @@
+# 任务说明：Matmul / SDPA 失败诊断
+
+运行以下测试并保留真实失败：
+
+- `ntops.torch.matmul`
+- `ntops.torch.scaled_dot_product_attention`
+
+检查文件：
+
+- `src/ntops/torch/matmul.py`
+- `src/ntops/torch/mm.py`
+- `src/ntops/torch/bmm.py`
+- `tests/test_matmul.py`
+- `tests/test_scaled_dot_product_attention.py`
+
+```bash
+cd ntops
+python3 -m pytest tests/test_matmul.py -q
+python3 -m pytest tests/test_scaled_dot_product_attention.py -q
+```
+
+出现数值失败时先固定随机种子；出现导入失败时先核对 PyTorch 版本，不通过跳过测试伪造成功。

--- a/skills/competition/ntops-dev/examples/maximum_new_operator/execution_log.md
+++ b/skills/competition/ntops-dev/examples/maximum_new_operator/execution_log.md
@@ -1,0 +1,74 @@
+# 执行记录
+
+## 环境
+
+- GPU：NVIDIA GeForce RTX 4090 D
+- Python：3.10.8
+- PyTorch：2.1.2+cu121
+- CUDA：12.1
+- Triton：3.0.0
+- pytest：8.4.2
+
+## 首次测试
+
+```bash
+cd ntops
+python3 -m pytest tests/test_maximum.py -q
+```
+
+结果：
+
+```text
+8 failed, 8 passed in 10.92s
+```
+
+同 shape 用例全部通过；0 维 `other` 全部编译失败。核心报错：
+
+```text
+invalid operands of type pointer<fp32> and triton.language.float32
+```
+
+生成代码将 0 维 tensor 作为指针参数直接传给 `triton.language.maximum`，而不是加载后的标量值。
+
+## 修复与回归
+
+Wrapper 对 `other.ndim == 0` 使用 `other.item()`，其余路径保持 tensor 输入。随后运行：
+
+```bash
+python3 -m pytest \
+  tests/test_maximum.py tests/test_add.py tests/test_mul.py -q
+```
+
+结果：
+
+```text
+32 passed in 26.48s
+```
+
+其中 `test_maximum.py` 包含 16 组：float16/float32、1D 至 4D、同 shape 和 0 维 `other`。
+
+## Benchmark
+
+```bash
+cd <ntskill-repository>
+python3 \
+  skills/competition/ntops-dev/scripts/run_operator_benchmark.py \
+  maximum --shape 1048576 --dtype float16 --warmup 10 --iters 100
+
+python3 \
+  skills/competition/ntops-dev/scripts/run_operator_benchmark.py \
+  maximum --shape 1048576 --dtype float16 --scalar-other \
+  --warmup 10 --iters 100
+```
+
+| 输入 | ntops | PyTorch | ntops / PyTorch |
+| --- | ---: | ---: | ---: |
+| 同 shape | 0.0515 ms | 0.0083 ms | 6.1974x |
+| 0 维 `other` | 0.0633 ms | 0.0093 ms | 6.7984x |
+
+## 结论
+
+- 新增算子、导出、correctness 和相邻回归已完成。
+- 两条性能结果均未达到 Proposal 目标。
+- 0 维路径虽然结果正确，但 `.item()` 带来主机同步，不适合性能敏感热路径。
+- 任意不同 shape 广播尚未支持，不能将本结果表述为完整 PyTorch broadcasting。

--- a/skills/competition/ntops-dev/examples/maximum_new_operator/patch_summary.md
+++ b/skills/competition/ntops-dev/examples/maximum_new_operator/patch_summary.md
@@ -1,0 +1,18 @@
+# 补丁摘要
+
+新增文件：
+
+- `src/ntops/kernels/maximum.py`
+- `src/ntops/torch/maximum.py`
+- `tests/test_maximum.py`
+
+修改文件：
+
+- `src/ntops/kernels/__init__.py`
+- `src/ntops/torch/__init__.py`
+
+Kernel 复用公共 `element_wise.arrangement`，application 使用 `ntl.maximum(input, other)`。Wrapper 使用 `_cached_make`，缓存键包含 `input.ndim` 和 `other.ndim`。
+
+0 维 `other` 首次测试时被生成代码当作指针传入 `tl.maximum`，导致 Triton 类型错误。最小修复是在 wrapper 中对 0 维输入使用 `other.item()`，把标量值传给 kernel。没有修改公共 arrangement 或编译器。
+
+该修复保证 correctness，但 `.item()` 会触发主机同步，因此 0 维路径被列为性能限制。

--- a/skills/competition/ntops-dev/examples/maximum_new_operator/task_description.md
+++ b/skills/competition/ntops-dev/examples/maximum_new_operator/task_description.md
@@ -1,0 +1,19 @@
+# 任务说明：新增 maximum 算子
+
+在 `ntops` 中新增：
+
+```python
+ntops.torch.maximum(input, other, *, out=None)
+```
+
+要求：
+
+- 使用 NineToothed DSL 编写 kernel；
+- 增加 torch wrapper、kernel/torch 导出和 pytest；
+- 与 `torch.maximum` 对齐；
+- 覆盖 float16、float32、1D 至 4D 非规则 shape；
+- 覆盖同 shape 双输入和 0 维 tensor `other`；
+- 先跑聚焦测试，再跑相邻逐元素算子回归；
+- 记录失败、修复和 benchmark，不修改 NineToothed 编译器核心。
+
+当前不要求支持任意不同 shape 的 PyTorch 广播。公共 `element_wise.arrangement` 只明确处理同维 tensor 和 0 维 tensor，该限制必须写入结果。

--- a/skills/competition/ntops-dev/examples/official_ntops_benchmark/execution_log.md
+++ b/skills/competition/ntops-dev/examples/official_ntops_benchmark/execution_log.md
@@ -1,0 +1,57 @@
+# 官方 ntops 性能对比记录
+
+环境：
+
+- GPU：NVIDIA GeForce RTX 4090 D
+- PyTorch：2.1.2+cu121
+- CUDA：12.1
+- 官方 ntops：`6bc90d5 Develop ResNet operators (#73)`
+- warmup：20
+- iters：100
+
+Correctness 预检查：
+
+```bash
+cd <clean-ntops-repository>
+python3 -m pytest \
+  tests/test_gelu.py tests/test_softmax.py tests/test_addmm.py -q
+```
+
+结果：
+
+```text
+18 passed, 8 skipped in 22.78s
+```
+
+Benchmark 命令：
+
+```bash
+cd <clean-ntops-repository>
+python3 \
+  <ntskill-repository>/skills/competition/ntops-dev/scripts/run_official_ntops_benchmark.py \
+  --warmup 20 --iters 100
+```
+
+结果：
+
+| 算子 | dtype | shape | ntops ms | PyTorch ms | ntops / PyTorch |
+| --- | --- | --- | ---: | ---: | ---: |
+| gelu | fp16 | `(1048576,)` | 0.0457 | 0.0079 | 5.7976 |
+| relu | fp16 | `(1048576,)` | 0.0451 | 0.0085 | 5.2794 |
+| silu | fp16 | `(1048576,)` | 0.0793 | 0.0087 | 9.0681 |
+| add | fp16 | `(1048576,)` | 0.0521 | 0.0081 | 6.4273 |
+| mul | fp16 | `(1048576,)` | 0.0520 | 0.0083 | 6.2449 |
+| gelu | fp32 | `(1048576,)` | 0.0451 | 0.0079 | 5.7182 |
+| relu | fp32 | `(1048576,)` | 0.0463 | 0.0085 | 5.4642 |
+| silu | fp32 | `(1048576,)` | 0.0454 | 0.0084 | 5.4181 |
+| add | fp32 | `(1048576,)` | 0.0518 | 0.0080 | 6.4540 |
+| mul | fp32 | `(1048576,)` | 0.0500 | 0.0082 | 6.0875 |
+| softmax | fp16 | `(1024, 1024)` | 0.0517 | 0.0112 | 4.6243 |
+| addmm | fp16 | `(512, 512, 512)` | 0.1497 | 0.0179 | 8.3579 |
+
+结论：
+
+- 本次选取的官方 ntops 算子在上述输入和环境下均慢于 PyTorch eager。
+- 该结果说明当前材料中的性能差距不只来自新增 `maximum`，也出现在若干官方已有算子样例中。
+- 结论不能外推到 ntops 全部算子，也不代表已经完成性能优化。
+- Proposal 中“性能达到 PyTorch/Triton 80%-90%”的计划目标需要在后续阶段调整为“先建立可复现 benchmark，再针对具体算子逐项优化”。

--- a/skills/competition/ntops-dev/examples/official_ntops_benchmark/task_description.md
+++ b/skills/competition/ntops-dev/examples/official_ntops_benchmark/task_description.md
@@ -1,0 +1,24 @@
+# 任务说明：官方 ntops 性能对比
+
+在干净的官方 `ntops` 仓库上运行一组代表性算子，与 PyTorch eager 做同卡 benchmark。
+
+目的：
+
+- 检查本 skill 记录的性能差距是否只来自本地新增算子。
+- 验证官方仓库已有算子在当前环境和输入下的 PyTorch 对比结果。
+- 给中期报告提供更清楚的性能边界。
+
+命令：
+
+```bash
+cd <clean-ntops-repository>
+python3 \
+  <ntskill-repository>/skills/competition/ntops-dev/scripts/run_official_ntops_benchmark.py \
+  --warmup 20 --iters 100
+```
+
+要求：
+
+- 使用干净官方 `ntops` 仓库，不使用本项目新增的 `maximum`、`square`。
+- 记录 GPU、PyTorch/CUDA 版本、warmup、iters、shape、dtype、ntops 延迟、PyTorch 延迟和相对比值。
+- 结论只限定到本次算子、输入和环境，不外推到全部 ntops 算子。

--- a/skills/competition/ntops-dev/examples/softmax_reduce_selftest/execution_log.md
+++ b/skills/competition/ntops-dev/examples/softmax_reduce_selftest/execution_log.md
@@ -1,0 +1,63 @@
+# Softmax 执行记录
+
+环境：NVIDIA GeForce RTX 4090 D，Python 3.10.8，PyTorch 2.1.2+cu121，CUDA 12.1，Triton 3.0.0。
+
+## Correctness
+
+```bash
+cd ntops
+python3 -m pytest tests/test_softmax.py -q
+```
+
+```text
+........                                                                 [100%]
+8 passed in 11.58s
+```
+
+## Benchmark
+
+```bash
+cd <ntskill-repository>
+python3 \
+  skills/competition/ntops-dev/scripts/run_operator_benchmark.py \
+  softmax --shape 1024,1024 --dtype float16 --warmup 10 --iters 50
+```
+
+```text
+ntops_ms=0.0536
+torch_ms=0.0091
+relative_to_torch=5.8902
+```
+
+## Generated source
+
+```bash
+python3 \
+  skills/competition/ntops-dev/scripts/inspect_generated_source.py \
+  softmax --shape 1024,1024 --dtype float16 --latest 1
+```
+
+关键统计：
+
+```text
+language_load=2
+language_store=1
+language_exp=3
+language_arange=33
+language_sum=1
+language_max=1
+autotune=True
+```
+
+当前检查方向是 reduction/mask 开销和两阶段表达式的重复生成；尚无复测证明这些因素已被优化。
+
+## 边界用例
+
+```text
+single_last_dim_fp16 ok=True shape=(7, 1) max_abs=0.0
+wide_fp16 ok=True shape=(2, 1024) max_abs=7.62939453125e-06
+middle_dim_fp32 ok=True shape=(3, 5, 7) dim=1 max_abs=5.960464477539063e-08
+large_values_fp32 ok=True shape=(4, 33) max_abs=9.313225746154785e-10
+```
+
+尚未覆盖空 tensor 和非连续 softmax 输入。Correctness 在上述范围内通过，性能未达到 Proposal 目标。

--- a/skills/competition/ntops-dev/examples/softmax_reduce_selftest/task_description.md
+++ b/skills/competition/ntops-dev/examples/softmax_reduce_selftest/task_description.md
@@ -1,0 +1,19 @@
+# 任务说明：Softmax 归约
+
+检查 `ntops.torch.softmax(input, dim, dtype=None)`：
+
+- 与 `torch.nn.functional.softmax` 对齐；
+- 覆盖 float16/float32 和多维 shape；
+- 检查单元素归约维、非末维归约和大值输入；
+- 运行 benchmark 和 generated-source 检查。
+
+相关文件：
+
+- `src/ntops/kernels/softmax.py`
+- `src/ntops/torch/softmax.py`
+- `tests/test_softmax.py`
+
+```bash
+cd ntops
+python3 -m pytest tests/test_softmax.py -q
+```

--- a/skills/competition/ntops-dev/references/feishu_ninetoothed_fix_notes.md
+++ b/skills/competition/ntops-dev/references/feishu_ninetoothed_fix_notes.md
@@ -1,0 +1,116 @@
+# Feishu NineToothed Fix Notes
+
+This note distills reusable guidance from the NineToothed troubleshooting documents distributed by the competition through Feishu. It is not a replacement for local `ntops` tests; use it as a checklist before changing operator code or declaring a diagnosis complete.
+
+Source boundary: the reviewed material is competition-provided NineToothed documentation. Checklist wording is a condensed engineering summary prepared for this skill, not an official NineToothed API specification. The skill does not reproduce the original documents, and every recommendation still requires validation against the local repository and CUDA tests.
+
+## Sources Reviewed
+
+- `Symbol 问题`
+- `自动注册｜图中断`
+- `广播问题`
+- `Mask & offsets 使用`
+- `Store`
+- `九齿 torch compile 解决方案`
+- `expand 防呆修改`
+- `Eval 问题`
+- `Embedding kernel 问题`
+
+This skill does not require Feishu access at runtime and must not depend on reopening external documents during evaluation.
+
+## Reusable Lessons
+
+### Symbol and constexpr inputs
+
+Shape-derived constants such as tile sizes, hidden dimensions, or block sizes should be represented as `Symbol(..., constexpr=True)` or explicit make-time/call-time parameters when the generated kernel needs them. Do not assume a constant can be safely hard-coded inside `arrangement` just because it is known from the input shape.
+
+When a shape-dependent value is needed in `arrangement`, pass it through the generated kernel call, for example `kernel(a, b, out, H=a.shape[-1])`. This keeps the arrangement expression symbolic while still giving the compiler a concrete constexpr.
+
+Checklist:
+
+- Identify every block size, reduction width, hidden dimension, and tile extent.
+- Decide whether it is a Python constant, a `Symbol` constexpr, or a runtime tensor-derived value.
+- If it is shape-derived, pass it through the make/kernel path rather than silently closing over one observed shape.
+- Add a second shape in correctness tests to catch accidental single-shape specialization.
+
+### Broadcast arrangement
+
+NineToothed arrangement expressions can reject or mis-handle forms that look equivalent under PyTorch broadcasting. In the broadcast note, a `(B, 1)` temperature tensor is intended to broadcast over `(B, H)` logits. Some `expand` plus `tile` forms fail at `make`, while a simpler `tile` form can compile but produce an incorrect result.
+
+Checklist:
+
+- Treat PyTorch broadcasting semantics and NineToothed arrangement semantics as related but not identical.
+- For each broadcast input, write down source shape, arranged shape, and output shape.
+- Use a minimal `eval(subs)` or tiny CUDA check to inspect the arranged tensors before trusting a compiled kernel.
+- Include at least one non-square or non-power-of-two shape so accidental symmetry does not hide a wrong broadcast.
+
+### Expand guardrails
+
+The expand note highlights a defensive check in offset construction: target dimensions that are not `-1` should not all be treated as broadcasted singleton dimensions. If the original size equals the requested new size, preserve the index instead of forcing that dimension's offset to zero.
+
+Checklist:
+
+- Distinguish "keep this dimension" from "broadcast this singleton dimension".
+- Test `expand` with unchanged dimensions, singleton-to-larger dimensions, and mixed `-1` dimensions.
+- For broadcast tasks, inspect both arranged shape and offset behavior, not shape alone.
+
+### Eval as a diagnostic, not an oracle
+
+The eval note shows that `.eval(subs)` can fail for some tensors declared with `shape_options`. Keep `eval` in the workflow because it is valuable for arrangement inspection, but record its limits.
+
+Checklist:
+
+- If `eval(subs)` fails, capture the tensor shape/options and the exact expression being evaluated.
+- Confirm whether the same case also fails at `make` or CUDA execution before treating it as an operator failure.
+- Use a tiny CUDA reference case when `eval` cannot represent the shape-options combination.
+
+### Mask and offsets
+
+Using `.data_ptr()` and `.offsets()` moves the implementation closer to handwritten Triton. That can be useful for low-level indexing, but it also moves responsibility for mask handling, multi-dimensional bounds, and address arithmetic into the operator code.
+
+Checklist:
+
+- For every `.offsets(axis)` use, state the logical axis and the physical address expression it feeds.
+- Add masks for tail blocks and non-divisible dimensions before load/store, not after a value has already been used.
+- Verify 1D examples separately from 2D or batched examples; a shape check that is enough for 1D can be incomplete for higher rank tensors.
+- When a task is easier with built-in arrangement/load/store behavior, prefer that over raw pointer arithmetic.
+
+### Store and scatter-like writes
+
+Scatter-like stores such as `a[b[i], j] = c[i, j]` need explicit reasoning about index tensors, row strides, and output mutation. The logical output shape is not enough to prove that the write-back address is correct.
+
+Checklist:
+
+- Separate read layout, index layout, and write layout in the operator contract.
+- Check whether the operation mutates an input, writes a fresh output, or returns a view-like result.
+- Test repeated indices, boundary indices, and non-contiguous source or destination tensors if the contract allows them.
+- Compare both final tensor values and untouched regions of the destination.
+
+### Embedding and advanced indexing
+
+Embedding is a lookup/scatter-adjacent pattern: input indices `(B, S)` select rows from `weight (num_emb, H)` to produce `output (B, S, H)`. A practical NineToothed decomposition can flatten `B*S` into a single logical dimension `M`, then tile/block that dimension while carrying the embedding dimension.
+
+Checklist:
+
+- State the index tensor dtype, valid index range, and out-of-range behavior.
+- Decide whether to flatten batch/sequence dimensions, and record how to map the flattened offset back to `(B, S)`.
+- Test boundary indices `0` and `num_emb - 1`; include repeated indices and non-contiguous output if supported.
+- Compare against `torch.nn.functional.embedding` or direct `weight[input]` reference.
+
+### torch.compile and custom op registration
+
+The reviewed compile notes show two separate concerns:
+
+- Wrapping a NineToothed operator as a `torch.op` can help avoid Dynamo inspecting the Python implementation directly.
+- If the NineToothed kernel is still compiled with dynamic parameters during a traced region, graph breaks can still happen.
+
+Checklist:
+
+- Stabilize the custom op schema before testing `torch.compile`.
+- Pre-build or cache the kernel outside the compiled hot path when possible.
+- Keep constexpr/block-size choices explicit; distinguish static mode from dynamic `ninetoothed.block_size()` mode.
+- Record whether the validation checks eager correctness only, `torch.compile` graph capture, or both.
+
+## Skill Usage Rule
+
+When an operator task touches shape-derived tiling, broadcasting, raw offsets, scatter/store, or `torch.compile`, first add a short "NineToothed risk note" to the task log. The note should state which issue pattern applies, the minimal reproduction or validation command, and what remains unverified.

--- a/skills/competition/ntops-dev/references/generated_source_diagnosis.md
+++ b/skills/competition/ntops-dev/references/generated_source_diagnosis.md
@@ -1,0 +1,71 @@
+# Generated Source and Performance Diagnosis
+
+Use this reference after correctness passes and benchmark shows a performance gap. The goal is not to claim a complete compiler-level proof, but to collect useful evidence for the next optimization step.
+
+Source: diagnosis fields come from the local `inspect_generated_source.py`, generated files under the NineToothed cache, and recorded RTX 4090 D runs. Bottleneck statements are hypotheses until a follow-up benchmark confirms them.
+
+## When To Inspect Generated Source
+
+Inspect generated source when:
+
+- a benchmark is much slower than PyTorch/Triton baseline,
+- a performance-sensitive operator uses reduction, matmul, pooling, or attention,
+- a failure may be related to dtype/precision, masks, or non-contiguous access,
+- the task asks for performance diagnosis rather than a new operator.
+
+## Evidence To Collect
+
+Record:
+
+- operator name,
+- benchmark command and result,
+- generated source path,
+- file size and line count,
+- counts of `tl.*` or `triton.language.*` operations such as load, store, dot, exp, erf, where, arange, sum, and max,
+- whether `@triton.heuristics` or `@triton.autotune` appears,
+- relevant `BLOCK_SIZE` / tile / constexpr names,
+- obvious dtype casts such as `tl.float32`, `tl.float16`, or TF32 precision variants.
+
+## Reading The Source
+
+Start with these questions:
+
+- Are there more loads/stores than the operator semantics suggest?
+- Are masks generated inside hot loops?
+- Is a reduction recomputing values that could be hoisted?
+- Does the code cast to float32 for numerical stability, and is that expected?
+- Does matmul use `tl.dot`, and does the precision setting match the reference?
+- Is the input contiguous assumption explicit, or does the code rely on strides?
+- Are tile sizes too small/large for the tested shape?
+
+## Interpreting Existing Historical Results
+
+The recorded historical benchmarks show:
+
+- GELU is correct but slower than PyTorch eager for tested shapes.
+- Softmax is correct but slower than PyTorch eager for `(1024, 1024)` float16.
+- AddMM is correct but slower than PyTorch eager for `(512, 512, 512)` float16.
+- Maximum is correct for the recorded same-shape and zero-dimensional cases but slower than PyTorch eager for `(1048576,)` float16.
+
+These results are not final optimization claims. They identify where final-round work should inspect generated source, tile choices, load/store patterns, and dtype/precision behavior.
+
+## Diagnosis Template
+
+```text
+Operator:
+Correctness result:
+Benchmark result:
+Generated source path:
+Source summary:
+  lines:
+  language_load:
+  language_store:
+  language_dot:
+  language_exp:
+  language_arange:
+  notable casts:
+  autotune/heuristics:
+Likely bottleneck:
+Next experiment:
+Risk:
+```

--- a/skills/competition/ntops-dev/references/ninetoothed_dsl_quick_reference.md
+++ b/skills/competition/ntops-dev/references/ninetoothed_dsl_quick_reference.md
@@ -1,0 +1,42 @@
+# NineToothed DSL Quick Reference
+
+Use this reference when choosing DSL patterns for an `ntops` operator.
+
+Source: distilled from the checked-in `ninetoothed/src/ninetoothed/`, `ntops/src/ntops/`, and their tests. It is a repository-oriented quick reference, not a substitute for the upstream API documentation.
+
+## Common Building Blocks
+
+- `Tensor(ndim, dtype=None)`: describes an input/output tensor surface for `ninetoothed.make`.
+- `block_size()`: declares a tunable block dimension.
+- `arrangement`: maps logical tensors into tiled, expanded, flattened, or otherwise arranged views.
+- `application`: expresses elementwise, reduction, or matrix computation on arranged tensors.
+- `premake(...)`: returns `(arrangement, application, tensors)` for wrapper-side cached compilation.
+
+## Elementwise Pattern
+
+For simple unary or binary elementwise operators, prefer the shared `ntops.kernels.element_wise.arrangement` helper. The operator-specific file usually only needs:
+
+- imports,
+- an `application(input, output)` function,
+- a `premake(ndim, dtype=None, block_size=None)` function,
+- `Tensor` descriptors for inputs and outputs.
+
+## Wrapper Pattern
+
+Torch wrappers usually:
+
+- allocate `output = torch.empty_like(input)` or a shape-specific tensor,
+- build a cached kernel with `_cached_make(...)`,
+- invoke `kernel(input, output, ...)`,
+- return the output tensor.
+
+## Risk Points
+
+- Broadcasting semantics must match PyTorch.
+- Non-contiguous tensors require explicit stride/layout attention.
+- Float16 comparisons need looser tolerances than float32.
+- Some generated kernels require CUDA even when Python import succeeds.
+- Approximation modes, such as GELU `approximate="tanh"`, should be documented if incomplete.
+- Treat `expand` on inputs and outputs differently. An expanded input is a read-only broadcast view that still needs stride verification; writing distinct reduction results through a zero-stride expanded output aliases addresses and can break pointer/mask lowering.
+- Minimize simultaneous symbolic transforms. Establish a working fixed-rank load/reduce/store first, then add `permute`, `unsqueeze`, `expand`, or dynamic tiling one at a time with a fresh CUDA check.
+- A generated-source cache hit is evidence only after linking it to the current operator invocation. Low/zero operator-match results from `--no-trigger` can be unrelated historical kernels.

--- a/skills/competition/ntops-dev/references/ntops_operator_workflow.md
+++ b/skills/competition/ntops-dev/references/ntops_operator_workflow.md
@@ -1,0 +1,52 @@
+# ntops Operator Workflow
+
+Use this reference when implementing or auditing an `ntops` operator.
+
+Source: derived from the checked-in `ntops` file layout, existing operators, exports, and tests. The workflow conventions are observations of this repository rather than new framework rules.
+
+## Repository Roles
+
+- `ninetoothed/`: NineToothed DSL and compiler implementation. Read for API behavior and generated-code concepts.
+- `ntops/`: operator library built on NineToothed. Most operator tasks should modify this repository only.
+
+## File Pattern
+
+A typical operator has four surfaces:
+
+- `src/ntops/kernels/<op>.py`: NineToothed arrangement/application/premake logic.
+- `src/ntops/torch/<op>.py`: PyTorch-like wrapper that allocates output and calls `_cached_make`.
+- `src/ntops/kernels/__init__.py`: kernel module import and `__all__` export.
+- `src/ntops/torch/__init__.py`: public torch wrapper import and `__all__` export.
+- `tests/test_<op>.py`: correctness test against PyTorch or a known reference.
+
+## Pattern Selection
+
+- Unary elementwise: start from `silu`, `tanh`, `relu`, or `gelu`.
+- Binary elementwise/broadcast: start from `add`, `sub`, `mul`, or `div`.
+- Matrix operators: start from `mm`, `bmm`, `addmm`, and `matmul`.
+- Reductions/pooling: start from `softmax`, `max_pool2d`, `avg_pool2d`, or `rms_norm`.
+
+“Start from” means inspect the live kernel, wrapper, and tests for repository conventions. It does not mean copy the nearest operator's arrangement. For a new reduction, compare a wrapper-normalized fixed-rank design with a direct arbitrary-rank arrangement. Prefer the smaller mapping when it satisfies the contract and verify copying/stride consequences explicitly.
+
+Do not use an expanded zero-stride output view as a scatter target for multiple logical outputs. Keep the output descriptor aligned with the physical output and make the program-to-output mapping explicit.
+
+## Test Expectations
+
+- Use CUDA skip guards for GPU-only kernels.
+- Cover float16 and float32 unless the operator contract excludes one.
+- Include representative random shapes and boundary-sensitive cases.
+- Compare against PyTorch with tolerances appropriate for dtype.
+- Record the exact command and result in the self-test log.
+- Before the parameterized suite, run fresh-process smoke cases for each structurally distinct path, especially full reduction, non-last-dimension reduction, and non-contiguous/offset input. A passing case in a warm process does not prove the final cached kernel works for other shapes or branches.
+
+## Self-Test Record Format
+
+Each self-test should include:
+
+- Input task description.
+- Files inspected by the agent.
+- Files created or changed.
+- Correctness command and result.
+- Benchmark command and result, or CUDA-pending status.
+- Failure diagnosis if anything fails.
+- Known unsupported cases.

--- a/skills/competition/ntops-dev/references/validation_and_benchmark.md
+++ b/skills/competition/ntops-dev/references/validation_and_benchmark.md
@@ -1,0 +1,115 @@
+# Validation and Benchmark Evidence
+
+Use this reference when recording correctness, benchmark, or diagnosis output.
+
+Source: commands follow the checked-in `ntops` pytest layout and the bundled benchmark scripts. Recorded numbers must come from actual command output; this document does not define official competition thresholds.
+
+## Correctness
+
+Run the narrowest relevant pytest first:
+
+```bash
+cd ntops
+python3 -m pytest tests/test_<op>.py -q
+```
+
+Record:
+
+- command,
+- environment if known,
+- pass/fail status,
+- failing shape/dtype/device if any,
+- tolerance policy,
+- fix and rerun result.
+
+## Benchmark
+
+Benchmark requires a single CUDA GPU for meaningful `ntops` operator evidence.
+
+Record:
+
+- GPU model,
+- CUDA, PyTorch, Triton, and Python versions,
+- input shapes,
+- dtype,
+- baseline implementation,
+- warmup count,
+- measured iterations,
+- latency or throughput,
+- conclusion.
+
+Minimum benchmark shape:
+
+```text
+operator=<op>
+baseline=torch reference or existing implementation
+device=cuda:0
+dtype=float16 and/or float32
+warmup>=10
+iters>=50
+```
+
+## Generated Source Inspection
+
+When benchmark shows a material gap, run:
+
+```bash
+cd <submission-root>
+python3 skills/competition/ntops-dev/scripts/inspect_generated_source.py \
+  softmax --shape 1024,1024 --dtype float16
+```
+
+For an operator that the tool cannot trigger generically, compile it with the task's
+real inputs first, then inspect the exact emitted file or the latest isolated cache:
+
+```bash
+python3 skills/competition/ntops-dev/scripts/inspect_generated_source.py \
+  <op> --source "$HOME/.ninetoothed/<generated>.py"
+python3 skills/competition/ntops-dev/scripts/inspect_generated_source.py \
+  <op> --no-trigger --latest 3
+```
+
+Then record:
+
+- generated source path,
+- line count and file size,
+- `tl.*` or `triton.language.*` operation counts, especially load, store, dot, exp, erf, where, arange, sum, and max,
+- notable `float32`/`float16` casts,
+- whether autotune or heuristics appear,
+- likely bottleneck and next experiment.
+
+Treat this as a diagnosis aid, not final proof. A performance claim still needs a follow-up benchmark.
+
+## Promotion Protocol
+
+For an optimization candidate, keep one immutable baseline and change one factor at a
+time. Use identical inputs, explicit fixed block/tile configuration,
+`max_num_configs=1`, warmup, iterations, and measurement method. Run at least three
+rounds in interleaved baseline/candidate order and compare medians. Reject and revert
+the candidate when correctness fails, measured improvement is below 5%, or the result
+is unstable. Preserve the rejected result as diagnostic evidence rather than presenting
+it as an optimization success.
+
+## Pending CUDA Evidence
+
+If local CUDA is unavailable, do not invent results. Record:
+
+- exact command to run on the remote RTX 4090 D/CUDA environment,
+- expected output artifact,
+- current status: `pending CUDA run`.
+
+## Failure Diagnosis
+
+Use this structure:
+
+```text
+Symptom:
+Command:
+Input shape/dtype/device:
+Observed:
+Expected:
+Likely root cause:
+Minimal fix:
+Verification:
+Remaining risk:
+```

--- a/skills/competition/ntops-dev/scripts/benchmark_protocol.py
+++ b/skills/competition/ntops-dev/scripts/benchmark_protocol.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Reusable fixed-protocol CUDA benchmark helpers for ntops candidates."""
+
+import argparse
+import json
+import statistics
+
+
+def _measure_ms(torch, fn, iterations):
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iterations):
+        fn()
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end) / iterations
+
+
+def benchmark_pair(torch, baseline, candidate, *, warmup=20, iterations=200, rounds=3):
+    """Measure equivalent callables in alternating order and return raw/median data."""
+    if warmup < 0 or iterations < 1 or rounds < 3:
+        raise ValueError("Require warmup >= 0, iterations >= 1, and rounds >= 3")
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for this benchmark protocol")
+
+    for _ in range(warmup):
+        baseline()
+        candidate()
+    torch.cuda.synchronize()
+
+    rows = []
+    for round_index in range(rounds):
+        order = ("baseline", "candidate") if round_index % 2 == 0 else (
+            "candidate",
+            "baseline",
+        )
+        measured = {}
+        for name in order:
+            fn = baseline if name == "baseline" else candidate
+            measured[name] = _measure_ms(torch, fn, iterations)
+        rows.append(
+            {
+                "round": round_index + 1,
+                "order": list(order),
+                "baseline_ms": measured["baseline"],
+                "candidate_ms": measured["candidate"],
+            }
+        )
+
+    baseline_median = statistics.median(row["baseline_ms"] for row in rows)
+    candidate_median = statistics.median(row["candidate_ms"] for row in rows)
+    improvement = (baseline_median - candidate_median) / baseline_median
+    return {
+        "warmup": warmup,
+        "iterations": iterations,
+        "rounds": rows,
+        "baseline_median_ms": baseline_median,
+        "candidate_median_ms": candidate_median,
+        "improvement_fraction": improvement,
+    }
+
+
+def promotion_decision(result, *, minimum_improvement=0.05, correctness=True):
+    """Return a conservative keep/revert decision for one benchmark result."""
+    if not correctness:
+        return {"promote": False, "reason": "correctness failed"}
+    improvement = result["improvement_fraction"]
+    if improvement < minimum_improvement:
+        return {
+            "promote": False,
+            "reason": (
+                f"improvement {improvement:.2%} is below "
+                f"the {minimum_improvement:.2%} threshold"
+            ),
+        }
+    return {
+        "promote": True,
+        "reason": f"improvement {improvement:.2%} meets the threshold",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Provide importable CUDA-event benchmark_pair() and promotion_decision() "
+            "helpers. Run --self-test to validate decision logic without CUDA."
+        )
+    )
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if not args.self_test:
+        parser.print_help()
+        return 0
+
+    result = {
+        "baseline_median_ms": 1.0,
+        "candidate_median_ms": 0.94,
+        "improvement_fraction": 0.06,
+    }
+    decision = promotion_decision(result)
+    assert decision["promote"] is True
+    assert promotion_decision(result, correctness=False)["promote"] is False
+    print(json.dumps({"result": result, "decision": decision}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/competition/ntops-dev/scripts/inspect_generated_source.py
+++ b/skills/competition/ntops-dev/scripts/inspect_generated_source.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import re
+from pathlib import Path
+
+
+CACHE_DIR = Path(os.environ.get("NINETOOTHED_CACHE_DIR", Path.home() / ".ninetoothed"))
+
+
+def _latest_sources():
+    if not CACHE_DIR.exists():
+        return []
+    candidates = [
+        path
+        for path in CACHE_DIR.rglob("*.py")
+        if path.is_file() and "__pycache__" not in path.parts
+    ]
+    return sorted(candidates, key=lambda path: path.stat().st_mtime, reverse=True)
+
+
+def _trigger_compile(operator, dtype_name, shape):
+    import torch
+
+    import ntops
+
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA is required to generate and inspect ntops source.")
+
+    dtype = getattr(torch, dtype_name)
+
+    if operator == "gelu":
+        x = torch.randn(shape, device="cuda", dtype=dtype)
+        ntops.torch.gelu(x)
+    elif operator == "softmax":
+        x = torch.randn(shape, device="cuda", dtype=dtype)
+        ntops.torch.softmax(x, dim=-1)
+    elif operator == "addmm":
+        if len(shape) != 3:
+            raise SystemExit("addmm shape must be m,n,k, for example 512,512,512")
+        m, n, k = shape
+        input_tensor = torch.randn((m, n), device="cuda", dtype=dtype)
+        mat1 = torch.randn((m, k), device="cuda", dtype=dtype)
+        mat2 = torch.randn((k, n), device="cuda", dtype=dtype)
+        ntops.torch.addmm(input_tensor, mat1, mat2)
+    else:
+        raise SystemExit(f"Unsupported operator: {operator}")
+
+    torch.cuda.synchronize()
+
+
+def _count(pattern, text):
+    return len(re.findall(pattern, text))
+
+
+def _summarize(path):
+    text = path.read_text(encoding="utf-8", errors="replace")
+    lines = text.splitlines()
+    lang = r"(?:tl|triton\.language)"
+    summary = {
+        "path": str(path),
+        "lines": len(lines),
+        "bytes": path.stat().st_size,
+        "language_load": _count(rf"\b{lang}\.load\b", text),
+        "language_store": _count(rf"\b{lang}\.store\b", text),
+        "language_dot": _count(rf"\b{lang}\.dot\b", text),
+        "language_exp": _count(rf"\b{lang}\.exp\b", text),
+        "language_erf": _count(rf"\b{lang}\.erf\b", text),
+        "language_where": _count(rf"\b{lang}\.where\b", text),
+        "language_arange": _count(rf"\b{lang}\.arange\b", text),
+        "language_sum": _count(rf"\b{lang}\.sum\b", text),
+        "language_max": _count(rf"\b{lang}\.max\b", text),
+        "float32": _count(r"\bfloat32\b", text),
+        "float16": _count(r"\bfloat16\b", text),
+        "autotune": "triton.autotune" in text,
+        "heuristics": "triton.heuristics" in text,
+    }
+    block_names = sorted(set(re.findall(r"\b[A-Z][A-Z0-9_]*BLOCK[A-Z0-9_]*\b", text)))
+    constexpr_names = sorted(set(re.findall(r"\b[A-Z][A-Z0-9_]*\b", text)))
+    summary["block_names"] = ", ".join(block_names[:20]) if block_names else "(none)"
+    summary["constexpr_sample"] = ", ".join(constexpr_names[:20])
+    return summary
+
+
+def _operator_score(operator, summary):
+    if operator == "softmax":
+        return (
+            summary["language_exp"] * 4
+            + summary["language_sum"] * 3
+            + summary["language_max"] * 3
+            - summary["language_dot"] * 5
+        )
+    if operator == "addmm":
+        return summary["language_dot"] * 5 + summary["language_load"]
+    if operator == "gelu":
+        return summary["language_erf"] * 5 + summary["language_exp"] * 2
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Summarize NineToothed generated source. Known operators can be triggered; "
+            "any operator can be inspected with --source or --no-trigger."
+        )
+    )
+    parser.add_argument("operator", help="Operator label used for reporting/scoring.")
+    parser.add_argument("--shape", default=None)
+    parser.add_argument("--dtype", default="float16", choices=["float16", "float32"])
+    parser.add_argument("--latest", type=int, default=3)
+    parser.add_argument(
+        "--source",
+        type=Path,
+        help="Inspect one generated .py file directly without triggering compilation.",
+    )
+    parser.add_argument(
+        "--no-trigger",
+        action="store_true",
+        help="Inspect latest cache files without invoking the operator.",
+    )
+    args = parser.parse_args()
+
+    default_shapes = {
+        "gelu": (1048576,),
+        "softmax": (1024, 1024),
+        "addmm": (512, 512, 512),
+    }
+    shape = (
+        tuple(int(part) for part in args.shape.split(",") if part)
+        if args.shape
+        else default_shapes.get(args.operator)
+    )
+
+    if args.source:
+        source = args.source.expanduser().resolve()
+        if not source.is_file():
+            raise SystemExit(f"Generated source not found: {source}")
+        candidates = [source]
+    elif args.no_trigger:
+        candidates = _latest_sources()[: max(args.latest, 10)]
+    else:
+        if args.operator not in default_shapes:
+            raise SystemExit(
+                f"Cannot trigger {args.operator!r}; use --source PATH or --no-trigger."
+            )
+        before = {path: path.stat().st_mtime for path in _latest_sources()}
+        _trigger_compile(args.operator, args.dtype, shape)
+        after = _latest_sources()
+        changed = [
+            path
+            for path in after
+            if path not in before or path.stat().st_mtime != before[path]
+        ]
+        candidates = changed if changed else after[: max(args.latest, 10)]
+    summarized = [(_operator_score(args.operator, _summarize(path)), path) for path in candidates]
+    summarized.sort(key=lambda item: item[0], reverse=True)
+    selected = [path for _, path in summarized[: args.latest]]
+
+    print(f"operator={args.operator}")
+    print(f"shape={shape if shape is not None else '(not triggered)'}")
+    print(f"dtype={args.dtype}")
+    print(f"cache_dir={CACHE_DIR}")
+    print(f"generated_files_considered={len(selected)}")
+
+    for index, path in enumerate(selected, start=1):
+        summary = _summarize(path)
+        print(f"\n[source {index}]")
+        print(f"operator_match_score={_operator_score(args.operator, summary)}")
+        for key, value in summary.items():
+            print(f"{key}={value}")
+
+    if not selected:
+        print("No generated source files found.")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/competition/ntops-dev/scripts/run_correctness_test.py
+++ b/skills/competition/ntops-dev/scripts/run_correctness_test.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run a narrow ntops correctness test.")
+    parser.add_argument("--repo", default="ntops", help="Path to the ntops repository.")
+    parser.add_argument("--test", default="tests/test_gelu.py", help="Pytest target.")
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    if not repo.is_dir():
+        raise SystemExit(f"ntops repository not found: {repo}")
+
+    command = [sys.executable, "-m", "pytest", args.test, "-q"]
+    print(f"Running in {repo}: {' '.join(command)}")
+    return subprocess.call(command, cwd=repo)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/competition/ntops-dev/scripts/run_coverage_checks.py
+++ b/skills/competition/ntops-dev/scripts/run_coverage_checks.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+import argparse
+import time
+
+
+def _require_cuda(torch):
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA is required for ntops coverage checks.")
+
+
+def _check_addmm():
+    import torch
+
+    import ntops
+
+    _require_cuda(torch)
+    torch.manual_seed(20260607)
+    m, n, k = 64, 48, 80
+    cases = []
+
+    input_contig = torch.randn((m, n), device="cuda", dtype=torch.float16)
+    mat1_contig = torch.randn((m, k), device="cuda", dtype=torch.float16)
+    mat2_contig = torch.randn((k, n), device="cuda", dtype=torch.float16)
+    cases.append(("contiguous", input_contig, mat1_contig, mat2_contig))
+
+    input_nc = torch.randn((n, m), device="cuda", dtype=torch.float16).t()
+    mat1_nc = torch.randn((k, m), device="cuda", dtype=torch.float16).t()
+    mat2_nc = torch.randn((n, k), device="cuda", dtype=torch.float16).t()
+    cases.append(("all_non_contiguous_transpose", input_nc, mat1_nc, mat2_nc))
+
+    print("[addmm_non_contiguous]")
+    for name, input_tensor, mat1, mat2 in cases:
+        output = ntops.torch.addmm(input_tensor, mat1, mat2, beta=0.75, alpha=1.25)
+        reference = torch.addmm(input_tensor, mat1, mat2, beta=0.75, alpha=1.25)
+        torch.cuda.synchronize()
+        max_abs = (output - reference).abs().max().item()
+        ok = torch.allclose(output, reference, rtol=1e-2, atol=1e-2)
+        print(
+            f"{name} ok={ok} "
+            f"input_contig={input_tensor.is_contiguous()} "
+            f"mat1_contig={mat1.is_contiguous()} "
+            f"mat2_contig={mat2.is_contiguous()} "
+            f"input_stride={tuple(input_tensor.stride())} "
+            f"mat1_stride={tuple(mat1.stride())} "
+            f"mat2_stride={tuple(mat2.stride())} "
+            f"max_abs={max_abs}"
+        )
+
+
+def _check_softmax():
+    import torch
+    import torch.nn.functional as F
+
+    import ntops
+
+    _require_cuda(torch)
+    torch.manual_seed(20260607)
+    cases = [
+        ("single_last_dim_fp16", (7, 1), torch.float16, -1),
+        ("wide_fp16", (2, 1024), torch.float16, -1),
+        ("middle_dim_fp32", (3, 5, 7), torch.float32, 1),
+        ("large_values_fp32", (4, 33), torch.float32, -1),
+    ]
+
+    print("[softmax_boundary]")
+    for name, shape, dtype, dim in cases:
+        if name == "large_values_fp32":
+            input_tensor = torch.randn(shape, device="cuda", dtype=dtype) * 40
+        else:
+            input_tensor = torch.randn(shape, device="cuda", dtype=dtype)
+
+        output = ntops.torch.softmax(input_tensor, dim=dim)
+        reference = F.softmax(input_tensor, dim=dim)
+        torch.cuda.synchronize()
+        max_abs = (output - reference).abs().max().item()
+        ok = torch.allclose(output, reference, rtol=1e-2, atol=1e-2)
+        print(
+            f"{name} ok={ok} shape={shape} dtype={dtype} dim={dim} max_abs={max_abs}"
+        )
+
+
+def _check_matmul():
+    import torch
+
+    import ntops
+
+    _require_cuda(torch)
+    seed = 0
+    shape_a = (1, 394, 724)
+    shape_b = (1, 724, 388)
+
+    print("[matmul_fixed_repro]")
+    print(f"seed={seed} shape_a={shape_a} shape_b={shape_b}")
+    torch.manual_seed(seed)
+    input_tensor = torch.randn(shape_a, dtype=torch.float16, device="cuda")
+    other = torch.randn(shape_b, dtype=torch.float16, device="cuda")
+
+    start = time.perf_counter()
+    output = ntops.torch.matmul(input_tensor, other)
+    reference = torch.matmul(input_tensor, other)
+    torch.cuda.synchronize()
+    elapsed = time.perf_counter() - start
+
+    diff = (output - reference).abs()
+    max_abs = diff.max().item()
+    max_ref = reference.abs().max().item()
+    max_rel = (diff / reference.abs().clamp_min(1e-6)).max().item()
+    ok = torch.allclose(output, reference, rtol=1e-2, atol=1e-2)
+    print(
+        f"ok={ok} elapsed_s={elapsed:.4f} max_abs={max_abs} "
+        f"max_rel={max_rel} max_ref={max_ref}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run ntops self-test coverage checks.")
+    parser.add_argument("target", choices=["addmm", "softmax", "matmul"])
+    args = parser.parse_args()
+
+    if args.target == "addmm":
+        _check_addmm()
+    elif args.target == "softmax":
+        _check_softmax()
+    else:
+        _check_matmul()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/competition/ntops-dev/scripts/run_official_ntops_benchmark.py
+++ b/skills/competition/ntops-dev/scripts/run_official_ntops_benchmark.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+
+import argparse
+import time
+
+
+def _measure(torch, fn, warmup, iters):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    torch.cuda.synchronize()
+    return (time.perf_counter() - start) * 1000 / iters
+
+
+def _report(torch, name, shape, dtype, ntops_fn, torch_fn, warmup, iters):
+    ntops_ms = _measure(torch, ntops_fn, warmup, iters)
+    torch_ms = _measure(torch, torch_fn, warmup, iters)
+    print(
+        f"{name}\tshape={shape}\tdtype={dtype}\t"
+        f"ntops_ms={ntops_ms:.4f}\ttorch_ms={torch_ms:.4f}\t"
+        f"ratio={ntops_ms / torch_ms:.4f}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Benchmark selected official ntops operators against PyTorch."
+    )
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--iters", type=int, default=100)
+    args = parser.parse_args()
+
+    import torch
+    import torch.nn.functional as F
+
+    import ntops
+
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA is required for ntops benchmark.")
+
+    torch.manual_seed(20260607)
+    print(f"gpu={torch.cuda.get_device_name(0)}")
+    print(f"torch={torch.__version__} cuda={torch.version.cuda}")
+    print(f"warmup={args.warmup} iters={args.iters}")
+
+    for dtype in [torch.float16, torch.float32]:
+        x = torch.randn((1048576,), device="cuda", dtype=dtype)
+        y = torch.randn((1048576,), device="cuda", dtype=dtype)
+        _report(
+            torch,
+            "gelu",
+            (1048576,),
+            dtype,
+            lambda x=x: ntops.torch.gelu(x),
+            lambda x=x: F.gelu(x),
+            args.warmup,
+            args.iters,
+        )
+        _report(
+            torch,
+            "relu",
+            (1048576,),
+            dtype,
+            lambda x=x: ntops.torch.relu(x),
+            lambda x=x: torch.relu(x),
+            args.warmup,
+            args.iters,
+        )
+        _report(
+            torch,
+            "silu",
+            (1048576,),
+            dtype,
+            lambda x=x: ntops.torch.silu(x),
+            lambda x=x: F.silu(x),
+            args.warmup,
+            args.iters,
+        )
+        _report(
+            torch,
+            "add",
+            (1048576,),
+            dtype,
+            lambda x=x, y=y: ntops.torch.add(x, y),
+            lambda x=x, y=y: torch.add(x, y),
+            args.warmup,
+            args.iters,
+        )
+        _report(
+            torch,
+            "mul",
+            (1048576,),
+            dtype,
+            lambda x=x, y=y: ntops.torch.mul(x, y),
+            lambda x=x, y=y: torch.mul(x, y),
+            args.warmup,
+            args.iters,
+        )
+
+    x = torch.randn((1024, 1024), device="cuda", dtype=torch.float16)
+    _report(
+        torch,
+        "softmax",
+        (1024, 1024),
+        torch.float16,
+        lambda x=x: ntops.torch.softmax(x, dim=-1),
+        lambda x=x: F.softmax(x, dim=-1),
+        args.warmup,
+        args.iters,
+    )
+
+    m = n = k = 512
+    input_tensor = torch.randn((m, n), device="cuda", dtype=torch.float16)
+    mat1 = torch.randn((m, k), device="cuda", dtype=torch.float16)
+    mat2 = torch.randn((k, n), device="cuda", dtype=torch.float16)
+    _report(
+        torch,
+        "addmm",
+        (m, n, k),
+        torch.float16,
+        lambda: ntops.torch.addmm(input_tensor, mat1, mat2),
+        lambda: torch.addmm(input_tensor, mat1, mat2),
+        args.warmup,
+        args.iters,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/competition/ntops-dev/scripts/run_operator_benchmark.py
+++ b/skills/competition/ntops-dev/scripts/run_operator_benchmark.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+
+import argparse
+import time
+
+
+def _shape(value):
+    return tuple(int(part) for part in value.split(",") if part)
+
+
+def _measure(torch, fn, warmup, iters):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    torch.cuda.synchronize()
+    return (time.perf_counter() - start) / iters
+
+
+def _print_result(operator, shape, dtype, gpu, ntops_latency, torch_latency):
+    print(f"operator={operator}")
+    print(f"shape={shape}")
+    print(f"dtype={dtype}")
+    print(f"gpu={gpu}")
+    print(f"ntops_ms={ntops_latency * 1000:.4f}")
+    print(f"torch_ms={torch_latency * 1000:.4f}")
+    print(f"relative_to_torch={ntops_latency / torch_latency:.4f}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Benchmark selected ntops operators.")
+    parser.add_argument("operator", choices=["softmax", "addmm", "matmul", "maximum"])
+    parser.add_argument("--shape", default=None, help="Operator-specific comma shape.")
+    parser.add_argument("--dtype", default="float16", choices=["float16", "float32"])
+    parser.add_argument(
+        "--scalar-other",
+        action="store_true",
+        help="Use a zero-dimensional second input for maximum.",
+    )
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=50)
+    args = parser.parse_args()
+
+    import torch
+    import torch.nn.functional as F
+
+    import ntops
+
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA is required for this benchmark.")
+
+    dtype = getattr(torch, args.dtype)
+    gpu = torch.cuda.get_device_name(0)
+
+    if args.operator == "softmax":
+        shape = _shape(args.shape or "1024,1024")
+        x = torch.randn(shape, device="cuda", dtype=dtype)
+        dim = -1
+        ntops_latency = _measure(
+            torch, lambda: ntops.torch.softmax(x, dim=dim), args.warmup, args.iters
+        )
+        torch_latency = _measure(
+            torch, lambda: F.softmax(x, dim=dim), args.warmup, args.iters
+        )
+    elif args.operator == "addmm":
+        m, n, k = _shape(args.shape or "512,512,512")
+        input_tensor = torch.randn((m, n), device="cuda", dtype=dtype)
+        mat1 = torch.randn((m, k), device="cuda", dtype=dtype)
+        mat2 = torch.randn((k, n), device="cuda", dtype=dtype)
+        ntops_latency = _measure(
+            torch,
+            lambda: ntops.torch.addmm(input_tensor, mat1, mat2),
+            args.warmup,
+            args.iters,
+        )
+        torch_latency = _measure(
+            torch,
+            lambda: torch.addmm(input_tensor, mat1, mat2),
+            args.warmup,
+            args.iters,
+        )
+        shape = (m, n, k)
+    elif args.operator == "matmul":
+        m, n, k = _shape(args.shape or "512,512,512")
+        mat1 = torch.randn((m, k), device="cuda", dtype=dtype)
+        mat2 = torch.randn((k, n), device="cuda", dtype=dtype)
+        ntops_latency = _measure(
+            torch, lambda: ntops.torch.matmul(mat1, mat2), args.warmup, args.iters
+        )
+        torch_latency = _measure(
+            torch, lambda: torch.matmul(mat1, mat2), args.warmup, args.iters
+        )
+        shape = (m, n, k)
+    else:
+        shape = _shape(args.shape or "1048576")
+        input_tensor = torch.randn(shape, device="cuda", dtype=dtype)
+        other_shape = () if args.scalar_other else shape
+        other = torch.randn(other_shape, device="cuda", dtype=dtype)
+        ntops_latency = _measure(
+            torch,
+            lambda: ntops.torch.maximum(input_tensor, other),
+            args.warmup,
+            args.iters,
+        )
+        torch_latency = _measure(
+            torch,
+            lambda: torch.maximum(input_tensor, other),
+            args.warmup,
+            args.iters,
+        )
+
+    _print_result(args.operator, shape, args.dtype, gpu, ntops_latency, torch_latency)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
`pytest` output:

```text
$ python3 -m pytest -q --tb=short
203 passed, 16 failed in 1549.32s (0:25:49)

15 项既有 AOT 测试因 nvcc 未加入 PATH 失败；另 1 项既有 notebook
测试中的 Jupyter 子进程没有继承 editable NineToothed 的导入路径。

本 PR 只新增 skills/competition/ntops-dev/，未修改 src/、编译器核心或
既有测试。全仓 ruff format、ruff check 和 contributing-style 检查通过。
完整测试结果以上游 CI 为准。
```

## 1. 提交信息

- Skill：`ntops-dev`
- 赛题：T3-1-1 NineToothed 算子开发 Skill

本 PR 共新增 24 个文件，全部位于上述目录，包括 `SKILL.md`、5 份离线参考资料、6 个工具脚本和 5 组案例目录。

## 2. 目标与适用范围

`ntops-dev` 用于指导 Agent 完成 NineToothed/ntops 算子的需求分析、kernel/wrapper/导出开发、correctness 测试、generated source 检查、AOT 构建和 fixed-config benchmark。它覆盖 broadcast、reduction、non-contiguous、stride/offset 和性能回退诊断，并要求 Agent 记录失败、最小修复和复测结果。

当前不覆盖通用 PyTorch/Triton/CUDA 开发、NineToothed 编译器核心修改、动态 shape、任意 `as_strided` 布局或未验证 dtype。

## 3. 安装与使用

将 `skills/competition/ntops-dev/` 复制到评测 Agent 的 Skill 目录，或在 NineToothed/ntops 算子任务开始前让 Agent 读取 `SKILL.md`。说明、references、scripts 和 examples 均可离线使用，运行时不需要私有账号或联网服务。

## 4. 自测与性能材料

| 类型 | 任务 | 运行结果与结论 |
| --- | --- | --- |
| 逐元素/广播 | maximum | 修复 0 维 `other` 路径，聚焦及相邻回归 `32 passed in 26.48s` |
| 归约/分块 | softmax | 数值稳定性、非末维和 generated source 检查通过，`8 passed in 11.58s` |
| 布局敏感 | addmm | non-contiguous/stride/offset 用例 `2 passed in 10.46s`，最大误差为 0 |
| 性能/诊断 | matmul/SDPA | matmul 得到 `1 failed, 7 passed`，SDPA 受当时 PyTorch API 限制；保留复现、根因边界和规避建议 |

fixed-config benchmark 在同一张 GPU 上固定 shape、dtype、warmup、iterations 和 `max_num_configs=1`，基线与候选交错运行三轮并取 median：

| 算子 | 输入 | PyTorch median | ntops median | ntops / PyTorch |
| --- | --- | ---: | ---: | ---: |
| softmax | 1024×1024, float16 | 0.007281 ms | 0.020014 ms | 2.749× |
| addmm | 512×512×512, float16 | 0.015729 ms | 0.031252 ms | 1.987× |

两项正式 benchmark 均慢于 PyTorch，因此只作为性能回退与诊断材料，不声称优化成功。softmax 任务同时定位并修复了动态 block meta 与单配置 launcher 不匹配的功能问题。

AOT 跨进程实验进行了两次独立复现，Agent 自测均为 AOT 2 passed 加 abs 回归 8 passed，参赛者自建外部测试分别得到 6/7 和 7/7。第二次首次 build/load/run 约 42.70 秒，缓存存在时新进程首次调用约 0.25 毫秒。

完整命令、运行记录、失败边界和补丁摘要见 `examples/` 与最终赛题报告。

## 5. 有无 Skill 对比

下表只统计同一冻结版 `SKILL.md`（SHA-256：`575dd28d4c240f0530262c1a924b0fa063b4c693d9f7cafbbfac1990f4fd34b1`）的三项同期 A/B：

| 任务 | 无 Skill | 有 Skill | 结果 |
| --- | ---: | ---: | --- |
| amax | 3/10；3 passed、39 failed | 10/10；42 passed | 有 Skill 组完成任务 |
| sign | 10/10 | 10/10 | correctness 持平 |
| softmax fixed-config | 10/10 | 10/10 | correctness 持平 |

三项合计为无 Skill 23/30、有 Skill 30/30，完整完成任务数为 2/3 和 3/3。7 分差异全部来自 amax，且无 Skill 组同时发生了编辑失败和提前退出。这组数据说明 Skill 在该项自建任务中起到了作用，不足以证明总体成功率已稳定提高。

早期 Skill 哈希和 B-only 实验不混入这组同期 A/B 合计。controller 均为参赛者自建外部测试，不是官方隐藏评测。最终泛化效果仍以赛题组 8 项隐藏任务为准。

## 6. 安全、引用与生成式 AI 披露

Skill 不包含密钥、私有账号、联网强依赖、隐藏评测答案或规避评测逻辑；不引导 Agent 删除测试、伪造结果或调用同名 PyTorch API 冒充 NineToothed kernel。

参赛者创建了初版 Skill，整理赛题和九齿资料，设计实验，并亲自启动和执行各组 Agent 会话及实验命令。Codex 参与后续 Skill 修改、工具编辑、证据核对、脱敏和报告排版。A/B 与 B-only 中的独立 Agent 负责编写算子代码和测试，这正是本赛题要评估的工作方式。

[加班仙人球_九齿skill创新挑战_T3-1-1_赛题报告.pdf](https://github.com/user-attachments/files/29944392/_.skill._T3-1-1_.pdf)
[REFERENCE.md](https://github.com/user-attachments/files/29944415/REFERENCE.md)
[HONOR_CODE.md](https://github.com/user-attachments/files/29944451/HONOR_CODE.md)
[加班仙人球_九齿skill创新挑战_proposal.pdf](https://github.com/user-attachments/files/29944464/_.skill._proposal.pdf)
