### PR TITLE
Add [2026春季][T1-2-1] CearX

### DIFF
--- a/scripts/benchmark_full_tile.py
+++ b/scripts/benchmark_full_tile.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import statistics
+from pathlib import Path
+
+import torch
+
+from ninetoothed.aot import _load_launch_func
+
+
+def _make_case(case_id, size, dtype):
+    if case_id == "hit_small":
+        size = 256
+        input = torch.randn(size, device="cuda", dtype=dtype)
+        other = torch.randn_like(input)
+        output = torch.empty_like(input)
+        specialization_hit = True
+    elif case_id == "hit_large":
+        input = torch.randn(size, device="cuda", dtype=dtype)
+        other = torch.randn_like(input)
+        output = torch.empty_like(input)
+        specialization_hit = True
+    elif case_id == "fallback_nondivisible":
+        size += 1
+        input = torch.randn(size, device="cuda", dtype=dtype)
+        other = torch.randn_like(input)
+        output = torch.empty_like(input)
+        specialization_hit = False
+    elif case_id == "fallback_noncontiguous":
+        input = torch.randn(size * 2, device="cuda", dtype=dtype)[::2]
+        other = torch.randn(size, device="cuda", dtype=dtype)
+        output = torch.empty_like(other)
+        specialization_hit = False
+    else:
+        raise ValueError(f"Unknown case: {case_id}.")
+
+    return (input, other, output), specialization_hit
+
+
+def _measure(kernel, values, warmup, iterations):
+    for _ in range(warmup):
+        kernel(*values)
+
+    torch.cuda.synchronize()
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+
+    for _ in range(iterations):
+        kernel(*values)
+
+    end.record()
+    end.synchronize()
+
+    return start.elapsed_time(end) / iterations
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--baseline-dir", type=Path, required=True)
+    parser.add_argument("--submitted-dir", type=Path, required=True)
+    parser.add_argument("--comparison-id", default="baseline_vs_submitted")
+    parser.add_argument("--baseline-label", default="baseline")
+    parser.add_argument("--submitted-label", default="submitted")
+    parser.add_argument(
+        "--full-tile-variant",
+        choices=("baseline", "submitted", "both", "neither"),
+        default="submitted",
+    )
+    parser.add_argument("--kernel-name", required=True)
+    parser.add_argument("--dtype", default="float16")
+    parser.add_argument("--size", type=int, default=1 << 20)
+    parser.add_argument("--warmup", type=int, default=100)
+    parser.add_argument("--iterations", type=int, default=10000)
+    parser.add_argument("--rounds", type=int, default=9)
+    parser.add_argument("--json-out", type=Path, required=True)
+    args = parser.parse_args()
+
+    kernels = {
+        "baseline": _load_launch_func(args.kernel_name, args.baseline_dir),
+        "submitted": _load_launch_func(args.kernel_name, args.submitted_dir),
+    }
+    dtype = getattr(torch, args.dtype)
+    torch.manual_seed(20260712)
+    results = []
+
+    for case_id in (
+        "hit_small",
+        "hit_large",
+        "fallback_nondivisible",
+        "fallback_noncontiguous",
+    ):
+        values, specialization_hit = _make_case(case_id, args.size, dtype)
+        timings = {"baseline": [], "submitted": []}
+        measurement_order = []
+
+        for round_id in range(1, args.rounds + 1):
+            order = (
+                ("baseline", "submitted") if round_id % 2 else ("submitted", "baseline")
+            )
+            measurement_order.append(list(order))
+
+            for variant in order:
+                timings[variant].append(
+                    _measure(kernels[variant], values, args.warmup, args.iterations)
+                )
+                torch.testing.assert_close(values[2], values[0] + values[1])
+
+        baseline_runtime = statistics.median(timings["baseline"])
+        submitted_runtime = statistics.median(timings["submitted"])
+        results.append(
+            {
+                "comparison_id": args.comparison_id,
+                "baseline_label": args.baseline_label,
+                "submitted_label": args.submitted_label,
+                "full_tile_variant": args.full_tile_variant,
+                "case_id": case_id,
+                "dtype": args.dtype,
+                "numel": values[0].numel(),
+                "baseline_runtime_ms": baseline_runtime,
+                "submitted_runtime_ms": submitted_runtime,
+                "speedup": baseline_runtime / submitted_runtime,
+                "specialization_hit": specialization_hit,
+                "workload_expected_to_hit_full_tile": specialization_hit,
+                "correctness_passed": True,
+                "warmup": args.warmup,
+                "rounds": args.rounds,
+                "iterations": args.iterations,
+                "measurement_order": measurement_order,
+                "baseline_round_runtime_ms": timings["baseline"],
+                "submitted_round_runtime_ms": timings["submitted"],
+            }
+        )
+
+    args.json_out.parent.mkdir(parents=True, exist_ok=True)
+    args.json_out.write_text(json.dumps(results, indent=2) + "\n")
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/measure_full_tile_generated.py
+++ b/scripts/measure_full_tile_generated.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Measure masks, SASS instructions, registers, and cubin payload size."""
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def sha256(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def mask_count(path):
+    return len(re.findall(r"\bmask\s*=", path.read_text(encoding="utf-8")))
+
+
+def run_tool(command):
+    return subprocess.run(
+        command,
+        check=True,
+        encoding="utf-8",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    ).stdout
+
+
+def cubin_metrics(path, nvdisasm, cuobjdump):
+    sass = run_tool([nvdisasm, "--print-code", str(path)])
+    resource_usage = run_tool([cuobjdump, "--dump-resource-usage", str(path)])
+    instructions = sum(
+        re.match(r"^\s*/\*[0-9a-fA-F]+\*/", line) is not None
+        for line in sass.splitlines()
+    )
+    register_match = re.search(r"\bREG:([0-9]+)\b", resource_usage)
+
+    if register_match is None:
+        raise RuntimeError(f"Cannot find register usage in {path}.")
+
+    return {
+        "sass_instruction_count": instructions,
+        "register_count": int(register_match.group(1)),
+        "cubin_payload_bytes": path.stat().st_size,
+        "cubin_sha256": sha256(path),
+        "sass": sass,
+        "resource_usage": resource_usage,
+    }
+
+
+def reduction(baseline, submitted):
+    return (baseline - submitted) / baseline
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--case",
+        action="append",
+        nargs=5,
+        metavar=(
+            "CASE_ID",
+            "BASELINE_SOURCE",
+            "SUBMITTED_SOURCE",
+            "BASELINE_CUBIN",
+            "SUBMITTED_CUBIN",
+        ),
+        required=True,
+    )
+    parser.add_argument("--json-out", type=Path, required=True)
+    parser.add_argument("--derived-dir", type=Path)
+    parser.add_argument("--nvdisasm", default=shutil.which("nvdisasm"))
+    parser.add_argument("--cuobjdump", default=shutil.which("cuobjdump"))
+    args = parser.parse_args()
+
+    if not args.nvdisasm or not args.cuobjdump:
+        raise SystemExit("nvdisasm and cuobjdump must be available or specified")
+
+    rows = []
+
+    for (
+        case_id,
+        baseline_source,
+        submitted_source,
+        baseline_cubin,
+        submitted_cubin,
+    ) in args.case:
+        baseline_source = Path(baseline_source)
+        submitted_source = Path(submitted_source)
+        baseline_cubin = Path(baseline_cubin)
+        submitted_cubin = Path(submitted_cubin)
+
+        for path in (
+            baseline_source,
+            submitted_source,
+            baseline_cubin,
+            submitted_cubin,
+        ):
+            if not path.is_file():
+                raise FileNotFoundError(path)
+
+        baseline_metrics = cubin_metrics(baseline_cubin, args.nvdisasm, args.cuobjdump)
+        submitted_metrics = cubin_metrics(
+            submitted_cubin, args.nvdisasm, args.cuobjdump
+        )
+        baseline_masks = mask_count(baseline_source)
+        submitted_masks = mask_count(submitted_source)
+
+        row = {
+            "case_id": case_id,
+            "baseline_generated_source": str(baseline_source),
+            "submitted_generated_source": str(submitted_source),
+            "baseline_generated_source_sha256": sha256(baseline_source),
+            "submitted_generated_source_sha256": sha256(submitted_source),
+            "baseline_cubin": str(baseline_cubin),
+            "submitted_cubin": str(submitted_cubin),
+            "baseline_cubin_sha256": baseline_metrics["cubin_sha256"],
+            "submitted_cubin_sha256": submitted_metrics["cubin_sha256"],
+            "baseline_mask_arg_count": baseline_masks,
+            "submitted_mask_arg_count": submitted_masks,
+            "mask_arg_reduction": reduction(baseline_masks, submitted_masks),
+            "baseline_sass_instruction_count": baseline_metrics[
+                "sass_instruction_count"
+            ],
+            "submitted_sass_instruction_count": submitted_metrics[
+                "sass_instruction_count"
+            ],
+            "sass_instruction_reduction": reduction(
+                baseline_metrics["sass_instruction_count"],
+                submitted_metrics["sass_instruction_count"],
+            ),
+            "baseline_register_count": baseline_metrics["register_count"],
+            "submitted_register_count": submitted_metrics["register_count"],
+            "baseline_cubin_bytes": baseline_metrics["cubin_payload_bytes"],
+            "submitted_cubin_bytes": submitted_metrics["cubin_payload_bytes"],
+        }
+        rows.append(row)
+
+        if args.derived_dir is not None:
+            args.derived_dir.mkdir(parents=True, exist_ok=True)
+
+            for variant, metrics in (
+                ("baseline", baseline_metrics),
+                ("submitted", submitted_metrics),
+            ):
+                prefix = args.derived_dir / f"{case_id}.{variant}"
+                Path(f"{prefix}.sass.txt").write_text(metrics["sass"], encoding="utf-8")
+                Path(f"{prefix}.resource.txt").write_text(
+                    metrics["resource_usage"], encoding="utf-8"
+                )
+
+    args.json_out.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(rows, indent=2) + "\n"
+    args.json_out.write_text(payload, encoding="utf-8")
+    print(payload, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ninetoothed/aot.py
+++ b/src/ninetoothed/aot.py
@@ -10,7 +10,7 @@ import uuid
 
 import ninetoothed.dtype
 import ninetoothed.naming as naming
-from ninetoothed.generation import CACHE_DIR, CodeGenerator
+from ninetoothed.generation import CACHE_DIR, CodeGenerator, cache_source
 from ninetoothed.tensor import Tensor
 from ninetoothed.utils import calculate_default_configs
 
@@ -81,6 +81,27 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
     variant_specs = _enumerate_variant_specs(
         launch_arg_names, tensors, _find_tensor_by_source_name
     )
+    full_tile_spec = _full_tile_spec(kernel_func)
+
+    if not _is_safe_full_tile_spec(
+        full_tile_spec, launch_arg_names, tensors, _find_tensor_by_source_name
+    ):
+        full_tile_spec = ()
+
+    if full_tile_spec:
+        suffix, divisible, contiguous, size_type, stride_type, _ = variant_specs[0]
+        variant_specs.insert(
+            0,
+            (
+                f"{suffix}_full_tile",
+                divisible,
+                contiguous,
+                size_type,
+                stride_type,
+                full_tile_spec,
+            ),
+        )
+
     _, tensor_ndims, _ = _per_tensor_dim_options(
         launch_arg_names, tensors, _find_tensor_by_source_name
     )
@@ -93,6 +114,7 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
         contiguity_spec,
         size_type,
         stride_type,
+        full_tile_spec,
     ) in variant_specs:
         variant_outputs = _build_variant(
             source_file,
@@ -110,6 +132,7 @@ def _aot(func, caller, kernel_name, num_warps, num_stages):
             contiguity_spec=contiguity_spec,
             size_type=size_type,
             stride_type=stride_type,
+            full_tile_spec=full_tile_spec,
         )
         output_contents.update(variant_outputs)
 
@@ -157,6 +180,7 @@ def _generate_dispatcher(kernel_name, launch_arg_names, variant_specs, tensor_nd
         contiguity_spec,
         size_type,
         stride_type,
+        full_tile_spec,
     ) in variant_specs:
         variant_name = f"launch_{kernel_name}_{variant_suffix}"
         externs.append(
@@ -173,9 +197,7 @@ def _generate_dispatcher(kernel_name, launch_arg_names, variant_specs, tensor_nd
 
             continue
 
-        checks = tuple(
-            f"{name}.shape[{dim}] % 16 == 0" for name, dim in divisibility_spec
-        ) + tuple(f"{name}.strides[{dim}] == 1" for name, dim in contiguity_spec)
+        checks = _variant_checks(divisibility_spec, contiguity_spec, full_tile_spec)
 
         if checks:
             branches.append(f"{_INDENTATION}if ({' && '.join(checks)}) {call}")
@@ -205,6 +227,31 @@ def _generate_dispatcher(kernel_name, launch_arg_names, variant_specs, tensor_nd
     return source, header
 
 
+def _variant_checks(divisibility_spec, contiguity_spec, full_tile_spec):
+    full_tile_dims = {(name, dim): tile for name, dim, tile in full_tile_spec}
+    checks = tuple(
+        f"{name}.shape[{dim}] % 16 == 0"
+        for name, dim in divisibility_spec
+        if (name, dim) not in full_tile_dims or full_tile_dims[(name, dim)] % 16 != 0
+    ) + tuple(f"{name}.strides[{dim}] == 1" for name, dim in contiguity_spec)
+
+    for dim in sorted({dim for _, dim, _ in full_tile_spec}):
+        dim_specs = tuple(spec for spec in full_tile_spec if spec[1] == dim)
+        first_name, _, first_tile = dim_specs[0]
+        # Zero is mathematically divisible by every positive tile, but the
+        # generated CUDA launch expression uses C integer division.  For a
+        # zero-sized dimension that expression can still produce one program,
+        # so a mask-free variant must never accept an empty dimension.
+        checks += (f"{first_name}.shape[{dim}] > 0",)
+        checks += (f"{first_name}.shape[{dim}] % {first_tile} == 0",)
+        checks += tuple(
+            f"{name}.shape[{dim}] == {first_name}.shape[{dim}]"
+            for name, _, _ in dim_specs[1:]
+        )
+
+    return checks
+
+
 def _build_variant(
     source_file,
     kernel_func,
@@ -222,7 +269,11 @@ def _build_variant(
     contiguity_spec,
     size_type=ninetoothed.dtype.int32,
     stride_type=ninetoothed.dtype.int32,
+    full_tile_spec=(),
 ):
+    if full_tile_spec:
+        source_file = _make_full_tile_source(source_file, full_tile_spec)
+
     divisibility_set = {
         (naming.remove_prefixes(name), dim) for name, dim in divisibility_spec
     }
@@ -299,7 +350,11 @@ def _build_variant(
     pattern = rf"\({', '.join(rf'(.*) {param}' for param in param_strings)}\)"
     c_param_type_strings = re.search(pattern, c_header_file).groups()
 
+    # Variants can share a Triton signature while compiling different source
+    # (for example, masked and mask-free full-tile kernels).  Include the
+    # variant suffix to prevent C++ ODR collisions between their Kernel types.
     kernel_name_with_hash = f"{kernel_name}_{signature_hash}"
+    kernel_namespace = f"{kernel_name_with_hash}_{variant_suffix}"
 
     unparser = _Unparser(c_param_type_strings, constexpr_strides)
 
@@ -324,13 +379,13 @@ def _build_variant(
     kernel_end = len(c_source_file)
     cpp_source_file = (
         c_source_file[:kernel_start]
-        + f"namespace {kernel_name_with_hash} {{\n"
+        + f"namespace {kernel_namespace} {{\n"
         + "struct Kernel {\n"
         + textwrap.indent(c_source_file[kernel_start:kernel_end], _INDENTATION)
         + "};\n"
         + textwrap.indent(c_source_file[kernel_end:], _INDENTATION)
         + "}\n"
-        + f"\nstatic ninetoothed::ThreadSafeUnorderedMap<unsigned long long, {kernel_name_with_hash}::Kernel> kernels_{variant_suffix};\n"
+        + f"\nstatic ninetoothed::ThreadSafeUnorderedMap<unsigned long long, {kernel_namespace}::Kernel> kernels_{variant_suffix};\n"
         + f'\nextern "C" {launch_func_unparsed}\n'
     )
     cpp_source_file_name = f"{kernel_name}.{variant_suffix}.cpp"
@@ -386,6 +441,7 @@ def _enumerate_variant_specs(launch_arg_names, tensors, find_tensor):
                     contiguity_spec,
                     ninetoothed.dtype.int32,
                     ninetoothed.dtype.int32,
+                    (),
                 )
             )
 
@@ -393,7 +449,7 @@ def _enumerate_variant_specs(launch_arg_names, tensors, find_tensor):
         return sum(1 for name, dim in spec if innermost_dims.get(name) == dim)
 
     def _specificity(entry):
-        _, divisibility_spec, contiguity_spec, _, _ = entry
+        _, divisibility_spec, contiguity_spec, _, _, _ = entry
 
         return (
             -len(divisibility_spec),
@@ -419,10 +475,273 @@ def _enumerate_variant_specs(launch_arg_names, tensors, find_tensor):
             (),
             ninetoothed.dtype.int64,
             ninetoothed.dtype.int64,
+            (),
         )
     )
 
     return specs
+
+
+def _full_tile_spec(kernel_func):
+    """Find canonical tiled accesses whose tail checks can be specialized."""
+    specs = set()
+
+    for node in ast.walk(kernel_func):
+        if not (
+            isinstance(node, ast.Compare)
+            and len(node.ops) == 1
+            and isinstance(node.ops[0], ast.Lt)
+            and len(node.comparators) == 1
+            and isinstance(node.comparators[0], ast.Name)
+        ):
+            continue
+
+        match = Tensor.size_pattern().fullmatch(node.comparators[0].id)
+
+        if match is None:
+            continue
+
+        source_name = naming.remove_prefixes(match.group(1))
+        dim = int(match.group(3))
+        tile = _canonical_tile_size(node.left)
+
+        if tile is not None and tile > 1:
+            specs.add((source_name, dim, tile))
+
+    return tuple(sorted(specs))
+
+
+def _is_safe_full_tile_spec(full_tile_spec, launch_arg_names, tensors, find_tensor):
+    """Accept same-shaped tensors that are directly tiled in every dimension."""
+    tensor_ndims = {}
+
+    for name in launch_arg_names:
+        tensor = find_tensor(tensors, name)
+
+        if tensor is None or tensor.source.ndim == 0:
+            continue
+        # A direct ``tile`` creates exactly the source level and one tiled
+        # level.  Additional levels indicate expand/pad/slice-style layout
+        # transforms whose program bounds are not implied by source shapes.
+
+        if len(tensor._levels) != 2:
+            return False
+
+        tensor_ndims[naming.remove_prefixes(name)] = tensor.source.ndim
+
+    if not tensor_ndims or len(set(tensor_ndims.values())) != 1:
+        return False
+
+    ndim = next(iter(tensor_ndims.values()))
+
+    if len(full_tile_spec) != len(tensor_ndims) * ndim or {
+        name for name, _, _ in full_tile_spec
+    } != set(tensor_ndims):
+        return False
+
+    specs_by_name = {
+        name: {
+            dim: tile for spec_name, dim, tile in full_tile_spec if spec_name == name
+        }
+        for name in tensor_ndims
+    }
+
+    if any(set(specs) != set(range(ndim)) for specs in specs_by_name.values()):
+        return False
+
+    return (
+        len(
+            {
+                tuple(specs[dim] for dim in range(ndim))
+                for specs in specs_by_name.values()
+            }
+        )
+        == 1
+    )
+
+
+def _canonical_tile_size(node):
+    """Recognize ``program_index * TILE + arange(0, TILE)``."""
+    if not (isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add)):
+        return None
+
+    terms = (node.left, node.right)
+    multiply = None
+    lane = None
+    tile = None
+
+    for index, term in enumerate(terms):
+        if not (isinstance(term, ast.BinOp) and isinstance(term.op, ast.Mult)):
+            continue
+
+        for program_index, constant in (
+            (term.left, term.right),
+            (term.right, term.left),
+        ):
+            if not (
+                isinstance(program_index, ast.Name)
+                and re.fullmatch(r".*_index_\d+", program_index.id) is not None
+                and isinstance(constant, ast.Constant)
+                and isinstance(constant.value, int)
+                and not isinstance(constant.value, bool)
+            ):
+                continue
+
+            multiply = term
+            lane = terms[1 - index]
+            tile = constant.value
+            break
+
+        if multiply is not None:
+            break
+
+    if multiply is None:
+        return None
+
+    while isinstance(lane, ast.Subscript):
+        lane = lane.value
+
+    if not (
+        tile is not None
+        and isinstance(lane, ast.Call)
+        and isinstance(lane.func, ast.Attribute)
+        and lane.func.attr == "arange"
+        and len(lane.args) >= 2
+        and isinstance(lane.args[0], ast.Constant)
+        and lane.args[0].value == 0
+        and isinstance(lane.args[1], ast.Constant)
+        and lane.args[1].value == tile
+    ):
+        return None
+
+    return tile
+
+
+def _make_full_tile_source(source_file, full_tile_spec):
+    guarded = set(full_tile_spec)
+    guarded_dims = {(name, dim) for name, dim, _ in guarded}
+
+    canonical_sizes = {}
+
+    for name, dim, _ in full_tile_spec:
+        canonical_sizes.setdefault(dim, name)
+
+    tree = ast.parse(pathlib.Path(source_file).read_text())
+    canonical_size_names = {}
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Name):
+            continue
+
+        match = Tensor.size_pattern().fullmatch(node.id)
+
+        if match is None:
+            continue
+
+        dim = int(match.group(3))
+
+        if naming.remove_prefixes(match.group(1)) == canonical_sizes.get(dim):
+            canonical_size_names.setdefault(dim, node.id)
+
+    class _EqualShapePropagator(ast.NodeTransformer):
+        def visit_Name(self, node):
+            match = Tensor.size_pattern().fullmatch(node.id)
+
+            if match is None:
+                return node
+
+            name = naming.remove_prefixes(match.group(1))
+            dim = int(match.group(3))
+            canonical_name = canonical_sizes.get(dim)
+
+            if canonical_name is None or name == canonical_name:
+                return node
+
+            size_name = self._canonical_size_name(dim)
+
+            if size_name is not None:
+                return ast.copy_location(ast.Name(id=size_name, ctx=node.ctx), node)
+
+            return node
+
+        @staticmethod
+        def _canonical_size_name(dim):
+            return canonical_size_names.get(dim)
+
+    class _Simplifier(ast.NodeTransformer):
+        @staticmethod
+        def _proven_true_mask(node):
+            if isinstance(node, ast.Constant):
+                return node.value is True
+
+            if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitAnd):
+                return _Simplifier._proven_true_mask(
+                    node.left
+                ) and _Simplifier._proven_true_mask(node.right)
+            return False
+
+        def visit_Compare(self, node):
+            self.generic_visit(node)
+
+            if not (
+                len(node.ops) == 1
+                and isinstance(node.ops[0], ast.Lt)
+                and len(node.comparators) == 1
+            ):
+                return node
+
+            # Program indices are compiler-generated by unraveling
+            # ``program_id(0)``.  Under the same positive, divisible and
+            # equal-shape guards as the lane bounds, their outer-tile bounds
+            # are also true.  Replace only indices belonging to a guarded
+            # tensor/dimension; do not let the call-level mask cleanup accept
+            # arbitrary leftover comparisons.
+            if isinstance(node.left, ast.Name):
+                index_match = re.fullmatch(r"(.+)_index_(\d+)", node.left.id)
+
+                if index_match is not None:
+                    index_spec = (
+                        naming.remove_prefixes(index_match.group(1)),
+                        int(index_match.group(2)),
+                    )
+
+                    if index_spec in guarded_dims:
+                        return ast.copy_location(ast.Constant(True), node)
+
+            if not isinstance(node.comparators[0], ast.Name):
+                return node
+
+            match = Tensor.size_pattern().fullmatch(node.comparators[0].id)
+
+            if match is None:
+                return node
+
+            spec = (
+                naming.remove_prefixes(match.group(1)),
+                int(match.group(3)),
+                _canonical_tile_size(node.left),
+            )
+
+            if spec in guarded:
+                return ast.copy_location(ast.Constant(True), node)
+
+            return node
+
+        def visit_Call(self, node):
+            self.generic_visit(node)
+            node.keywords = [
+                keyword
+                for keyword in node.keywords
+                if not (keyword.arg == "mask" and self._proven_true_mask(keyword.value))
+            ]
+
+            return node
+
+    _EqualShapePropagator().visit(tree)
+    _Simplifier().visit(tree)
+    ast.fix_missing_locations(tree)
+
+    return str(cache_source(ast.unparse(tree) + "\n"))
 
 
 def _per_tensor_dim_options(launch_arg_names, tensors, find_tensor):
@@ -865,6 +1184,7 @@ def _load_launch_func(kernel_name, output_dir):
 def _compile_library(kernel_name, output_dir):
     command = [
         "nvcc",
+        "-O3",
         "-shared",
         "-arch",
         "native",

--- a/src/ninetoothed/tensor.py
+++ b/src/ninetoothed/tensor.py
@@ -1,3 +1,4 @@
+import ast
 import copy
 import functools
 import itertools
@@ -6,6 +7,48 @@ import re
 
 import ninetoothed.naming as naming
 from ninetoothed.symbol import Symbol
+
+
+def _is_call_named(node, name):
+    return isinstance(node, ast.Call) and (
+        (isinstance(node.func, ast.Name) and node.func.id == name)
+        or (isinstance(node.func, ast.Attribute) and node.func.attr == name)
+    )
+
+
+def _is_nonnegative(node):
+    """Return whether a generated index expression is statically nonnegative."""
+    if isinstance(node, ast.Constant):
+        return isinstance(node.value, (int, float)) and node.value >= 0
+
+    if isinstance(node, ast.Name):
+        # Generated program indices are obtained by unraveling program_id(0).
+        return re.fullmatch(r".*_index_\d+", node.id) is not None
+
+    if _is_call_named(node, "arange"):
+        return len(node.args) >= 1 and _is_nonnegative(node.args[0])
+
+    if isinstance(node, ast.Subscript):
+        return _is_nonnegative(node.value)
+
+    if isinstance(node, ast.BinOp) and isinstance(node.op, (ast.Add, ast.Mult)):
+        return _is_nonnegative(node.left) and _is_nonnegative(node.right)
+
+    return False
+
+
+def _is_arange_bounded_by(index, size):
+    node = index.node
+
+    while isinstance(node, ast.Subscript):
+        node = node.value
+
+    return (
+        _is_call_named(node, "arange")
+        and len(node.args) >= 2
+        and ast.dump(node.args[1], include_attributes=False)
+        == ast.dump(Symbol(size).node, include_attributes=False)
+    )
 
 
 class Tensor:
@@ -570,8 +613,11 @@ class Tensor:
         for index, size in zip(indices, self.shape):
             index = Symbol(index)
 
-            self.source._mask &= index < size
-            self.source._mask &= index >= 0
+            if not _is_arange_bounded_by(index, size):
+                self.source._mask &= index < size
+
+            if not _is_nonnegative(index.node):
+                self.source._mask &= index >= 0
 
         for output_, output in zip(self._outputs, outputs):
             output_.clear()

--- a/tests/test_competition_full_tile.py
+++ b/tests/test_competition_full_tile.py
@@ -1,0 +1,347 @@
+import ast
+import re
+from pathlib import Path
+
+import pytest
+import torch
+
+import ninetoothed
+import ninetoothed.aot as aot
+import ninetoothed.naming as naming
+from ninetoothed import Tensor
+from ninetoothed.generation import CodeGenerator
+
+TILE = 256
+
+
+def arrangement(input, other, output):
+    return tuple(tensor.tile((TILE,)) for tensor in (input, other, output))
+
+
+def application(input, other, output):
+    output = input + other  # noqa: F841
+
+
+def arrangement_2d(input, other, output):
+    return tuple(tensor.tile((32, 64)) for tensor in (input, other, output))
+
+
+def application_2d(input, other, output):
+    output = input + other  # noqa: F841
+
+
+@pytest.fixture(scope="module")
+def full_tile_kernel(tmp_path_factory):
+    output_dir = tmp_path_factory.mktemp("competition_full_tile")
+    tensors = tuple(Tensor(1, dtype=ninetoothed.float16) for _ in range(3))
+
+    return ninetoothed.make(
+        arrangement,
+        application,
+        tensors,
+        caller="cuda",
+        kernel_name="competition_full_tile_add",
+        output_dir=output_dir,
+    )
+
+
+@pytest.fixture(scope="module")
+def full_tile_kernel_2d(tmp_path_factory):
+    output_dir = tmp_path_factory.mktemp("competition_full_tile_2d")
+    tensors = tuple(Tensor(2, dtype=ninetoothed.float16) for _ in range(3))
+
+    return ninetoothed.make(
+        arrangement_2d,
+        application_2d,
+        tensors,
+        caller="cuda",
+        kernel_name="competition_full_tile_add_2d",
+        output_dir=output_dir,
+    )
+
+
+@pytest.mark.parametrize("size", (TILE * 16, TILE * 4096))
+def test_specialization_hit_correctness(full_tile_kernel, size):
+    input = torch.randn(size, device="cuda", dtype=torch.float16)
+    other = torch.randn_like(input)
+    output = torch.empty_like(input)
+
+    full_tile_kernel(input, other, output)
+
+    torch.testing.assert_close(output, input + other)
+
+
+def test_nondivisible_fallback_correctness(full_tile_kernel):
+    size = TILE * 16 + 1
+    input = torch.randn(size, device="cuda", dtype=torch.float16)
+    other = torch.randn_like(input)
+    output = torch.empty_like(input)
+
+    full_tile_kernel(input, other, output)
+
+    torch.testing.assert_close(output, input + other)
+
+
+def test_empty_fallback_correctness(full_tile_kernel):
+    input = torch.empty(0, device="cuda", dtype=torch.float16)
+    other = torch.empty_like(input)
+    output = torch.empty_like(input)
+
+    full_tile_kernel(input, other, output)
+    torch.cuda.synchronize()
+
+    assert output.numel() == 0
+
+
+def test_noncontiguous_fallback_correctness(full_tile_kernel):
+    size = TILE * 16
+    input = torch.randn(size * 2, device="cuda", dtype=torch.float16)[::2]
+    other = torch.randn(size, device="cuda", dtype=torch.float16)
+    output = torch.empty(size, device="cuda", dtype=torch.float16)
+
+    full_tile_kernel(input, other, output)
+
+    torch.testing.assert_close(output, input + other)
+
+
+def test_different_shape_fallback_correctness(full_tile_kernel):
+    size = TILE * 16
+    input = torch.randn(size, device="cuda", dtype=torch.float16)
+    other = torch.randn(size * 2, device="cuda", dtype=torch.float16)
+    output = torch.empty_like(input)
+
+    full_tile_kernel(input, other, output)
+
+    torch.testing.assert_close(output, input + other[:size])
+
+
+def test_two_dimensional_specialization_hit_correctness(full_tile_kernel_2d):
+    shape = (32 * 16, 64 * 16)
+    input = torch.randn(shape, device="cuda", dtype=torch.float16)
+    other = torch.randn_like(input)
+    output = torch.empty_like(input)
+
+    full_tile_kernel_2d(input, other, output)
+
+    torch.testing.assert_close(output, input + other)
+
+
+def test_two_dimensional_fallback_correctness(full_tile_kernel_2d):
+    shape = (32 * 16 + 1, 64 * 16)
+    input = torch.randn(shape, device="cuda", dtype=torch.float16)
+    other = torch.randn_like(input)
+    output = torch.empty_like(input)
+
+    full_tile_kernel_2d(input, other, output)
+
+    torch.testing.assert_close(output, input + other)
+
+
+@pytest.mark.parametrize("shape", ((0, 64), (32, 0), (0, 0)))
+def test_two_dimensional_empty_fallback_correctness(full_tile_kernel_2d, shape):
+    input = torch.empty(shape, device="cuda", dtype=torch.float16)
+    other = torch.empty_like(input)
+    output = torch.empty_like(input)
+
+    full_tile_kernel_2d(input, other, output)
+    torch.cuda.synchronize()
+
+    assert output.numel() == 0
+
+
+def _generated_kernel_source():
+    tensors = tuple(Tensor(1, dtype=ninetoothed.float16) for _ in range(3))
+    arranged = arrangement(*tensors)
+    application.__annotations__ = dict(zip(("input", "other", "output"), arranged))
+    generator = CodeGenerator()
+    source_file = generator(
+        application,
+        caller="cuda",
+        kernel_name="competition_full_tile_source",
+        num_warps=8,
+        num_stages=3,
+        max_num_configs=None,
+        prettify=False,
+    )
+
+    return generator, source_file
+
+
+def test_generated_source_removes_all_boundary_masks():
+    generator, source_file = _generated_kernel_source()
+    spec = aot._full_tile_spec(generator.kernel_func)
+    specialized_file = aot._make_full_tile_source(source_file, spec)
+    specialized = Path(specialized_file).read_text()
+
+    assert len(spec) == 3
+    assert "mask=" not in specialized
+
+
+def test_generated_source_removes_two_dimensional_boundary_masks():
+    tensors = tuple(Tensor(2, dtype=ninetoothed.float16) for _ in range(3))
+    arranged = arrangement_2d(*tensors)
+    application_2d.__annotations__ = dict(zip(("input", "other", "output"), arranged))
+    generator = CodeGenerator()
+    source_file = generator(
+        application_2d,
+        caller="cuda",
+        kernel_name="competition_full_tile_source_2d",
+        num_warps=8,
+        num_stages=3,
+        max_num_configs=None,
+        prettify=False,
+    )
+    spec = aot._full_tile_spec(generator.kernel_func)
+    launch_names = tuple(arg.arg for arg in generator.launch_func.args.args)
+
+    assert len(spec) == 6
+    assert aot._is_safe_full_tile_spec(
+        spec,
+        launch_names,
+        generator.tensors,
+        lambda values, name: next(
+            tensor for tensor in values if tensor.source.name.endswith(name)
+        ),
+    )
+    specialized_file = aot._make_full_tile_source(source_file, spec)
+    specialized = Path(specialized_file).read_text()
+    assert "mask=" not in specialized
+    tree = ast.parse(specialized)
+    kernel = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "competition_full_tile_source_2d"
+    )
+    used_size_sources = {
+        naming.remove_prefixes(match.group(1))
+        for node in ast.walk(kernel)
+        if isinstance(node, ast.Name)
+        if (match := Tensor.size_pattern().fullmatch(node.id)) is not None
+    }
+    assert len(used_size_sources) == 1
+
+
+def test_dispatcher_has_strict_hit_and_fallback_guards():
+    generator, _ = _generated_kernel_source()
+    launch_names = tuple(arg.arg for arg in generator.launch_func.args.args)
+    spec = aot._full_tile_spec(generator.kernel_func)
+    variants = [
+        (
+            "fast_full_tile",
+            tuple((name, 0) for name in launch_names),
+            tuple((name, 0) for name in launch_names),
+            ninetoothed.int32,
+            ninetoothed.int32,
+            spec,
+        ),
+        (
+            "ordinary_divisible",
+            tuple((name, 0) for name in launch_names),
+            tuple((name, 0) for name in launch_names),
+            ninetoothed.int32,
+            ninetoothed.int32,
+            (),
+        ),
+        (
+            "fallback",
+            (),
+            (),
+            ninetoothed.int64,
+            ninetoothed.int64,
+            (),
+        ),
+    ]
+    source, _ = aot._generate_dispatcher(
+        "competition_full_tile_source", launch_names, variants, (1, 1, 1)
+    )
+
+    assert source.count("% 256 == 0") == 1
+    assert source.count("% 16 == 0") == 3
+    assert source.count(".strides[0] == 1") == 6
+    assert source.count(".shape[0] > 0") == 1
+    assert source.count(".shape[0] ==") == 2
+    assert re.search(r"if \(.*full_tile", source)
+    assert "launch_competition_full_tile_source_fallback" in source
+
+
+def test_non_multiple_of_16_tile_keeps_aot_divisibility_guard():
+    variants = [
+        (
+            "fast_full_tile",
+            (("input", 0),),
+            (("input", 0),),
+            ninetoothed.int32,
+            ninetoothed.int32,
+            (("input", 0, 10),),
+        ),
+        (
+            "fallback",
+            (),
+            (),
+            ninetoothed.int64,
+            ninetoothed.int64,
+            (),
+        ),
+    ]
+    source, _ = aot._generate_dispatcher(
+        "competition_full_tile_non_aligned", ("input",), variants, (1,)
+    )
+
+    assert "input.shape[0] % 16 == 0" in source
+    assert "input.shape[0] % 10 == 0" in source
+    assert "input.shape[0] > 0" in source
+
+
+def test_non_program_multiplier_is_not_a_canonical_tile():
+    expression = ast.parse("7 * 256 + triton.language.arange(0, 256)", mode="eval").body
+
+    assert aot._canonical_tile_size(expression) is None
+
+
+def test_unrelated_program_bound_is_not_removed(tmp_path):
+    source = tmp_path / "unrelated_mask.py"
+    source.write_text(
+        """
+import triton
+import triton.language
+
+@triton.jit
+def unrelated_mask(pointer, unrelated_index_0, limit):
+    triton.language.load(
+        pointer,
+        mask=unrelated_index_0 < limit,
+        other=None,
+    )
+""".lstrip()
+    )
+
+    specialized = Path(
+        aot._make_full_tile_source(source, (("input", 0, TILE),))
+    ).read_text()
+
+    assert "mask=" in specialized
+
+
+def test_incomplete_high_rank_spec_is_not_eligible_for_mask_free_variant():
+    tensors = tuple(Tensor(2) for _ in range(3))
+    launch_names = ("input", "other", "output")
+
+    assert not aot._is_safe_full_tile_spec(
+        (("input", 1, 64), ("other", 1, 64), ("output", 1, 64)),
+        launch_names,
+        tensors,
+        lambda values, name: values[launch_names.index(name)],
+    )
+
+
+def test_expanded_layout_is_not_eligible_for_mask_free_variant():
+    source = Tensor(1)
+    expanded = source.tile((TILE,)).expand((2, -1))
+
+    assert not aot._is_safe_full_tile_spec(
+        ((source.name, 0, TILE),),
+        (source.name,),
+        (expanded,),
+        lambda values, name: values[0],
+    )


### PR DESCRIPTION
# [2026春季][T1-2-1]CearX

`pytest` output:

```text
tests/test_competition_full_tile.py: 19 passed in 85.54s
tests/test_aot_auto_tuning.py: 4 passed in 81.38s
tests/test_aot.py -k "not addmm": 10 passed, 1 skipped, 1 deselected in 588.28s
```

> 上述 pytest 结果只用于证明 correctness 和 AOT 回归，不是性能测试，也不用于计算 speedup。

## 核心工作

我们实现了一个安全的 AOT full-tile 特化机制，简化受严格 guard 保护的专用 kernel 生成代码。

NineToothed 基线对完整 tile 仍生成边界 mask。本提交在 AOT 编译阶段识别规范 tile 索引，建立 full-tile 证明，并生成 mask-free 专用 variant。dispatcher 在运行时检查正数 shape、tile 整除、shape 相等、contiguity 和整数范围；任一条件不成立时继续使用原通用 variant。

对应专用 variant 的主要结果：

| 场景 | mask | SASS | registers | cubin payload bytes |
| --- | ---: | ---: | ---: | ---: |
| 1D | 3 → 0 | 64 → 24 | 14 → 12 | 7,400 → 5,352 |
| 2D | 3 → 0 | 232 → 72 | 26 → 20 | 15,592 → 7,656 |

这些指标反映单个受测 variant 的 device-code 简化。full-tile 本身在当前 RTX 4090 D 微基准中没有呈现稳定 runtime 加速；已观测的 runtime 改善主要来自独立的 host `nvcc -O3` 改动。

## 特化机制

本提交修改 NineToothed AOT 编译链，不修改 `ntops` 算子。当所有非标量 tensor 都是 direct tile，rank 和 tile 一致，运行时 shape 为正数且可被 tile 整除，各 tensor 的 shape 相等，并满足原 contiguity guard 时，dispatcher 选择 mask-free 专用 variant。其他输入继续使用原通用 variant。

具体改动：

- 对生成器内部的 `arange` 上界和可证明的非负下界做保守 AST 简化；
- 识别 `compiler_generated_program_index * TILE + arange(0, TILE)` 形式的规范 tile 访问；
- 生成 full-tile variant，只删除已证明为真的 mask；
- runtime guard 检查 `shape > 0`、tile 整除、shape 相等、contiguity 和 int32 溢出；
- 使用 `variant_suffix` 隔离相同 Triton signature 下的 C++ namespace/type；
- AOT host library 使用 `nvcc -O3`。

## 结果边界

本提交包含两类优化，它们的收益不同：

- full-tile variant 在受 guard 约束的输入上消除 mask。1D 的 mask `3 → 0`、SASS `64 → 24`；2D 的 mask `3 → 0`、SASS `232 → 72`。这些数据证明对应专用 variant 的 device-code 指标下降。
- AOT host library 的 `nvcc -O3` 带来四个场景 `1.021x–1.037x` 的消融结果。
- 在 baseline 和 submitted 都使用 `-O3` 时，full-tile 的增量为 `1.000x / 0.997x / 0.997x / 0.999x`。当前 RTX 4090 D 微基准没有证明 full-tile mask 消除带来稳定 runtime 加速，其中三个场景有轻微回退。

因此，本 PR 将 full-tile 描述为 generated-code 优化，将已观测的 runtime 改善主要归于 host `-O3`。不把 pytest 通过数写成性能证据，也不声称 full-tile 带来显著 runtime 加速。

`cubin payload bytes` 是对应 kernel variant 的 device cubin 指标，不是整个 AOT library、wheel 或提交包的大小。本实现新增 full-tile variant，但没有测量包含所有 variant 的最终 library 体积，因此不声称“编译后的包变小”。

代码提交只包含：

- `src/ninetoothed/aot.py`
- `src/ninetoothed/tensor.py`
- `tests/test_competition_full_tile.py`
- `scripts/benchmark_full_tile.py`
- `scripts/measure_full_tile_generated.py`

## 安全边界

Full-tile variant 要求每个非标量 tensor 只有 source 和 direct tile 两层，所有 tensor rank 相同，每维都有规范 tile 访问，并使用相同 tile 向量。非整除、空维度、非连续、shape 不同、expand/高层级布局、不完整高 rank spec、非标准 program-index 表达式或 int32 溢出均回退。原普通 divisible `%16` guard 保留。

开发中发现 `shape == 0` 会因 `0 % TILE == 0` 误命中 mask-free variant，并在 `(0,)` 和 `(0, 64)` 上触发 CUDA illegal memory access。最终实现增加 `shape > 0` guard，并为 1D 和三个 2D 空维度增加同步 CUDA 回归。

## Correctness 与 AOT 回归

环境：NVIDIA RTX 4090 D / CUDA 12.8 / Triton 3.1.0。以下结果为 2026-07-12 在服务器上重跑的终端输出。这些测试检查 correctness、空维度 guard、fallback、AOT 和 autotuning 回归，不测量 kernel runtime。

```text
tests/test_competition_full_tile.py: 19 passed in 85.54s
tests/test_aot_auto_tuning.py: 4 passed in 81.38s
tests/test_aot.py -k "not addmm": 10 passed, 1 skipped, 1 deselected in 588.28s
```

三组命令的 `pytest exit status` 均为 `0`。测试结果见截图。

被 deselect 的 AOT `addmm` 在提交版和未修改的上游 `c9ebd495...` 上均在同一 `torch.allclose(..., atol=0.075)` 断言失败，输出差异一致。本提交没有修改测试或放宽容差，不把该项计作通过。探索性全仓运行中观察到一次 AOT `matmul` 失败，随后单独重跑为 `1 passed in 70.79s`。本提交不声称全量 pytest 通过。

## 测试结果截图

### 专项回归：19 passed

<img width="1006" height="733" alt="image1" src="https://github.com/user-attachments/assets/3d29d0a5-7370-417b-ae0f-bb744751c463" />

### AOT autotuning：4 passed

<img width="1075" height="730" alt="image2" src="https://github.com/user-attachments/assets/faed95f9-996f-43fb-8f30-8aa419934826" />

### AOT 主回归：10 passed, 1 skipped, 1 deselected

<img width="1016" height="749" alt="image3" src="https://github.com/user-attachments/assets/b794348d-547d-4dd3-ab1f-fe72cd2ec745" />

## 测试复现

下面三组命令就是上述最终测试的复现方式。它们检查 correctness 和 AOT 回归，不生成 Runtime 与 Generated code 表中的性能数据。

```bash
cd /root/ninetoothed-submitted
set -o pipefail

RUN_ROOT=$(mktemp -d /tmp/ninetoothed-specialty.XXXXXX)
mkdir -p "$RUN_ROOT/home" "$RUN_ROOT/pytest"
PATH=/usr/local/cuda-12.8/bin:$PATH \
HOME="$RUN_ROOT/home" \
PYTHONPATH="$PWD/scripts:$PWD/src" \
PYTHONPYCACHEPREFIX="$RUN_ROOT/pycache" \
python3 -m pytest -q tests/test_competition_full_tile.py \
  --basetemp="$RUN_ROOT/pytest" \
  --junitxml="$RUN_ROOT/final_specialty.xml" \
  2>&1 | tee "$RUN_ROOT/final_specialty.log"
TEST_STATUS=${PIPESTATUS[0]}
echo "pytest exit status: $TEST_STATUS"

RUN_ROOT=$(mktemp -d /tmp/ninetoothed-aot-tuning.XXXXXX)
mkdir -p "$RUN_ROOT/home" "$RUN_ROOT/pytest"
PATH=/usr/local/cuda-12.8/bin:$PATH \
HOME="$RUN_ROOT/home" \
PYTHONPATH="$PWD/scripts:$PWD/src" \
PYTHONPYCACHEPREFIX="$RUN_ROOT/pycache" \
python3 -m pytest -q tests/test_aot_auto_tuning.py \
  --basetemp="$RUN_ROOT/pytest" \
  --junitxml="$RUN_ROOT/final_aot_auto_tuning.xml" \
  2>&1 | tee "$RUN_ROOT/final_aot_auto_tuning.log"
TEST_STATUS=${PIPESTATUS[0]}
echo "pytest exit status: $TEST_STATUS"

RUN_ROOT=$(mktemp -d /tmp/ninetoothed-aot.XXXXXX)
mkdir -p "$RUN_ROOT/home" "$RUN_ROOT/pytest"
PATH=/usr/local/cuda-12.8/bin:$PATH \
HOME="$RUN_ROOT/home" \
PYTHONPATH="$PWD/scripts:$PWD/src" \
PYTHONPYCACHEPREFIX="$RUN_ROOT/pycache" \
python3 -m pytest -q tests/test_aot.py \
  -k "not addmm" \
  --basetemp="$RUN_ROOT/pytest" \
  --junitxml="$RUN_ROOT/final_aot.xml" \
  2>&1 | tee "$RUN_ROOT/final_aot.log"
TEST_STATUS=${PIPESTATUS[0]}
echo "pytest exit status: $TEST_STATUS"
```

## Generated code

| Case | mask | SASS | registers | cubin payload bytes |
| --- | ---: | ---: | ---: | ---: |
| 1D | 3 → 0 | 64 → 24（62.5%） | 14 → 12 | 7,400 → 5,352 |
| 2D | 3 → 0 | 232 → 72（69.0%） | 26 → 20 | 15,592 → 7,656 |

表中 cubin 大小只对应单个受测 variant，不代表整个 AOT library 或发布包变小。

## Runtime 与消融

测试使用 RTX 4090 D、float16 和 CUDA Event。每个场景 warmup 100 次，再执行 11 轮 AB/BA 交替测量，每轮调用 10,000 次。

| Case | 输入规模/布局 | 专用 variant | Baseline ms | Submitted ms | Speedup |
| --- | --- | --- | ---: | ---: | ---: |
| `hit_small` | 256 contiguous | 命中 | 0.0131635 | 0.0129253 | 1.018x |
| `hit_large` | 1,048,576 contiguous | 命中 | 0.0130651 | 0.0128589 | 1.016x |
| `fallback_nondivisible` | 1,048,577 contiguous | 回退 | 0.0131670 | 0.0127650 | 1.031x |
| `fallback_noncontiguous` | 1,048,576 stride-2 view | 回退 | 0.0133036 | 0.0129225 | 1.029x |

消融结果：

- full-tile、无 `-O3`：hit 为 `1.011x / 1.011x`；
- 仅 `-O3`：四场景为 `1.021x / 1.024x / 1.036x / 1.037x`；
- 同为 `-O3` 时加入 full-tile：`1.000x / 0.997x / 0.997x / 0.999x`。

这组数据表明，整体 runtime 差异主要来自 host `-O3`。mask-free variant 可以确认的收益是 generated-code 指标下降，而不是当前微基准中的稳定 runtime 加速。同为 `-O3` 时，full-tile 的四场景增量为 `1.000x / 0.997x / 0.997x / 0.999x`，其中三个场景轻微回退。整体组合的 runtime 改善低于 5%，不声称显著加速。

[加班仙人球_九齿编译优化_T1-2-1_赛题报告.pdf](https://github.com/user-attachments/files/29946857/_._T1-2-1_.pdf)
[HONOR_CODE.md](https://github.com/user-attachments/files/29946859/HONOR_CODE.md)
[REFERENCE.md](https://github.com/user-attachments/files/29946862/REFERENCE.md)
