### PR TITLE
Address remaining SSA review comments

### DIFF
--- a/src/ninetoothed/__init__.py
+++ b/src/ninetoothed/__init__.py
@@ -1,6 +1,4 @@
-from ninetoothed.aot import aot
 from ninetoothed.build import build
-from ninetoothed.compiler import lower
 from ninetoothed.compiler.jit import jit
 from ninetoothed.dtype import (
     bfloat16,
@@ -28,7 +26,6 @@ __all__ = [
     "bfloat16",
     "block_size",
     "build",
-    "aot",
     "float16",
     "float32",
     "float64",
@@ -39,7 +36,6 @@ __all__ = [
     "eval",
     "subs",
     "jit",
-    "lower",
     "make",
     "uint8",
     "uint16",

--- a/src/ninetoothed/auto_tuner.py
+++ b/src/ninetoothed/auto_tuner.py
@@ -163,7 +163,7 @@ class AutoTuner:
             )
             failures.append(f"{candidate_id}: {reason}")
 
-        return "All autotuning candidates failed: " + "; ".join(failures)
+        return "All auto-tuning candidates failed: " + "; ".join(failures)
 
     @staticmethod
     def _make_arg_key(args, kwargs):

--- a/src/ninetoothed/backends/materializers/__init__.py
+++ b/src/ninetoothed/backends/materializers/__init__.py
@@ -25,6 +25,7 @@ def materializer_for(target: Target | str):
 
     if _DEFAULT_REGISTRY is None:
         _DEFAULT_REGISTRY = create_default_registry()
+
     return _DEFAULT_REGISTRY.get(target)
 
 

--- a/src/ninetoothed/compiler/driver.py
+++ b/src/ninetoothed/compiler/driver.py
@@ -31,9 +31,9 @@ from .specialization import (
 
 @dataclass(frozen=True, kw_only=True)
 class CompileRequest:
+    arrangement: Any | None = None
     application: Any
     tensors: tuple[Any, ...] = ()
-    arrangement: Any | None = None
     backend: Target | str | None = None
     caller: str = "torch"
     kernel_name: str | None = None
@@ -142,8 +142,8 @@ def make(
 
     return DEFAULT_COMPILER.materialize(
         CompileRequest(
-            application=application,
             arrangement=arrangement,
+            application=application,
             tensors=tuple(tensors),
             backend=backend,
             caller=caller,
@@ -180,8 +180,8 @@ def lower(
     """Lower a NineToothed kernel without initializing a backend runtime."""
     compilation = DEFAULT_COMPILER.compile(
         CompileRequest(
-            application=application,
             arrangement=arrangement,
+            application=application,
             tensors=tuple(tensors),
             backend=backend,
             caller=caller,
@@ -486,7 +486,7 @@ def _validate_tuning_options(target: Target, request: CompileRequest) -> None:
         or request.max_num_configs not in {None, 1}
     ):
         raise NotImplementedError(
-            f"Backend autotuning is not supported for `{target.value}` yet; "
+            f"Backend auto-tuning is not supported for `{target.value}` yet; "
             "use scalar num_warps/num_stages and max_num_configs=1."
         )
 

--- a/tests/test_compiler_entrypoints.py
+++ b/tests/test_compiler_entrypoints.py
@@ -2,7 +2,6 @@ import importlib
 import os
 import subprocess
 import sys
-from dataclasses import fields
 
 import pytest
 
@@ -25,22 +24,7 @@ def test_public_entrypoints_remain_conservative():
     assert callable(ninetoothed.build)
     assert callable(ninetoothed.jit)
     assert callable(ninetoothed.make)
-    assert "aot" not in ninetoothed.__all__
-    assert "lower" not in ninetoothed.__all__
     assert not hasattr(ninetoothed, "load_built_artifact")
-
-    subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            (
-                "import ninetoothed; "
-                "assert 'aot' not in vars(ninetoothed); "
-                "assert 'lower' not in vars(ninetoothed)"
-            ),
-        ],
-        check=True,
-    )
 
 
 def test_legacy_entrypoint_modules_remain_importable():
@@ -53,14 +37,6 @@ def test_jit_implementation_class_is_not_public():
 
     assert not hasattr(compiler, "JIT")
     assert "JIT" not in compiler.__all__
-
-
-def test_compile_request_preserves_public_argument_order():
-    assert tuple(field.name for field in fields(CompileRequest))[:3] == (
-        "arrangement",
-        "application",
-        "tensors",
-    )
 
 
 def test_jit_function_and_decorator_use_the_default_compiler(monkeypatch):

--- a/tests/test_compiler_entrypoints.py
+++ b/tests/test_compiler_entrypoints.py
@@ -5,11 +5,11 @@ import sys
 from dataclasses import fields
 
 import pytest
-from ninetoothed.compiler import DEFAULT_COMPILER, Compiler, CompileRequest
-from ninetoothed.compiler import driver as compiler_driver
 
 import ninetoothed
 from ninetoothed import Tensor
+from ninetoothed.compiler import DEFAULT_COMPILER, Compiler, CompileRequest
+from ninetoothed.compiler import driver as compiler_driver
 
 
 def _arrangement(input, other, output):

--- a/tests/test_compiler_entrypoints.py
+++ b/tests/test_compiler_entrypoints.py
@@ -2,13 +2,14 @@ import importlib
 import os
 import subprocess
 import sys
+from dataclasses import fields
 
 import pytest
+from ninetoothed.compiler import DEFAULT_COMPILER, Compiler, CompileRequest
+from ninetoothed.compiler import driver as compiler_driver
 
 import ninetoothed
 from ninetoothed import Tensor
-from ninetoothed.compiler import DEFAULT_COMPILER, Compiler, CompileRequest
-from ninetoothed.compiler import driver as compiler_driver
 
 
 def _arrangement(input, other, output):
@@ -19,13 +20,27 @@ def _application(input, other, output):
     output = input + other  # noqa: F841
 
 
-def test_public_entrypoints_are_functions_backed_by_default_compiler():
+def test_public_entrypoints_remain_conservative():
     assert isinstance(DEFAULT_COMPILER, Compiler)
-    assert callable(ninetoothed.aot)
+    assert callable(ninetoothed.build)
     assert callable(ninetoothed.jit)
-    assert callable(ninetoothed.lower)
     assert callable(ninetoothed.make)
+    assert "aot" not in ninetoothed.__all__
+    assert "lower" not in ninetoothed.__all__
     assert not hasattr(ninetoothed, "load_built_artifact")
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import ninetoothed; "
+                "assert 'aot' not in vars(ninetoothed); "
+                "assert 'lower' not in vars(ninetoothed)"
+            ),
+        ],
+        check=True,
+    )
 
 
 def test_legacy_entrypoint_modules_remain_importable():
@@ -38,6 +53,14 @@ def test_jit_implementation_class_is_not_public():
 
     assert not hasattr(compiler, "JIT")
     assert "JIT" not in compiler.__all__
+
+
+def test_compile_request_preserves_public_argument_order():
+    assert tuple(field.name for field in fields(CompileRequest))[:3] == (
+        "arrangement",
+        "application",
+        "tensors",
+    )
 
 
 def test_jit_function_and_decorator_use_the_default_compiler(monkeypatch):
@@ -64,7 +87,7 @@ def test_pure_lowering_does_not_query_runtime_cuda_architecture(monkeypatch):
         raise AssertionError("Pure lowering must not query a runtime device.")
 
     monkeypatch.setattr(cache, "_runtime_cuda_architecture", unexpected_query)
-    artifact = ninetoothed.lower(
+    artifact = compiler_driver.lower(
         _arrangement,
         _application,
         (Tensor(1), Tensor(1), Tensor(1)),
@@ -165,8 +188,8 @@ def test_triton_launch_plan_contains_limited_runtime_variants():
         {"max_num_configs": 2},
     ),
 )
-def test_non_triton_backends_reject_unsupported_autotuning(backend, options):
-    with pytest.raises(NotImplementedError, match="autotuning is not supported"):
+def test_non_triton_backends_reject_unsupported_auto_tuning(backend, options):
+    with pytest.raises(NotImplementedError, match="auto-tuning is not supported"):
         DEFAULT_COMPILER.compile(
             CompileRequest(
                 arrangement=_arrangement,

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -36,7 +36,7 @@ def test_auto_tuning_generation(
     if backend != "triton" and (
         isinstance(num_warps, tuple) or isinstance(num_stages, tuple)
     ):
-        with pytest.raises(NotImplementedError, match="autotuning is not supported"):
+        with pytest.raises(NotImplementedError, match="auto-tuning is not supported"):
             ninetoothed.make(
                 arrangement,
                 application,

--- a/tests/test_triton_runtime_auto_tuning.py
+++ b/tests/test_triton_runtime_auto_tuning.py
@@ -1,10 +1,10 @@
 import uuid
 
-import ninetoothed.auto_tuner as auto_tuner
 import pytest
 import torch
 
 import ninetoothed
+import ninetoothed.auto_tuner as auto_tuner
 from ninetoothed import Tensor
 from tests.utils import get_available_devices
 

--- a/tests/test_triton_runtime_auto_tuning.py
+++ b/tests/test_triton_runtime_auto_tuning.py
@@ -1,10 +1,10 @@
 import uuid
 
+import ninetoothed.auto_tuner as auto_tuner
 import pytest
 import torch
 
 import ninetoothed
-import ninetoothed.auto_tuner as auto_tuner
 from ninetoothed import Tensor
 from tests.utils import get_available_devices
 
@@ -33,7 +33,7 @@ def test_triton_tuple_configurations_are_benchmarked_and_cached(device, monkeypa
         _application,
         tuple(Tensor(shape=(257,), dtype=ninetoothed.float32) for _ in range(3)),
         backend="triton",
-        kernel_name=f"runtime_autotune_{uuid.uuid4().hex}",
+        kernel_name=f"runtime_auto_tuning_{uuid.uuid4().hex}",
         num_warps=(4, 8),
         num_stages=(1,),
         max_num_configs=2,
@@ -54,7 +54,7 @@ def test_triton_tuple_configurations_are_benchmarked_and_cached(device, monkeypa
     assert len(benchmarked) == 2
 
 
-def test_autotuner_validates_arguments_before_benchmark(tmp_path, monkeypatch):
+def test_auto_tuner_validates_arguments_before_benchmark(tmp_path, monkeypatch):
     monkeypatch.setattr(auto_tuner, "_AUTO_TUNING_CACHE_DIR", tmp_path)
     benchmarked = []
 
@@ -77,7 +77,7 @@ def test_autotuner_validates_arguments_before_benchmark(tmp_path, monkeypatch):
     assert not benchmarked
 
 
-def test_autotuner_cache_is_reused_across_instances(tmp_path, monkeypatch):
+def test_auto_tuner_cache_is_reused_across_instances(tmp_path, monkeypatch):
     monkeypatch.setattr(auto_tuner, "_AUTO_TUNING_CACHE_DIR", tmp_path)
     benchmarked = []
 
@@ -106,7 +106,7 @@ def test_autotuner_cache_is_reused_across_instances(tmp_path, monkeypatch):
     assert len(benchmarked) == 2
 
 
-def test_autotuner_retries_transient_candidate_failures(tmp_path, monkeypatch):
+def test_auto_tuner_retries_transient_candidate_failures(tmp_path, monkeypatch):
     monkeypatch.setattr(auto_tuner, "_AUTO_TUNING_CACHE_DIR", tmp_path)
 
     def fail(function, args, kwargs):
@@ -121,7 +121,7 @@ def test_autotuner_retries_transient_candidate_failures(tmp_path, monkeypatch):
         cache_namespace="retry",
     )
 
-    with pytest.raises(RuntimeError, match="All autotuning candidates failed"):
+    with pytest.raises(RuntimeError, match="All auto-tuning candidates failed"):
         first(1)
 
     benchmarked = []


### PR DESCRIPTION
## Summary

- Keep the root package API conservative by exposing the SSA `jit` entrypoint without adding root-level `aot` or `lower` exports.
- Normalize auto-tuning naming across tests and user-facing errors while preserving the `AutoTuner` type.
- Align `CompileRequest` and its construction sites with the established `arrangement`, `application`, `tensors` order.
- Add the requested registry spacing and keep the compiler entrypoint coverage focused on supported behavior.

## Scope

This follows up the four unresolved review threads on #164. It does not address the Triton AOT multi-device/context issue, which is covered by #195.

## Validation

- Built and installed the editable package in `accelerator-dev/nvidia:latest` with `pip install --no-deps --force-reinstall -e .`.
- `ruff check` (Ruff 0.15.21)
- `ruff format --check` (Ruff 0.15.21)
- `python scripts/check_contributing_style.py`
- Current affected tests after the requested test cleanup: 96 passed
- Full NVIDIA single-device suite from the production-code commit is shown below. The subsequent commits only adjust test coverage and import ordering. The multi-device case is skipped for #195; the TileLang reload parameter is deselected because the NVIDIA image does not include the optional TileLang dependency.

`pytest` output:

```text
$ CUDA_VISIBLE_DEVICES=0 PYTHONPATH=src python -m pytest \
    --deselect='tests/test_built_artifact_reload.py::test_aot_built_artifact_can_be_reloaded[tilelang-cuda]'

collected 338 items / 1 deselected / 337 selected

========== 336 passed, 1 skipped, 1 deselected in 1851.00s (0:30:50) ==========
```
