### PR TITLE
Split the stride-contiguity guard into nested boolean pairs

### DIFF
--- a/src/ninetoothed/backends/emitters/ssa.py
+++ b/src/ninetoothed/backends/emitters/ssa.py
@@ -6,6 +6,7 @@ plans before lowering.  Backend-specific code is limited to spelling scalar
 expressions, loops, buffers, and launch wrappers.
 """
 
+import functools
 import json
 import re
 from dataclasses import replace
@@ -669,7 +670,12 @@ def _with_contiguous_1d_fast_path(
     predicate = (
         " && ".join(f"({stride} == 1)" for stride in stride_params)
         if target.c_style_syntax
-        else " and ".join(f"({stride} == 1)" for stride in stride_params)
+        # Some Triton frontends (e.g. MetaX's) reject chained boolean operators
+        # (a and b and c), so nest them pairwise into two-operand comparisons.
+        else functools.reduce(
+            lambda acc, term: f"({acc} and {term})",
+            (f"({stride} == 1)" for stride in stride_params),
+        )
     )
 
     if target.c_style_syntax:


### PR DESCRIPTION
This addresses a code-generation issue that prevents NineToothed kernels from compiling on Triton frontends that reject chained boolean operators, for example the MetaX Triton fork (`triton 3.0.0+metax`).

## Problem

The stride-contiguity fast-path guard is emitted as a flat chained boolean whenever an operation guards two or more tensors. For `add` the generated Triton contains:

```python
if (stride_0 == 1) and (stride_1 == 1) and (stride_2 == 1):
```

NVIDIA's Triton accepts this, but some frontends reject chained boolean operators:

```
UnsupportedLanguageConstruct: chained boolean operators (A or B or C) are not supported; use parentheses to split the chain.
```

Every operation whose fast path guards two or more tensors hits this (add, addmm, matmul, attention, ...), so no such kernel compiles on those frontends.

## Fix

Emit the guard as left-nested operand pairs so every operator has exactly two operands:

```python
if ((stride_0 == 1) and (stride_1 == 1)) and (stride_2 == 1):
```

`and` is associative and the operands are side-effect-free comparisons, so the condition is unchanged and platforms that already accepted the flat chain are unaffected. Only the Triton/Python branch is touched; the C-style (`&&`) branch is left as is. `stride_params` is guaranteed non-empty here because the enclosing function returns early when it is empty.

## Verification

`tests/test_add.py` guards three tensors and therefore generates this exact predicate. On a MetaX GPU (`torch 2.8.0+metax`, `triton 3.0.0+metax`) it fails to compile before this change and passes after.

`pytest` output:

```
# before this change (flat chain)
$ python -m pytest tests/test_add.py -q
E   UnsupportedLanguageConstruct: chained boolean operators (A or B or C) are not supported; use parentheses to split the chain.
src/ninetoothed/auto_tuner.py:66: RuntimeError
FAILED tests/test_add.py::test[98432-dtype0-cuda] - RuntimeError: All auto-tuning configurations failed
1 failed in 6.39s

# after this change (nested pairs)
$ python -m pytest tests/test_add.py -q
.                                                                        [100%]
1 passed in 7.28s
```

I do not have an NVIDIA GPU on hand to attach a full-suite run there, but the change is a pure parenthesization of an already-passing condition, so it is a no-op on frontends that accepted the flat chain.
