### PR TITLE
Fix portable fast-path predicates

### DIFF
--- a/src/ninetoothed/backends/emitters/ssa.py
+++ b/src/ninetoothed/backends/emitters/ssa.py
@@ -73,7 +73,7 @@ from ninetoothed.backends.emitters.expressions import (
 from ninetoothed.backends.emitters.expressions import (
     valid_symbol as _valid_symbol,
 )
-from ninetoothed.ir import Kernel, TensorSpec, ir_to_dict, ssa
+from ninetoothed.ir import IndexExpr, Kernel, TensorSpec, ir_to_dict, ssa
 
 _BINARY = {
     "add": "+",
@@ -666,10 +666,11 @@ def _with_contiguous_1d_fast_path(
         layout_contiguous=True,
         vector_program=vector_program,
     )
+    conditions = tuple(f"({stride} == 1)" for stride in stride_params)
     predicate = (
-        " && ".join(f"({stride} == 1)" for stride in stride_params)
+        " && ".join(conditions)
         if target.c_style_syntax
-        else " and ".join(f"({stride} == 1)" for stride in stride_params)
+        else IndexExpr.parse(" and ".join(conditions)).render()
     )
 
     if target.c_style_syntax:

--- a/tests/test_ssa_first_backend_lowering.py
+++ b/tests/test_ssa_first_backend_lowering.py
@@ -1110,6 +1110,51 @@ def scalarized_index_application(x, indices, y):
             isinstance(node, ast.Name) and node.id == "mask" for node in ast.walk(mask)
         )
 
+    def test_contiguous_fast_path_uses_binary_python_boolean_operations(self):
+        tensors = (Tensor(1), Tensor(1), Tensor(1))
+
+        for backend in ("triton", "tilelang"):
+            artifact = lower_application(
+                binary_arrangement,
+                helper_call_application,
+                tensors,
+                backend=backend,
+                kernel_name=f"ssa_contiguous_fast_path_{backend}",
+            )
+            module = ast.parse(artifact.primary_source)
+            fast_paths = []
+
+            for node in ast.walk(module):
+                if not isinstance(node, ast.If):
+                    continue
+
+                comparison_count = sum(
+                    isinstance(child, ast.Compare) for child in ast.walk(node.test)
+                )
+
+                if comparison_count == len(tensors):
+                    fast_paths.append(node)
+
+            assert len(fast_paths) == 1
+            bool_ops = [
+                node
+                for node in ast.walk(fast_paths[0].test)
+                if isinstance(node, ast.BoolOp)
+            ]
+            assert bool_ops
+            operand_counts = tuple(len(node.values) for node in bool_ops)
+            assert all(count == 2 for count in operand_counts), operand_counts
+
+        cuda_artifact = lower_application(
+            binary_arrangement,
+            helper_call_application,
+            tensors,
+            backend="cuda",
+            kernel_name="ssa_contiguous_fast_path_cuda",
+        )
+        assert " && " in cuda_artifact.primary_source
+        assert " and " not in cuda_artifact.primary_source
+
     def test_from_source_generates_axis_reduction_for_native_backends(self):
         kernel = _ssa_kernel(
             "\ndef axis_addmv_application(bias, a, x, out):\n    out = bias + sum(a * x, axis=1)\n",


### PR DESCRIPTION
## Summary

- Render Python-backend contiguous fast-path conjunctions as nested binary boolean operations.
- Preserve the existing CUDA C-style conjunction output.
- Cover Triton, TileLang, and CUDA source structure with one regression test.

Root cause: the shared SSA emitter produced one three-value Python `BoolOp`; Triton 3.1 and 3.3 accept only binary boolean operations in this path.

`pytest` output:

```
Current head 214f16d2 on master efe519d1, GitHub push workflow:
======================= 396 passed in 622.39s (0:10:22) =======================

Current head 214f16d2, local source-lowering suite:
.....................................                                    [100%]
37 passed in 1.93s

Previous head 19532780, NVIDIA (accelerator-dev/nvidia:latest), full SSA lowering test file:
Running 37 items in this shard
.....................................                                    [100%]
37 passed in 2.37s

Previous head 19532780, Iluvatar (image e8382905ffaa), portable fast-path regression:
.                                                                        [100%]
1 passed in 0.85s
```

The current-head local run exercises the real NineToothed lowering and generated-source AST. It uses an import-only Triton namespace because this test file does not invoke the Triton runtime. The only change from `19532780` to `214f16d2` is the equivalent test-side boolean counter rewrite.

Additional Hygon evidence from pre-rebase head `2d720193`; the emitter patch is unchanged by the rebase:

```
Hygon (sglang-deepseek-v4-dev-zkjh), master reproduction:
FAILED tests/test_add.py::test[98432-dtype0-cuda]
UnsupportedLanguageConstruct: chained boolean operators are not supported
1 failed in 14.39s

Hygon, affected suites on pre-rebase head 2d720193:
.............................                                            [100%]
29 passed in 16.74s
```
