### PR TITLE
Use portable attention reference

### DIFF
--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -1,6 +1,5 @@
 import pytest
 import torch
-import torch.nn.functional as F
 
 import ninetoothed
 import ninetoothed.language as ntl
@@ -9,6 +8,21 @@ from tests.utils import get_available_devices
 
 BLOCK_SIZE_M = ninetoothed.block_size(lower_bound=64, upper_bound=128)
 BLOCK_SIZE_N = ninetoothed.block_size(lower_bound=32, upper_bound=64)
+
+
+def _reference_attention(q, k, v, is_causal):
+    q_cpu = q.detach().cpu().double()
+    k_cpu = k.detach().cpu().double()
+    v_cpu = v.detach().cpu().double()
+    scores = q_cpu @ k_cpu.transpose(-1, -2)
+
+    if is_causal:
+        mask = torch.ones(scores.shape[-2:], dtype=torch.bool).triu(1)
+        scores.masked_fill_(mask, float("-inf"))
+
+    output = torch.softmax(scores, dim=-1) @ v_cpu
+
+    return output.to(device=v.device, dtype=v.dtype)
 
 
 def arrangement(
@@ -106,12 +120,13 @@ def attention(q, k, v, is_causal=False):
 @pytest.mark.parametrize("num_heads", (4,))
 @pytest.mark.parametrize("batch_size", (2,))
 def test(batch_size, num_heads, seq_len, emb_dim, dtype, device, is_causal, rtol, atol):
+    torch.manual_seed(20260722)
     q, k, v = (
         torch.randn(batch_size, num_heads, seq_len, emb_dim, dtype=dtype, device=device)
         for _ in range(3)
     )
 
     output = attention(q, k, v, is_causal=is_causal)
-    expected = F.scaled_dot_product_attention(q, k, v, is_causal=is_causal, scale=1)
+    expected = _reference_attention(q, k, v, is_causal)
 
-    assert torch.allclose(output, expected, rtol=rtol, atol=atol)
+    torch.testing.assert_close(output, expected, rtol=rtol, atol=atol)

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -120,7 +120,6 @@ def attention(q, k, v, is_causal=False):
 @pytest.mark.parametrize("num_heads", (4,))
 @pytest.mark.parametrize("batch_size", (2,))
 def test(batch_size, num_heads, seq_len, emb_dim, dtype, device, is_causal, rtol, atol):
-    torch.manual_seed(20260722)
     q, k, v = (
         torch.randn(batch_size, num_heads, seq_len, emb_dim, dtype=dtype, device=device)
         for _ in range(3)
@@ -129,4 +128,4 @@ def test(batch_size, num_heads, seq_len, emb_dim, dtype, device, is_causal, rtol
     output = attention(q, k, v, is_causal=is_causal)
     expected = _reference_attention(q, k, v, is_causal)
 
-    torch.testing.assert_close(output, expected, rtol=rtol, atol=atol)
+    assert torch.allclose(output, expected, rtol=rtol, atol=atol)

--- a/tests/test_attention_reference.py
+++ b/tests/test_attention_reference.py
@@ -1,0 +1,40 @@
+import pytest
+import torch
+
+from tests.test_attention import _reference_attention
+
+
+@pytest.mark.parametrize("is_causal", (False, True))
+@pytest.mark.parametrize("dtype", (torch.float32, torch.float16))
+def test_sequence_length_one_returns_value(dtype, is_causal):
+    q = torch.tensor([[[[1, 2, 3, 4]]]], dtype=dtype)
+    k = torch.tensor([[[[4, 3, 2, 1]]]], dtype=dtype)
+    v = torch.tensor([[[[1, -2, 3, -4]]]], dtype=dtype)
+
+    output = _reference_attention(q, k, v, is_causal)
+
+    torch.testing.assert_close(output, v)
+
+
+@pytest.mark.parametrize("is_causal", (False, True))
+@pytest.mark.parametrize("dtype", (torch.float32, torch.float16))
+@pytest.mark.parametrize("seq_len", (1, 31, 32, 33, 64, 65))
+def test_zero_scores_return_expected_mean(seq_len, dtype, is_causal):
+    q = torch.zeros((1, 2, seq_len, 8), dtype=dtype)
+    k = torch.zeros_like(q)
+    v = (
+        torch.arange(2 * seq_len * 8, dtype=torch.float64).reshape(1, 2, seq_len, 8)
+        / 16
+    ).to(dtype)
+
+    output = _reference_attention(q, k, v, is_causal)
+
+    if is_causal:
+        divisor = torch.arange(1, seq_len + 1, dtype=torch.float64).reshape(
+            1, 1, seq_len, 1
+        )
+        expected = v.double().cumsum(dim=-2) / divisor
+    else:
+        expected = v.double().mean(dim=-2, keepdim=True).expand_as(v)
+
+    torch.testing.assert_close(output, expected.to(dtype))


### PR DESCRIPTION
## Summary

- Replace vendor fused attention as the expected-value implementation with a CPU float64 reference.
- Preserve the existing randomized device inputs, `torch.allclose` comparison, parameter matrix, and tolerances.
- Cover the reference independently across causal modes, dtypes, and block-boundary sequence lengths.

The vendor fused attention implementation is not a portable oracle: on Iluvatar it produces incorrect FP32 results even when the NineToothed kernel agrees with the CPU float64 computation. This change keeps the existing kernel, parameter matrix, and tolerances unchanged.

Functional implementation validation before the assertion-only cleanup:

`pytest` output:

```
NVIDIA (accelerator-dev/nvidia:latest):
....................................                                     [100%]
36 passed in 143.67s

Hygon (sglang-deepseek-v4-dev-zkjh):
....................................                                     [100%]
36 passed in 187.66s

Iluvatar (image e8382905ffaa, 16x TG-V200):
....................................                                     [100%]
36 passed in 88.50s
```

Latest head `9a219bb7` validation after removing the redundant local seed and restoring the original assertion API:

```
NVIDIA: 36 passed in 146.15s
Iluvatar: 36 passed in 102.59s
Hygon: not rerun because the host was temporarily unreachable via SSH
```

The GitHub pytest jobs run all attention tests successfully. Their remaining failure is the unrelated TileLang artifact-reload case on a runner without TileLang; capability gating for that case is kept in #200.
