### PR TITLE
Optimize Triton runtime with validated launch caching

### DIFF
--- a/src/ninetoothed/auto_tuner.py
+++ b/src/ninetoothed/auto_tuner.py
@@ -68,7 +68,10 @@ class AutoTuner:
                 best_timing = min(timings)
                 best_timing_index = timings.index(best_timing)
                 best_func = self._funcs[best_timing_index]
+                result = best_func(*args, **kwargs)
                 self._best_func[arg_key] = best_func
+
+                return result
 
         return best_func(*args, **kwargs)
 

--- a/src/ninetoothed/backends/materializers/triton.py
+++ b/src/ninetoothed/backends/materializers/triton.py
@@ -379,14 +379,19 @@ def _triton_prepare_invocation(function, kernel):
 
 def _tensor_memory_span(value):
     try:
+        device = value.device
+    except (AttributeError, RuntimeError, TypeError):
+        device = None
+
+    try:
         shape = tuple(value.shape)
 
         if any(size == 0 for size in shape):
-            return None
+            return (device, 0, 0)
 
         element_size = value.element_size()
-        storage = value.untyped_storage().data_ptr()
-        lower = upper = value.storage_offset()
+        data_ptr = value.data_ptr()
+        lower = upper = 0
 
         for size, stride in zip(shape, value.stride()):
             extent = (size - 1) * stride
@@ -394,65 +399,95 @@ def _tensor_memory_span(value):
             upper += max(0, extent)
 
         return (
-            value.device,
-            storage,
-            storage + lower * element_size,
-            storage + (upper + 1) * element_size,
+            device,
+            data_ptr + lower * element_size,
+            data_ptr + (upper + 1) * element_size,
         )
     except (AttributeError, RuntimeError, TypeError):
-        return None
+        return (device, None, None)
+
+
+def _memory_spans_overlap(first, second):
+    first_device, first_start, first_end = first
+    second_device, second_start, second_end = second
+
+    if (
+        first_device is not None
+        and second_device is not None
+        and first_device != second_device
+    ):
+        return False
+
+    if None in (first_start, first_end, second_start, second_end):
+        return True
+
+    if first_start == first_end or second_start == second_end:
+        return False
+
+    return first_start < second_end and second_start < first_end
 
 
 def _runtime_alias_signature(abi, public):
     from ninetoothed.compiler.runtime import _binding_value
 
     output_names = set(abi.outputs)
-    physical_tensors = []
-    seen = set()
+    physical_tensors = {}
     aliases = []
 
     for binding in abi.kernel_args:
-        if (
-            binding.kind not in {"tensor", "jagged_values", "jagged_offsets"}
-            or binding.source not in public
+        if binding.source not in public or binding.kind not in {
+            "tensor",
+            "scalar",
+            "constexpr",
+            "jagged_values",
+            "jagged_offsets",
+        }:
+            continue
+
+        value = _binding_value(binding, public)
+
+        if binding.kind in {"scalar", "constexpr"} and not all(
+            hasattr(value, attribute) for attribute in ("data_ptr", "shape", "stride")
         ):
             continue
 
         identity = (binding.source, binding.kind)
-
-        if identity in seen:
-            continue
-
-        seen.add(identity)
-        value = _binding_value(binding, public)
         access = binding.access or (
             "read"
-            if binding.kind == "jagged_offsets"
-            else "write"
+            if binding.kind in {"scalar", "constexpr", "jagged_offsets"}
+            else "read_write"
             if binding.source in output_names
             else "read"
         )
-        physical_tensors.append((*identity, access, value, _tensor_memory_span(value)))
+        previous = physical_tensors.get(identity)
+
+        if previous is not None and previous[2] != access:
+            access = "read_write"
+
+        physical_tensors[identity] = (
+            *identity,
+            access,
+            value,
+            _tensor_memory_span(value),
+        )
 
     writers = tuple(
-        tensor for tensor in physical_tensors if tensor[2] in {"write", "read_write"}
+        tensor
+        for tensor in physical_tensors.values()
+        if tensor[2] in {"write", "read_write"}
     )
     readers = tuple(
-        tensor for tensor in physical_tensors if tensor[2] in {"read", "read_write"}
+        tensor
+        for tensor in physical_tensors.values()
+        if tensor[2] in {"read", "read_write"}
     )
 
     for writer_name, writer_kind, _access, writer, writer_span in writers:
         for reader_name, reader_kind, _access, reader, reader_span in readers:
             overlaps = writer is reader
 
-            if not overlaps and (
-                writer_span is not None
-                and reader_span is not None
-                and writer_span[:2] == reader_span[:2]
-                and writer_span[2] < reader_span[3]
-                and reader_span[2] < writer_span[3]
-            ):
-                overlaps = True
+            if not overlaps:
+                overlaps = _memory_spans_overlap(writer_span, reader_span)
 
             if overlaps:
                 aliases.append((writer_name, writer_kind, reader_name, reader_kind))
@@ -489,7 +524,10 @@ def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
         nonlocal active, active_identity
         active_identity = identity
         active = entry
-        handle._selected_tuning_candidate = candidates_by_launch[entry[1]]
+        record(entry[1])
+
+    def record(selected):
+        handle._selected_tuning_candidate = candidates_by_launch[selected]
 
     def remember(identity, selection_key, selected, prepared):
         token = object()
@@ -507,6 +545,12 @@ def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
         activate(identity, entry)
 
         return prepared
+
+    def remember_best_effort(identity, selection_key, selected, prepared):
+        try:
+            return remember(identity, selection_key, selected, prepared)
+        except TypeError:
+            return None
 
     def launch(*args, **kwargs):
         active_snapshot = active
@@ -566,49 +610,64 @@ def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
             selected = cached[1]
 
         if selected is None and alias_signature:
-            failures = []
+            selected = tuner._funcs[0]
 
-            for candidate in tuner._funcs:
-                try:
-                    prepared = candidate._ninetoothed_prepare(
-                        args,
-                        kwargs,
-                        public=public,
-                    )
-                    result = candidate._ninetoothed_invoke_prepared(
-                        prepared,
-                        args,
-                        kwargs,
-                    )
-                except Exception as exc:  # noqa: BLE001
-                    candidate_id = candidates_by_launch[candidate].get("id", "unknown")
-                    failures.append(f"{candidate_id}: {type(exc).__name__}: {exc}")
-                    continue
+            try:
+                prepared = selected._ninetoothed_prepare(
+                    args,
+                    kwargs,
+                    public=public,
+                )
+            except Exception:  # noqa: BLE001
+                result = selected(*args, **kwargs)
+            else:
+                result = selected._ninetoothed_invoke_prepared(
+                    prepared,
+                    args,
+                    kwargs,
+                )
+                remember_best_effort(
+                    identity,
+                    selection_key,
+                    selected,
+                    prepared,
+                )
 
-                remember(identity, selection_key, candidate, prepared)
+            record(selected)
 
-                return result
-
-            raise RuntimeError(
-                "All alias-safe Triton candidates failed: " + "; ".join(failures)
-            )
+            return result
 
         if selected is None:
             result = tuner(*args, **kwargs)
             selected = tuner._best_func[key]
-            prepared = selected._ninetoothed_prepare(args, kwargs, public=public)
-            remember(identity, selection_key, selected, prepared)
+            record(selected)
+
+            try:
+                prepared = selected._ninetoothed_prepare(args, kwargs, public=public)
+            except Exception:  # noqa: BLE001
+                return result
+
+            remember_best_effort(identity, selection_key, selected, prepared)
 
             return result
 
-        prepared = selected._ninetoothed_prepare(args, kwargs, public=public)
-        cached_prepared = remember(identity, selection_key, selected, prepared)
+        try:
+            prepared = selected._ninetoothed_prepare(args, kwargs, public=public)
+        except Exception:  # noqa: BLE001
+            result = selected(*args, **kwargs)
+            record(selected)
 
-        return selected._ninetoothed_invoke_prepared(
-            cached_prepared or prepared,
+            return result
+
+        result = selected._ninetoothed_invoke_prepared(
+            prepared,
             args,
             kwargs,
         )
+        record(selected)
+        remember_best_effort(identity, selection_key, selected, prepared)
+
+        return result
 
     return launch
 

--- a/src/ninetoothed/backends/materializers/triton.py
+++ b/src/ninetoothed/backends/materializers/triton.py
@@ -181,6 +181,7 @@ def _candidate_launch(compilation, launch, kernel, candidate):
         _ninetoothed_num_warps=int(candidate["num_warps"]),
         _ninetoothed_num_stages=int(candidate["num_stages"]),
     )
+
     return _runtime_wrapper(
         function,
         compilation.launch_abi,
@@ -324,6 +325,7 @@ def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
         ):
             prepared_calls[identity] = cached
             activate(identity, cached)
+
             return cached[1]._ninetoothed_invoke_prepared(cached[2], args, kwargs)
 
         public = _public_values(
@@ -361,10 +363,12 @@ def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
             selected = tuner._best_func[key]
             prepared = selected._ninetoothed_prepare(args, kwargs, public=public)
             remember(identity, key, selected, prepared)
+
             return result
 
         prepared = selected._ninetoothed_prepare(args, kwargs, public=public)
         remember(identity, key, selected, prepared)
+
         return selected._ninetoothed_invoke_prepared(prepared, args, kwargs)
 
     return launch
@@ -393,6 +397,7 @@ def _triton_specialization_key(compilation, args, kwargs):
         scalar_values.append((binding.source, type(value).__name__, repr(value)))
 
     base = AutoTuner._make_arg_key(args, kwargs)
+
     return f"{base}, specialization={tuple(scalar_values)!r}"
 
 

--- a/src/ninetoothed/backends/materializers/triton.py
+++ b/src/ninetoothed/backends/materializers/triton.py
@@ -8,6 +8,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import types
 from dataclasses import replace
 from pathlib import Path
 
@@ -99,6 +100,7 @@ def _materialize(compilation):
     from ninetoothed.compiler.runtime import (
         Handle,
         _runtime_wrapper,
+        _verified_runtime_launch,
         import_python_module,
     )
 
@@ -115,16 +117,23 @@ def _materialize(compilation):
     os.environ.setdefault("TRITON_CACHE_DIR", str(TRITON_CACHE_DIR))
     module = import_python_module(source)
     launch = getattr(module, artifact.entrypoint)
+    kernel = getattr(module, f"{artifact.kernel_name}_kernel", None)
     candidates = tuple(compilation.launch_plan.tuning_candidates)
     candidate_launches = tuple(
-        _candidate_launch(compilation, launch, candidate) for candidate in candidates
+        _candidate_launch(compilation, launch, kernel, candidate)
+        for candidate in candidates
     )
     tuner = None
 
     if len(candidate_launches) > 1:
         from ninetoothed.auto_tuner import AutoTuner
 
-        tuner = AutoTuner(
+        class TritonAutoTuner(AutoTuner):
+            @staticmethod
+            def _make_arg_key(args, kwargs):
+                return _triton_specialization_key(compilation, args, kwargs)
+
+        tuner = TritonAutoTuner(
             candidate_launches,
             tuple((cache_key, candidate["id"]) for candidate in candidates),
             cache_namespace=f"jit_{cache_key}",
@@ -132,59 +141,259 @@ def _materialize(compilation):
         )
         wrapped = tuner
     elif candidate_launches:
-        wrapped = candidate_launches[0]
+        wrapped = _verified_runtime_launch(candidate_launches[0])
     else:
-        wrapped = _runtime_wrapper(
-            launch,
-            compilation.launch_abi,
-            specs=compilation.kernel.tensors,
+        wrapped = _verified_runtime_launch(
+            _runtime_wrapper(
+                launch,
+                compilation.launch_abi,
+                specs=compilation.kernel.tensors,
+                prepare_invocation=_triton_prepare_invocation(launch, kernel),
+            )
         )
 
-    kernel = getattr(module, f"{artifact.kernel_name}_kernel", None)
     handle = Handle(compilation, kernel, wrapped, source)
     handle._tuner = tuner
     handle._selected_tuning_candidate = candidates[0] if len(candidates) == 1 else None
 
     if tuner is not None:
         by_launch = dict(zip(candidate_launches, candidates))
-
-        def tuned_launch(*args, **kwargs):
-            result = tuner(*args, **kwargs)
-            arg_key = tuner._make_arg_key(args, kwargs)
-            handle._selected_tuning_candidate = by_launch[tuner._best_func[arg_key]]
-
-            return result
-
-        handle._launch = tuned_launch
+        handle._launch = _tuned_runtime_launch(
+            tuner,
+            by_launch,
+            handle,
+            compilation,
+        )
 
     return handle
 
 
-def _candidate_launch(compilation, launch, candidate):
+def _candidate_launch(compilation, launch, kernel, candidate):
     from ninetoothed.compiler.runtime import _runtime_wrapper
 
-    wrapped = _runtime_wrapper(
-        functools.partial(
-            launch,
-            _ninetoothed_num_warps=int(candidate["num_warps"]),
-            _ninetoothed_num_stages=int(candidate["num_stages"]),
-        ),
-        compilation.launch_abi,
-        specs=compilation.kernel.tensors,
-    )
     bindings = {binding.name: binding for binding in compilation.launch_abi.kernel_args}
-    meta_kwargs = {
+    meta_values = {
         str(bindings[name].source): value
         for name, value in dict(candidate.get("meta_parameters", {})).items()
     }
+    function = functools.partial(
+        launch,
+        _ninetoothed_num_warps=int(candidate["num_warps"]),
+        _ninetoothed_num_stages=int(candidate["num_stages"]),
+    )
+    return _runtime_wrapper(
+        function,
+        compilation.launch_abi,
+        specs=compilation.kernel.tensors,
+        binding_overrides=meta_values,
+        prepare_invocation=_triton_prepare_invocation(function, kernel),
+    )
 
-    if not meta_kwargs:
-        return wrapped
 
-    def launch_candidate(*args, **kwargs):
-        return wrapped(*args, **(dict(kwargs) | meta_kwargs))
+def _triton_prepare_invocation(function, kernel):
+    if kernel is None:
+        return None
 
-    return launch_candidate
+    target = getattr(function, "func", function)
+
+    if not isinstance(target, types.FunctionType):
+        return None
+
+    kernel_names = tuple(
+        name
+        for name in target.__code__.co_names
+        if target.__globals__.get(name) is kernel
+    )
+
+    if len(kernel_names) != 1:
+        return None
+
+    kernel_name = kernel_names[0]
+    partial_args = getattr(function, "args", ())
+    partial_keywords = getattr(function, "keywords", None) or {}
+
+    def prepare(values):
+        calls = []
+
+        class KernelProxy:
+            def __getitem__(self, grid):
+                bound_kernel = kernel[grid]
+
+                def capture(*args, **kwargs):
+                    calls.append((bound_kernel, args, kwargs))
+
+                return capture
+
+        globals_copy = dict(target.__globals__)
+        globals_copy[kernel_name] = KernelProxy()
+        dry_launch = types.FunctionType(
+            target.__code__,
+            globals_copy,
+            target.__name__,
+            target.__defaults__,
+            target.__closure__,
+        )
+        dry_launch.__kwdefaults__ = target.__kwdefaults__
+        functools.partial(
+            dry_launch,
+            *partial_args,
+            **partial_keywords,
+        )(*values)
+        bound_calls = tuple(calls)
+
+        if not bound_calls:
+            return None
+
+        def invoke():
+            for bound_kernel, args, kwargs in bound_calls:
+                bound_kernel(*args, **kwargs)
+
+        return invoke
+
+    return prepare
+
+
+def _runtime_outputs_alias_inputs(abi, public):
+    outputs = {
+        name: public[name]
+        for name in abi.outputs
+        if name in public and hasattr(public[name], "data_ptr")
+    }
+
+    for output_name, output in outputs.items():
+        for input_name, value in public.items():
+            if input_name == output_name or not hasattr(value, "data_ptr"):
+                continue
+
+            if output is value:
+                return True
+
+            try:
+                same_device = output.device == value.device
+                output_storage = output.untyped_storage().data_ptr()
+                input_storage = value.untyped_storage().data_ptr()
+            except (AttributeError, RuntimeError, TypeError):
+                continue
+
+            if same_device and output_storage == input_storage:
+                return True
+
+    return False
+
+
+def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
+    from ninetoothed.compiler.runtime import (
+        _empty_launch,
+        _first_output,
+        _public_values,
+        _remember_verified_runtime_call,
+        _runtime_call_identity,
+    )
+
+    active_identity = None
+    active = None
+    prepared_calls = {}
+
+    def activate(identity, entry):
+        nonlocal active, active_identity
+        active_identity = identity
+        active = entry
+        handle._selected_tuning_candidate = candidates_by_launch[entry[1]]
+
+    def remember(identity, key, selected, prepared):
+        entry = (key, selected, prepared)
+        _remember_verified_runtime_call(prepared_calls, identity, entry)
+        activate(identity, entry)
+
+    def launch(*args, **kwargs):
+        identity = _runtime_call_identity(args, kwargs)
+
+        if (
+            active is not None
+            and identity == active_identity
+            and active[2].guard.matches(args, kwargs, identity_verified=True)
+        ):
+            return active[1]._ninetoothed_invoke_prepared(active[2], args, kwargs)
+
+        cached = prepared_calls.pop(identity, None)
+
+        if cached is not None and cached[2].guard.matches(
+            args,
+            kwargs,
+            identity_verified=True,
+        ):
+            prepared_calls[identity] = cached
+            activate(identity, cached)
+            return cached[1]._ninetoothed_invoke_prepared(cached[2], args, kwargs)
+
+        public = _public_values(
+            compilation.launch_abi,
+            args,
+            kwargs,
+            specs=compilation.kernel.tensors,
+        )
+
+        if _empty_launch(compilation.launch_abi, public):
+            return _first_output(compilation.launch_abi, public)
+
+        key = tuner._make_arg_key(args, kwargs)
+        selected = next(
+            (
+                entry[1]
+                for entry in reversed(tuple(prepared_calls.values()))
+                if entry[0] == key
+            ),
+            None,
+        )
+
+        if selected is None and cached is not None and cached[0] == key:
+            selected = cached[1]
+
+        if selected is None and _runtime_outputs_alias_inputs(
+            compilation.launch_abi,
+            public,
+        ):
+            selected = tuner._funcs[0]
+            tuner._best_func[key] = selected
+
+        if selected is None:
+            result = tuner(*args, **kwargs)
+            selected = tuner._best_func[key]
+            prepared = selected._ninetoothed_prepare(args, kwargs, public=public)
+            remember(identity, key, selected, prepared)
+            return result
+
+        prepared = selected._ninetoothed_prepare(args, kwargs, public=public)
+        remember(identity, key, selected, prepared)
+        return selected._ninetoothed_invoke_prepared(prepared, args, kwargs)
+
+    return launch
+
+
+def _triton_specialization_key(compilation, args, kwargs):
+    from ninetoothed.auto_tuner import AutoTuner
+
+    public = dict(zip(compilation.launch_abi.public_args, args))
+    public.update(kwargs)
+    scalar_values = []
+
+    for binding in compilation.launch_abi.kernel_args:
+        if (
+            binding.kind not in {"scalar", "constexpr", "meta"}
+            or binding.source not in public
+        ):
+            continue
+
+        value = public[binding.source]
+        shape = getattr(value, "shape", None)
+
+        if shape is not None and not tuple(shape) and hasattr(value, "item"):
+            value = value.item()
+
+        scalar_values.append((binding.source, type(value).__name__, repr(value)))
+
+    base = AutoTuner._make_arg_key(args, kwargs)
+    return f"{base}, specialization={tuple(scalar_values)!r}"
 
 
 def _runtime_validator(compilation):

--- a/src/ninetoothed/backends/materializers/triton.py
+++ b/src/ninetoothed/backends/materializers/triton.py
@@ -425,28 +425,37 @@ def _runtime_alias_signature(abi, public):
 
         seen.add(identity)
         value = _binding_value(binding, public)
-        physical_tensors.append((*identity, value, _tensor_memory_span(value)))
+        access = binding.access or (
+            "read"
+            if binding.kind == "jagged_offsets"
+            else "write"
+            if binding.source in output_names
+            else "read"
+        )
+        physical_tensors.append((*identity, access, value, _tensor_memory_span(value)))
 
-    outputs = tuple(tensor for tensor in physical_tensors if tensor[0] in output_names)
-    inputs = tuple(
-        tensor for tensor in physical_tensors if tensor[0] not in output_names
+    writers = tuple(
+        tensor for tensor in physical_tensors if tensor[2] in {"write", "read_write"}
+    )
+    readers = tuple(
+        tensor for tensor in physical_tensors if tensor[2] in {"read", "read_write"}
     )
 
-    for output_name, output_kind, output, output_span in outputs:
-        for input_name, input_kind, value, input_span in inputs:
-            overlaps = output is value
+    for writer_name, writer_kind, _access, writer, writer_span in writers:
+        for reader_name, reader_kind, _access, reader, reader_span in readers:
+            overlaps = writer is reader
 
             if not overlaps and (
-                output_span is not None
-                and input_span is not None
-                and output_span[:2] == input_span[:2]
-                and output_span[2] < input_span[3]
-                and input_span[2] < output_span[3]
+                writer_span is not None
+                and reader_span is not None
+                and writer_span[:2] == reader_span[:2]
+                and writer_span[2] < reader_span[3]
+                and reader_span[2] < writer_span[3]
             ):
                 overlaps = True
 
             if overlaps:
-                aliases.append((output_name, output_kind, input_name, input_kind))
+                aliases.append((writer_name, writer_kind, reader_name, reader_kind))
 
     return tuple(aliases)
 

--- a/src/ninetoothed/backends/materializers/triton.py
+++ b/src/ninetoothed/backends/materializers/triton.py
@@ -292,6 +292,7 @@ def _triton_prepare_invocation(function, kernel):
         def expression(value):
             if isinstance(value, CallRef):
                 container = "_args" if value.kind == "positional" else "_kwargs"
+
                 return f"{container}[{value.key!r}]"
 
             name = f"_value_{len(namespace)}"
@@ -376,32 +377,64 @@ def _triton_prepare_invocation(function, kernel):
     return prepare
 
 
-def _runtime_outputs_alias_inputs(abi, public):
-    outputs = {
-        name: public[name]
-        for name in abi.outputs
-        if name in public and hasattr(public[name], "data_ptr")
-    }
+def _tensor_memory_span(value):
+    try:
+        shape = tuple(value.shape)
 
-    for output_name, output in outputs.items():
+        if any(size == 0 for size in shape):
+            return None
+
+        element_size = value.element_size()
+        storage = value.untyped_storage().data_ptr()
+        lower = upper = value.storage_offset()
+
+        for size, stride in zip(shape, value.stride()):
+            extent = (size - 1) * stride
+            lower += min(0, extent)
+            upper += max(0, extent)
+
+        return (
+            value.device,
+            storage,
+            storage + lower * element_size,
+            storage + (upper + 1) * element_size,
+        )
+    except (AttributeError, RuntimeError, TypeError):
+        return None
+
+
+def _runtime_alias_signature(abi, public):
+    output_names = set(abi.outputs)
+    aliases = []
+
+    for output_name in abi.outputs:
+        output = public.get(output_name)
+
+        if output is None or not hasattr(output, "data_ptr"):
+            continue
+
+        output_span = _tensor_memory_span(output)
+
         for input_name, value in public.items():
-            if input_name == output_name or not hasattr(value, "data_ptr"):
+            if input_name in output_names or not hasattr(value, "data_ptr"):
                 continue
 
             if output is value:
-                return True
-
-            try:
-                same_device = output.device == value.device
-                output_storage = output.untyped_storage().data_ptr()
-                input_storage = value.untyped_storage().data_ptr()
-            except (AttributeError, RuntimeError, TypeError):
+                aliases.append((output_name, input_name))
                 continue
 
-            if same_device and output_storage == input_storage:
-                return True
+            input_span = _tensor_memory_span(value)
 
-    return False
+            if (
+                output_span is not None
+                and input_span is not None
+                and output_span[:2] == input_span[:2]
+                and output_span[2] < input_span[3]
+                and input_span[2] < output_span[3]
+            ):
+                aliases.append((output_name, input_name))
+
+    return tuple(aliases)
 
 
 def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
@@ -435,7 +468,7 @@ def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
         active = entry
         handle._selected_tuning_candidate = candidates_by_launch[entry[1]]
 
-    def remember(identity, key, selected, prepared):
+    def remember(identity, selection_key, selected, prepared):
         token = object()
 
         def collected(_reference):
@@ -446,7 +479,7 @@ def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
         if prepared is None:
             return None
 
-        entry = (key, selected, prepared)
+        entry = (selection_key, selected, prepared)
         _remember_verified_runtime_call(prepared_calls, identity, entry)
         activate(identity, entry)
 
@@ -495,35 +528,58 @@ def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
             return _first_output(compilation.launch_abi, public)
 
         key = tuner._make_arg_key(args, kwargs)
+        alias_signature = _runtime_alias_signature(compilation.launch_abi, public)
+        selection_key = (key, alias_signature)
         selected = next(
             (
                 entry[1]
                 for entry in reversed(tuple(prepared_calls.values()))
-                if entry[0] == key
+                if entry[0] == selection_key
             ),
             None,
         )
 
-        if selected is None and cached is not None and cached[0] == key:
+        if selected is None and cached is not None and cached[0] == selection_key:
             selected = cached[1]
 
-        if selected is None and _runtime_outputs_alias_inputs(
-            compilation.launch_abi,
-            public,
-        ):
-            selected = tuner._funcs[0]
-            tuner._best_func[key] = selected
+        if selected is None and alias_signature:
+            failures = []
+
+            for candidate in tuner._funcs:
+                try:
+                    prepared = candidate._ninetoothed_prepare(
+                        args,
+                        kwargs,
+                        public=public,
+                    )
+                    result = candidate._ninetoothed_invoke_prepared(
+                        prepared,
+                        args,
+                        kwargs,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    candidate_id = candidates_by_launch[candidate].get("id", "unknown")
+                    failures.append(f"{candidate_id}: {type(exc).__name__}: {exc}")
+                    continue
+
+                remember(identity, selection_key, candidate, prepared)
+
+                return result
+
+            raise RuntimeError(
+                "All alias-safe Triton candidates failed: " + "; ".join(failures)
+            )
 
         if selected is None:
             result = tuner(*args, **kwargs)
             selected = tuner._best_func[key]
             prepared = selected._ninetoothed_prepare(args, kwargs, public=public)
-            remember(identity, key, selected, prepared)
+            remember(identity, selection_key, selected, prepared)
 
             return result
 
         prepared = selected._ninetoothed_prepare(args, kwargs, public=public)
-        cached_prepared = remember(identity, key, selected, prepared)
+        cached_prepared = remember(identity, selection_key, selected, prepared)
 
         return selected._ninetoothed_invoke_prepared(
             cached_prepared or prepared,

--- a/src/ninetoothed/backends/materializers/triton.py
+++ b/src/ninetoothed/backends/materializers/triton.py
@@ -404,35 +404,49 @@ def _tensor_memory_span(value):
 
 
 def _runtime_alias_signature(abi, public):
+    from ninetoothed.compiler.runtime import _binding_value
+
     output_names = set(abi.outputs)
+    physical_tensors = []
+    seen = set()
     aliases = []
 
-    for output_name in abi.outputs:
-        output = public.get(output_name)
-
-        if output is None or not hasattr(output, "data_ptr"):
+    for binding in abi.kernel_args:
+        if (
+            binding.kind not in {"tensor", "jagged_values", "jagged_offsets"}
+            or binding.source not in public
+        ):
             continue
 
-        output_span = _tensor_memory_span(output)
+        identity = (binding.source, binding.kind)
 
-        for input_name, value in public.items():
-            if input_name in output_names or not hasattr(value, "data_ptr"):
-                continue
+        if identity in seen:
+            continue
 
-            if output is value:
-                aliases.append((output_name, input_name))
-                continue
+        seen.add(identity)
+        value = _binding_value(binding, public)
+        physical_tensors.append((*identity, value, _tensor_memory_span(value)))
 
-            input_span = _tensor_memory_span(value)
+    outputs = tuple(tensor for tensor in physical_tensors if tensor[0] in output_names)
+    inputs = tuple(
+        tensor for tensor in physical_tensors if tensor[0] not in output_names
+    )
 
-            if (
+    for output_name, output_kind, output, output_span in outputs:
+        for input_name, input_kind, value, input_span in inputs:
+            overlaps = output is value
+
+            if not overlaps and (
                 output_span is not None
                 and input_span is not None
                 and output_span[:2] == input_span[:2]
                 and output_span[2] < input_span[3]
                 and input_span[2] < output_span[3]
             ):
-                aliases.append((output_name, input_name))
+                overlaps = True
+
+            if overlaps:
+                aliases.append((output_name, output_kind, input_name, input_kind))
 
     return tuple(aliases)
 

--- a/src/ninetoothed/backends/materializers/triton.py
+++ b/src/ninetoothed/backends/materializers/triton.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 import tempfile
 import types
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 from ninetoothed.backends.core import BuiltArtifact, Target
@@ -192,6 +192,8 @@ def _candidate_launch(compilation, launch, kernel, candidate):
 
 
 def _triton_prepare_invocation(function, kernel):
+    from ninetoothed.compiler.runtime import _is_cacheable_runtime_literal
+
     if kernel is None:
         return None
 
@@ -213,7 +215,100 @@ def _triton_prepare_invocation(function, kernel):
     partial_args = getattr(function, "args", ())
     partial_keywords = getattr(function, "keywords", None) or {}
 
-    def prepare(values):
+    @dataclass(frozen=True)
+    class ValueRef:
+        index: int
+
+        def resolve(self, values, _args, _kwargs):
+            return values[self.index]
+
+    @dataclass(frozen=True)
+    class CallRef:
+        kind: str
+        key: object
+
+        def resolve(self, _values, args, kwargs):
+            return args[self.key] if self.kind == "positional" else kwargs[self.key]
+
+    @dataclass(frozen=True)
+    class Literal:
+        value: object
+
+        def resolve(self, _values, _args, _kwargs):
+            return self.value
+
+    @dataclass(frozen=True)
+    class BoundCall:
+        function: object
+        args: tuple
+        kwargs: tuple
+
+        def invoke(self, values, args, kwargs):
+            self.function(
+                *(value.resolve(values, args, kwargs) for value in self.args),
+                **{
+                    name: value.resolve(values, args, kwargs)
+                    for name, value in self.kwargs
+                },
+            )
+
+    @dataclass(frozen=True)
+    class InvocationPlan:
+        call: object
+        requires_values: bool
+
+        def __call__(self, values, args, kwargs):
+            if self.requires_values:
+                self.call.invoke(values, args, kwargs)
+            else:
+                self.call(args, kwargs)
+
+    def plan_value(value, values, static_values, call_sources):
+        for index, candidate in enumerate(values):
+            if value is candidate:
+                if call_sources is not None and call_sources[index] is not None:
+                    return CallRef(*call_sources[index])
+
+                return (
+                    Literal(static_values[index])
+                    if static_values is not None
+                    else ValueRef(index)
+                )
+
+        if hasattr(value, "data_ptr") or (
+            hasattr(value, "shape") and hasattr(value, "dtype")
+        ):
+            return None
+
+        if _is_cacheable_runtime_literal(value):
+            return Literal(value)
+
+        return None
+
+    def build_direct_invocation(function, args, kwargs):
+        namespace = {"_function": function}
+        expressions = []
+
+        def expression(value):
+            if isinstance(value, CallRef):
+                container = "_args" if value.kind == "positional" else "_kwargs"
+                return f"{container}[{value.key!r}]"
+
+            name = f"_value_{len(namespace)}"
+            namespace[name] = value.value
+
+            return name
+
+        expressions.extend(expression(value) for value in args)
+        expressions.extend(f"{name}={expression(value)}" for name, value in kwargs)
+        source = (
+            "def invoke(_args, _kwargs):\n    _function(" + ", ".join(expressions) + ")"
+        )
+        exec(compile(source, "<ninetoothed-triton-invocation>", "exec"), namespace)
+
+        return namespace["invoke"]
+
+    def prepare(values, static_values=None, call_sources=None):
         calls = []
 
         class KernelProxy:
@@ -240,16 +335,43 @@ def _triton_prepare_invocation(function, kernel):
             *partial_args,
             **partial_keywords,
         )(*values)
-        bound_calls = tuple(calls)
 
-        if not bound_calls:
+        if len(calls) != 1:
             return None
 
-        def invoke():
-            for bound_kernel, args, kwargs in bound_calls:
-                bound_kernel(*args, **kwargs)
+        bound_kernel, args, kwargs = calls[0]
+        planned_args = tuple(
+            plan_value(value, values, static_values, call_sources) for value in args
+        )
+        planned_kwargs = tuple(
+            (
+                name,
+                plan_value(value, values, static_values, call_sources),
+            )
+            for name, value in kwargs.items()
+        )
 
-        return invoke
+        if any(value is None for value in planned_args) or any(
+            value is None for _name, value in planned_kwargs
+        ):
+            return None
+
+        planned_call = BoundCall(bound_kernel, planned_args, planned_kwargs)
+
+        requires_values = any(
+            isinstance(value, ValueRef) for value in planned_args
+        ) or any(isinstance(value, ValueRef) for _name, value in planned_kwargs)
+
+        if requires_values:
+            return InvocationPlan(planned_call, True)
+
+        direct_call = build_direct_invocation(
+            planned_call.function,
+            planned_call.args,
+            planned_call.kwargs,
+        )
+
+        return InvocationPlan(direct_call, False)
 
     return prepare
 
@@ -284,6 +406,7 @@ def _runtime_outputs_alias_inputs(abi, public):
 
 def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
     from ninetoothed.compiler.runtime import (
+        _arm_prepared_runtime_launch,
         _empty_launch,
         _first_output,
         _public_values,
@@ -295,6 +418,17 @@ def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
     active = None
     prepared_calls = {}
 
+    def evict(identity, token):
+        nonlocal active, active_identity
+        cached = prepared_calls.get(identity)
+
+        if cached is not None and cached[2].cache_token is token:
+            prepared_calls.pop(identity, None)
+
+        if active is not None and active[2].cache_token is token:
+            active = None
+            active_identity = None
+
     def activate(identity, entry):
         nonlocal active, active_identity
         active_identity = identity
@@ -302,23 +436,45 @@ def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
         handle._selected_tuning_candidate = candidates_by_launch[entry[1]]
 
     def remember(identity, key, selected, prepared):
+        token = object()
+
+        def collected(_reference):
+            evict(identity, token)
+
+        prepared = _arm_prepared_runtime_launch(prepared, collected, token)
+
+        if prepared is None:
+            return None
+
         entry = (key, selected, prepared)
         _remember_verified_runtime_call(prepared_calls, identity, entry)
         activate(identity, entry)
 
+        return prepared
+
     def launch(*args, **kwargs):
+        active_snapshot = active
+        active_identity_snapshot = active_identity
         identity = _runtime_call_identity(args, kwargs)
 
         if (
-            active is not None
-            and identity == active_identity
-            and active[2].guard.matches(args, kwargs, identity_verified=True)
+            active_snapshot is not None
+            and identity == active_identity_snapshot
+            and active_snapshot[2].matches(
+                args,
+                kwargs,
+                identity_verified=True,
+            )
         ):
-            return active[1]._ninetoothed_invoke_prepared(active[2], args, kwargs)
+            return active_snapshot[1]._ninetoothed_invoke_prepared(
+                active_snapshot[2],
+                args,
+                kwargs,
+            )
 
         cached = prepared_calls.pop(identity, None)
 
-        if cached is not None and cached[2].guard.matches(
+        if cached is not None and cached[2].matches(
             args,
             kwargs,
             identity_verified=True,
@@ -367,9 +523,13 @@ def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
             return result
 
         prepared = selected._ninetoothed_prepare(args, kwargs, public=public)
-        remember(identity, key, selected, prepared)
+        cached_prepared = remember(identity, key, selected, prepared)
 
-        return selected._ninetoothed_invoke_prepared(prepared, args, kwargs)
+        return selected._ninetoothed_invoke_prepared(
+            cached_prepared or prepared,
+            args,
+            kwargs,
+        )
 
     return launch
 

--- a/src/ninetoothed/compiler/driver.py
+++ b/src/ninetoothed/compiler/driver.py
@@ -444,6 +444,33 @@ def _tensor_access_modes(program: ssa.Program) -> dict[str, str]:
         for operation in operations
         for result in operation.results
     }
+    block_sources = {}
+
+    for operation in operations:
+        if operation.opcode != "scf.for" or not operation.regions:
+            continue
+
+        block_args = operation.regions[0].args
+
+        if not block_args:
+            continue
+
+        block_sources[block_args[0].name] = operation.operands[:3]
+        yield_operation = next(
+            (
+                nested
+                for nested in reversed(operation.regions[0].operations)
+                if nested.opcode == "scf.yield"
+            ),
+            None,
+        )
+        yielded = yield_operation.operands if yield_operation is not None else ()
+
+        for block_arg, initial, result in zip(
+            block_args[1:], operation.operands[3:], yielded
+        ):
+            block_sources[block_arg.name] = (initial, result)
+
     dependencies: dict[str, frozenset[str]] = {}
 
     def data_dependencies(name, visiting=frozenset()):
@@ -455,6 +482,16 @@ def _tensor_access_modes(program: ssa.Program) -> dict[str, str]:
 
         if name in visiting:
             return frozenset()
+
+        sources = block_sources.get(name)
+
+        if sources is not None:
+            result = frozenset().union(
+                *(data_dependencies(source, visiting | {name}) for source in sources)
+            )
+            dependencies[name] = result
+
+            return result
 
         producer = producers.get(name)
 
@@ -475,26 +512,43 @@ def _tensor_access_modes(program: ssa.Program) -> dict[str, str]:
             )
         )
         dependencies[name] = result
+
         return result
 
     reads = set()
     writes = set()
 
-    for operation in operations:
-        if operation.opcode == "mem.store" and len(operation.operands) >= 2:
-            reads.update(data_dependencies(operation.operands[0]))
+    def visit_effects(effect_operations, control_operands=()):
+        for operation in effect_operations:
+            if operation.opcode == "mem.store" and len(operation.operands) >= 2:
+                reads.update(data_dependencies(operation.operands[0]))
 
-            for index in operation.attrs.get("indices", ()):
-                reads.update(data_dependencies(str(index)))
+                for index in operation.attrs.get("indices", ()):
+                    reads.update(data_dependencies(str(index)))
 
-            writes.update(data_dependencies(operation.operands[1]))
-        elif operation.opcode == "mem.atomic_add" and operation.operands:
-            target = data_dependencies(operation.operands[0])
-            reads.update(target)
-            writes.update(target)
+                writes.update(data_dependencies(operation.operands[1]))
+            elif operation.opcode == "mem.atomic_add" and operation.operands:
+                target = data_dependencies(operation.operands[0])
+                reads.update(target)
+                writes.update(target)
 
-            for operand in operation.operands[1:]:
-                reads.update(data_dependencies(operand))
+                for operand in operation.operands[1:]:
+                    reads.update(data_dependencies(operand))
+
+            if operation.opcode in {"mem.store", "mem.atomic_add"}:
+                for operand in control_operands:
+                    reads.update(data_dependencies(operand))
+
+            control_arity = {"scf.if": 1, "scf.for": 3}.get(operation.opcode, 0)
+            nested_controls = (
+                *control_operands,
+                *operation.operands[:control_arity],
+            )
+
+            for region in operation.regions:
+                visit_effects(region.operations, nested_controls)
+
+    visit_effects(program.blocks[0].operations)
 
     writes.update(value.name for value in program.outputs if value.name in tensor_names)
 

--- a/src/ninetoothed/compiler/driver.py
+++ b/src/ninetoothed/compiler/driver.py
@@ -18,7 +18,7 @@ from ninetoothed.backends.core import (
 )
 from ninetoothed.frontend.layout import tensor_specs
 from ninetoothed.frontend.python import LoweringError, from_application
-from ninetoothed.ir import IndexExpr, Kernel, LaunchABI, LaunchBinding, LaunchPlan
+from ninetoothed.ir import IndexExpr, Kernel, LaunchABI, LaunchBinding, LaunchPlan, ssa
 from ninetoothed.naming import is_meta, remove_prefixes
 
 from .specialization import (
@@ -309,6 +309,7 @@ def _compile_kernel(request: CompileRequest) -> Compilation:
         specs,
         artifact,
         arranged,
+        program=program,
         meta_defaults=scheduled_defaults,
     )
     launch_plan = _launch_plan(launch_abi, artifact, request, arranged)
@@ -343,6 +344,7 @@ def _launch_abi(
     artifact: Artifact,
     arranged,
     *,
+    program: ssa.Program,
     meta_defaults: Mapping[str, int] | None = None,
 ) -> LaunchABI:
     by_name = {spec.name: spec for spec in specs}
@@ -355,37 +357,44 @@ def _launch_abi(
         name: getattr(getattr(tensor, "source", tensor), "value", None)
         for name, tensor in zip(params, arranged)
     }
+    output_names = tuple(artifact.metadata.get("outputs", ()))
+    access_modes = _tensor_access_modes(program)
     bindings = []
 
     for name in (
         *artifact.metadata.get("variables", ()),
-        *artifact.metadata.get("outputs", ()),
+        *output_names,
     ):
         if name in auxiliary_bindings:
             auxiliary = auxiliary_bindings[name]
+            kind = str(auxiliary["kind"])
+            source = str(auxiliary["source"])
             bindings.append(
                 LaunchBinding(
                     name=name,
-                    kind=str(auxiliary["kind"]),
-                    source=str(auxiliary["source"]),
+                    kind=kind,
+                    source=source,
+                    access=_binding_access(kind, source, access_modes, output_names),
                 )
             )
             continue
 
         spec = by_name[name]
+        kind = (
+            "constexpr"
+            if spec.constexpr
+            else "scalar"
+            if spec.ndim == 0
+            else "jagged_values"
+            if spec.jagged_dim is not None
+            else "tensor"
+        )
         bindings.append(
             LaunchBinding(
                 name=name,
-                kind=(
-                    "constexpr"
-                    if spec.constexpr
-                    else "scalar"
-                    if spec.ndim == 0
-                    else "jagged_values"
-                    if spec.jagged_dim is not None
-                    else "tensor"
-                ),
+                kind=kind,
                 source=name,
+                access=_binding_access(kind, name, access_modes, output_names),
             )
         )
 
@@ -406,9 +415,108 @@ def _launch_abi(
     return LaunchABI(
         public_args=tuple(params),
         kernel_args=tuple(bindings),
-        outputs=tuple(artifact.metadata.get("outputs", ())),
+        outputs=output_names,
         shape_params=shape_params,
     )
+
+
+def _binding_access(kind, source, access_modes, output_names):
+    if kind == "jagged_offsets":
+        return "read"
+
+    if kind not in {"tensor", "jagged_values"}:
+        return None
+
+    return access_modes.get(source, "write" if source in output_names else "read")
+
+
+def _tensor_access_modes(program: ssa.Program) -> dict[str, str]:
+    tensor_names = {
+        value.name for value in program.inputs if value.type.kind == "tensor"
+    }
+    operations = tuple(
+        operation
+        for block in program.blocks
+        for operation in _walk_ssa_operations(block.operations)
+    )
+    producers = {
+        result.name: operation
+        for operation in operations
+        for result in operation.results
+    }
+    dependencies: dict[str, frozenset[str]] = {}
+
+    def data_dependencies(name, visiting=frozenset()):
+        if name in tensor_names:
+            return frozenset((name,))
+
+        if name in dependencies:
+            return dependencies[name]
+
+        if name in visiting:
+            return frozenset()
+
+        producer = producers.get(name)
+
+        if producer is None or producer.opcode.startswith(("index.", "shape.")):
+            return frozenset()
+
+        nested_yields = (
+            operand
+            for region in producer.regions
+            for operation in _walk_ssa_operations(region.operations)
+            if operation.opcode == "scf.yield"
+            for operand in operation.operands
+        )
+        result = frozenset().union(
+            *(
+                data_dependencies(operand, visiting | {name})
+                for operand in (*producer.operands, *nested_yields)
+            )
+        )
+        dependencies[name] = result
+        return result
+
+    reads = set()
+    writes = set()
+
+    for operation in operations:
+        if operation.opcode == "mem.store" and len(operation.operands) >= 2:
+            reads.update(data_dependencies(operation.operands[0]))
+
+            for index in operation.attrs.get("indices", ()):
+                reads.update(data_dependencies(str(index)))
+
+            writes.update(data_dependencies(operation.operands[1]))
+        elif operation.opcode == "mem.atomic_add" and operation.operands:
+            target = data_dependencies(operation.operands[0])
+            reads.update(target)
+            writes.update(target)
+
+            for operand in operation.operands[1:]:
+                reads.update(data_dependencies(operand))
+
+    writes.update(value.name for value in program.outputs if value.name in tensor_names)
+
+    return {
+        name: (
+            "read_write"
+            if name in reads and name in writes
+            else "write"
+            if name in writes
+            else "read"
+        )
+        for name in tensor_names
+        if name in reads or name in writes
+    }
+
+
+def _walk_ssa_operations(operations):
+    for operation in operations:
+        yield operation
+
+        for region in operation.regions:
+            yield from _walk_ssa_operations(region.operations)
 
 
 def _launch_plan(

--- a/src/ninetoothed/compiler/driver.py
+++ b/src/ninetoothed/compiler/driver.py
@@ -427,7 +427,10 @@ def _binding_access(kind, source, access_modes, output_names):
     if kind not in {"tensor", "jagged_values"}:
         return None
 
-    return access_modes.get(source, "write" if source in output_names else "read")
+    return access_modes.get(
+        source,
+        "read_write" if source in output_names else "read",
+    )
 
 
 def _tensor_access_modes(program: ssa.Program) -> dict[str, str]:

--- a/src/ninetoothed/compiler/runtime.py
+++ b/src/ninetoothed/compiler/runtime.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import sys
 import tempfile
+import weakref
 from dataclasses import dataclass, replace
 from pathlib import Path
 from types import SimpleNamespace
@@ -267,6 +268,17 @@ def _runtime_dtypes(compilation, public) -> dict[str, str]:
     return result
 
 
+def _is_cacheable_runtime_literal(value) -> bool:
+    return (
+        value is None
+        or type(value) in (bool, int, float, complex, str, bytes)
+        or (
+            isinstance(value, tuple)
+            and all(_is_cacheable_runtime_literal(item) for item in value)
+        )
+    )
+
+
 @dataclass(frozen=True)
 class _RuntimeValueContract:
     is_tensor: bool
@@ -284,6 +296,10 @@ class _RuntimeValueContract:
     data_ptr_callable: bool = False
     storage_offset_callable: bool = False
     tensor_state: tuple | None = None
+
+    @property
+    def cacheable(self) -> bool:
+        return self.is_tensor or _is_cacheable_runtime_literal(self.value)
 
     @classmethod
     def from_value(cls, value, *, compare_scalar_tensor=False):
@@ -367,6 +383,12 @@ class _VerifiedRuntimeCall:
     positional: tuple[_RuntimeValueContract, ...]
     keywords: tuple[tuple[str, _RuntimeValueContract], ...]
     two_tensor_state: tuple | None = None
+
+    @property
+    def cacheable(self) -> bool:
+        return all(contract.cacheable for contract in self.positional) and all(
+            contract.cacheable for _name, contract in self.keywords
+        )
 
     @classmethod
     def from_call(cls, abi, args, kwargs):
@@ -496,13 +518,274 @@ class _VerifiedRuntimeCall:
         return True
 
 
+def _jagged_tensor_state(value):
+    try:
+        return (
+            type(value),
+            value.shape,
+            value.stride(),
+            value.dtype,
+            value.device,
+            value.data_ptr(),
+            value.storage_offset(),
+            getattr(value, "_version", None),
+        )
+    except (AttributeError, RuntimeError, TypeError):
+        return None
+
+
+@dataclass(frozen=True)
+class _JaggedOwnerContract:
+    owner: weakref.ReferenceType
+    values_state: tuple
+    offsets_state: tuple
+
+    @classmethod
+    def from_owner(cls, owner):
+        try:
+            reference = weakref.ref(owner)
+            values_state = _jagged_tensor_state(owner.values())
+            offsets_state = _jagged_tensor_state(owner.offsets())
+        except (AttributeError, RuntimeError, TypeError):
+            return None
+
+        if values_state is None or offsets_state is None:
+            return None
+
+        return cls(reference, values_state, offsets_state)
+
+    def matches(self):
+        owner = self.owner()
+
+        if owner is None:
+            return False
+
+        try:
+            state = (
+                _jagged_tensor_state(owner.values()),
+                _jagged_tensor_state(owner.offsets()),
+            )
+        except (AttributeError, RuntimeError, TypeError):
+            return False
+
+        return state == (self.values_state, self.offsets_state)
+
+
+@dataclass(frozen=True)
+class _PreparedBoundValue:
+    value: Any = None
+    tensor: weakref.ReferenceType | None = None
+    owner: weakref.ReferenceType | None = None
+    binding: LaunchBinding | None = None
+    flatten_tensor: bool = False
+
+    @classmethod
+    def from_value(cls, binding, value, public, *, flatten_tensors):
+        if binding.kind.startswith("jagged_"):
+            try:
+                owner = weakref.ref(public[binding.source])
+            except (KeyError, TypeError):
+                return None
+
+            return cls(
+                owner=owner,
+                binding=binding,
+                flatten_tensor=flatten_tensors
+                and binding.kind in {"jagged_values", "jagged_offsets"},
+            )
+
+        is_tensor = hasattr(value, "shape") and hasattr(value, "dtype")
+
+        if binding.kind != "tensor":
+            return cls(value=value) if _is_cacheable_runtime_literal(value) else None
+
+        if not is_tensor:
+            return None
+
+        try:
+            tensor = weakref.ref(value)
+        except TypeError:
+            return None
+
+        return cls(tensor=tensor, flatten_tensor=flatten_tensors)
+
+    def resolve(self, *, flatten_tensor=False):
+        if self.binding is not None:
+            owner = self.owner()
+
+            if owner is None:
+                return None, None
+
+            value = _jagged_binding_value(self.binding, owner)
+        elif self.tensor is not None:
+            value = self.tensor()
+        else:
+            return self.value, None
+
+        if value is None:
+            return None, None
+
+        if (
+            not self.flatten_tensor
+            or not flatten_tensor
+            or not hasattr(value, "as_strided")
+        ):
+            return value, None
+
+        storage_numel = value.untyped_storage().nbytes() // value.element_size()
+        storage_offset = value.storage_offset()
+        flattened = value.as_strided(
+            (storage_numel - storage_offset,),
+            (1,),
+            storage_offset=storage_offset,
+        )
+
+        return flattened, flattened
+
+
+@dataclass(frozen=True)
+class _RuntimeBindingPlan:
+    values: tuple[_PreparedBoundValue, ...]
+    jagged_owners: tuple[_JaggedOwnerContract, ...]
+
+    @classmethod
+    def from_values(cls, bindings, values, public, *, flatten_tensors):
+        planned = tuple(
+            _PreparedBoundValue.from_value(
+                binding,
+                value,
+                public,
+                flatten_tensors=flatten_tensors,
+            )
+            for binding, value in zip(bindings, values)
+        )
+
+        if any(value is None for value in planned):
+            return None
+
+        jagged_owners = []
+        owner_ids = set()
+
+        for value in planned:
+            if value.owner is None:
+                continue
+
+            owner = value.owner()
+
+            if owner is None:
+                return None
+
+            identity = id(owner)
+
+            if identity in owner_ids:
+                continue
+
+            contract = _JaggedOwnerContract.from_owner(owner)
+
+            if contract is None:
+                return None
+
+            owner_ids.add(identity)
+            jagged_owners.append(contract)
+
+        return cls(planned, tuple(jagged_owners))
+
+    @property
+    def owner_refs(self):
+        return tuple(
+            owner
+            for value in self.values
+            for owner in (value.tensor, value.owner)
+            if owner is not None
+        )
+
+    def static_values(self):
+        values = []
+
+        for planned in self.values:
+            if planned.binding is not None:
+                return None
+
+            if planned.tensor is None:
+                values.append(planned.value)
+                continue
+
+            value = planned.tensor()
+
+            if value is None:
+                return None
+
+            values.append(None)
+
+        return tuple(values)
+
+    def call_sources(self, bindings, args, kwargs, public_args):
+        positions = {name: index for index, name in enumerate(public_args[: len(args)])}
+        sources = []
+
+        for binding, planned in zip(bindings, self.values):
+            if planned.tensor is None:
+                sources.append(None)
+            elif binding.source in positions:
+                sources.append(("positional", positions[binding.source]))
+            elif binding.source in kwargs:
+                sources.append(("keyword", binding.source))
+            else:
+                return None
+
+        return tuple(sources)
+
+    def resolve(self, *, flatten_tensors=False):
+        values = []
+        keepalive = []
+
+        for planned in self.values:
+            value, temporary = planned.resolve(flatten_tensor=flatten_tensors)
+
+            if (
+                planned.tensor is not None or planned.owner is not None
+            ) and value is None:
+                return None
+
+            values.append(value)
+
+            if temporary is not None:
+                keepalive.append(temporary)
+
+        return tuple(values), tuple(keepalive)
+
+
 @dataclass(frozen=True)
 class _PreparedRuntimeLaunch:
     guard: _VerifiedRuntimeCall
-    values: tuple
-    keepalive: tuple
+    binding_plan: _RuntimeBindingPlan | None
+    owner_refs: tuple[weakref.ReferenceType, ...] | None
     empty: bool
-    invocation: Callable[[], Any] | None = None
+    invocation_plan: Callable[[tuple, tuple, dict], Any] | None = None
+    cache_token: object | None = None
+
+    @property
+    def cacheable(self) -> bool:
+        return (
+            self.guard.cacheable
+            and self.owner_refs is not None
+            and (self.empty or self.binding_plan is not None)
+        )
+
+    def matches(self, args, kwargs, *, identity_verified=False, call_key=None):
+        if not self.guard.matches(
+            args,
+            kwargs,
+            identity_verified=identity_verified,
+            call_key=call_key,
+        ):
+            return False
+
+        return (
+            self.binding_plan is None
+            or not self.binding_plan.jagged_owners
+            or all(contract.matches() for contract in self.binding_plan.jagged_owners)
+        )
 
 
 _VERIFIED_RUNTIME_CALL_CACHE_SIZE = 8
@@ -525,10 +808,74 @@ def _remember_verified_runtime_call(prepared_calls, identity, prepared):
     prepared_calls[identity] = prepared
 
 
+def _runtime_owner_refs(args, kwargs, binding_plan=None):
+    refs = []
+    identities = set()
+
+    def append(owner, reference=None):
+        identity = id(owner)
+
+        if identity in identities:
+            return True
+
+        try:
+            reference = reference or weakref.ref(owner)
+        except TypeError:
+            return False
+
+        identities.add(identity)
+        refs.append(reference)
+
+        return True
+
+    for value in (*args, *kwargs.values()):
+        if getattr(value, "shape", None) is None or not hasattr(value, "dtype"):
+            continue
+
+        if not append(value):
+            return None
+
+    if binding_plan is not None:
+        for reference in binding_plan.owner_refs:
+            owner = reference()
+
+            if owner is None or not append(owner, reference):
+                return None
+
+    return tuple(refs)
+
+
+def _arm_prepared_runtime_launch(prepared, callback, token):
+    if not prepared.cacheable:
+        return None
+
+    owners = tuple(owner() for owner in prepared.owner_refs)
+
+    if any(owner is None for owner in owners):
+        return None
+
+    return replace(
+        prepared,
+        owner_refs=tuple(weakref.ref(owner, callback) for owner in owners),
+        cache_token=token,
+    )
+
+
 def _verified_runtime_launch(launch):
     active_identity = None
     active = None
     prepared_calls = {}
+
+    def evict(identity, token):
+        nonlocal active, active_identity
+        cached = prepared_calls.get(identity)
+
+        if cached is not None and cached.cache_token is token:
+            prepared_calls.pop(identity, None)
+
+        if active is not None and active.cache_token is token:
+            active = None
+            active_identity = None
 
     def activate(identity, prepared):
         nonlocal active, active_identity
@@ -536,13 +883,26 @@ def _verified_runtime_launch(launch):
         active = prepared
 
     def remember(identity, prepared):
-        _remember_verified_runtime_call(prepared_calls, identity, prepared)
-        activate(identity, prepared)
+        token = object()
+
+        def collected(_reference):
+            evict(identity, token)
+
+        prepared = _arm_prepared_runtime_launch(prepared, collected, token)
+
+        if prepared is not None:
+            _remember_verified_runtime_call(prepared_calls, identity, prepared)
+            activate(identity, prepared)
+
+        return prepared
 
     def verified(*args, **kwargs):
+        active_snapshot = active
+        active_identity_snapshot = active_identity
         call_key = (
-            active.guard.call_key(args, kwargs)
-            if active is not None and active.guard.two_tensor_state is not None
+            active_snapshot.guard.call_key(args, kwargs)
+            if active_snapshot is not None
+            and active_snapshot.guard.two_tensor_state is not None
             else None
         )
         identity = (
@@ -552,20 +912,24 @@ def _verified_runtime_launch(launch):
         )
 
         if (
-            active is not None
-            and identity == active_identity
-            and active.guard.matches(
+            active_snapshot is not None
+            and identity == active_identity_snapshot
+            and active_snapshot.matches(
                 args,
                 kwargs,
                 identity_verified=True,
                 call_key=call_key,
             )
         ):
-            return launch._ninetoothed_invoke_prepared(active, args, kwargs)
+            return launch._ninetoothed_invoke_prepared(
+                active_snapshot,
+                args,
+                kwargs,
+            )
 
         cached = prepared_calls.pop(identity, None)
 
-        if cached is not None and cached.guard.matches(
+        if cached is not None and cached.matches(
             args,
             kwargs,
             identity_verified=True,
@@ -577,14 +941,18 @@ def _verified_runtime_launch(launch):
             return launch._ninetoothed_invoke_prepared(cached, args, kwargs)
 
         prepared = launch._ninetoothed_prepare(args, kwargs)
-        remember(
+        cached_prepared = remember(
             _two_tensor_call_identity(prepared.guard.two_tensor_state)
             if prepared.guard.two_tensor_state is not None
             else identity,
             prepared,
         )
 
-        return launch._ninetoothed_invoke_prepared(prepared, args, kwargs)
+        return launch._ninetoothed_invoke_prepared(
+            cached_prepared or prepared,
+            args,
+            kwargs,
+        )
 
     return verified
 
@@ -609,38 +977,89 @@ def _runtime_wrapper(
         if _empty_launch(abi, public):
             return _PreparedRuntimeLaunch(
                 _VerifiedRuntimeCall.from_call(abi, args, kwargs),
-                (),
-                (),
+                None,
+                _runtime_owner_refs(args, kwargs),
                 True,
             )
 
-        values, keepalive = _bound_values(abi, bound_public, scalar_mode="value")
+        values, _keepalive = _bound_values(abi, bound_public, scalar_mode="value")
         bindings = abi.kernel_args
 
-        if low_level:
-            values, flattened = _flatten_ffi_tensor_args(bindings, values)
-            keepalive.extend(flattened)
+        binding_plan = _RuntimeBindingPlan.from_values(
+            bindings,
+            values,
+            bound_public,
+            flatten_tensors=low_level,
+        )
+        resolved = (
+            binding_plan.resolve(flatten_tensors=low_level)
+            if binding_plan is not None
+            else None
+        )
+        resolved_values = resolved[0] if resolved is not None else ()
+        static_values = (
+            binding_plan.static_values() if binding_plan is not None else None
+        )
+        call_sources = (
+            binding_plan.call_sources(
+                bindings,
+                args,
+                kwargs,
+                abi.public_args,
+            )
+            if binding_plan is not None and static_values is not None
+            else None
+        )
 
-        values = tuple(values)
+        if static_values is not None and call_sources is None:
+            static_values = None
+
+        invocation_plan = (
+            prepare_invocation(resolved_values, static_values, call_sources)
+            if prepare_invocation is not None and resolved is not None
+            else None
+        )
+        owner_refs = _runtime_owner_refs(args, kwargs, binding_plan)
 
         return _PreparedRuntimeLaunch(
             _VerifiedRuntimeCall.from_call(abi, args, kwargs),
-            values,
-            tuple(keepalive),
+            binding_plan,
+            owner_refs,
             False,
-            prepare_invocation(values) if prepare_invocation is not None else None,
+            invocation_plan,
         )
 
     def invoke(prepared, args, kwargs):
         if prepared.empty:
             return _first_output_from_call(abi, args, kwargs)
 
-        if prepared.invocation is not None:
-            result = prepared.invocation()
-        else:
-            result = (
-                function(*prepared.values) if low_level else function(*args, **kwargs)
+        invocation_plan = prepared.invocation_plan
+        static_invocation = invocation_plan is not None and not getattr(
+            invocation_plan,
+            "requires_values",
+            True,
+        )
+        resolved = (
+            ((), ())
+            if static_invocation
+            else (
+                prepared.binding_plan.resolve(flatten_tensors=low_level)
+                if prepared.binding_plan is not None
+                else None
             )
+        )
+
+        if resolved is None:
+            return launch(*args, **kwargs)
+
+        values, keepalive = resolved
+
+        if invocation_plan is not None:
+            result = invocation_plan(values, args, kwargs)
+        else:
+            result = function(*values) if low_level else function(*args, **kwargs)
+
+        del keepalive
 
         if result is not None and not abi.outputs:
             return result

--- a/src/ninetoothed/compiler/runtime.py
+++ b/src/ninetoothed/compiler/runtime.py
@@ -353,10 +353,12 @@ class _RuntimeValueContract:
 
         if current_state != self.tensor_state:
             return False
+
         if self.scalar_value is None:
             return True
 
         item = value.item()
+
         return type(item) is self.scalar_value[0] and item == self.scalar_value[1]
 
 
@@ -440,6 +442,7 @@ class _VerifiedRuntimeCall:
             return None
 
         first, second = args
+
         return (
             expected_name,
             type(scalar),
@@ -570,6 +573,7 @@ def _verified_runtime_launch(launch):
         ):
             prepared_calls[identity] = cached
             activate(identity, cached)
+
             return launch._ninetoothed_invoke_prepared(cached, args, kwargs)
 
         prepared = launch._ninetoothed_prepare(args, kwargs)
@@ -579,6 +583,7 @@ def _verified_runtime_launch(launch):
             else identity,
             prepared,
         )
+
         return launch._ninetoothed_invoke_prepared(prepared, args, kwargs)
 
     return verified
@@ -890,6 +895,7 @@ def _first_output_from_call(abi, args, kwargs):
 
     name = abi.outputs[0]
     index = abi.public_args.index(name)
+
     return args[index] if index < len(args) else kwargs[name]
 
 

--- a/src/ninetoothed/compiler/runtime.py
+++ b/src/ninetoothed/compiler/runtime.py
@@ -7,10 +7,10 @@ import os
 import shutil
 import sys
 import tempfile
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Callable
 
 from ninetoothed.backends.core import BuiltArtifact, Target
 from ninetoothed.compiler.cache import (
@@ -267,32 +267,405 @@ def _runtime_dtypes(compilation, public) -> dict[str, str]:
     return result
 
 
+@dataclass(frozen=True)
+class _RuntimeValueContract:
+    is_tensor: bool
+    identity: int
+    value_type: type
+    value: Any = None
+    shape: tuple | None = None
+    stride: tuple | None = None
+    dtype: Any = None
+    device: Any = None
+    data_ptr: int | None = None
+    storage_offset: int | None = None
+    scalar_value: tuple[type, Any] | None = None
+    stride_callable: bool = False
+    data_ptr_callable: bool = False
+    storage_offset_callable: bool = False
+    tensor_state: tuple | None = None
+
+    @classmethod
+    def from_value(cls, value, *, compare_scalar_tensor=False):
+        shape = getattr(value, "shape", None)
+
+        if shape is None or not hasattr(value, "dtype"):
+            return cls(False, 0, type(value), value=value)
+
+        stride = getattr(value, "stride", None)
+        data_ptr = getattr(value, "data_ptr", None)
+        storage_offset = getattr(value, "storage_offset", None)
+        shape = tuple(shape)
+        stride_callable = callable(stride)
+        data_ptr_callable = callable(data_ptr)
+        storage_offset_callable = callable(storage_offset)
+        stride_value = tuple(stride()) if stride_callable else None
+        device = getattr(value, "device", None)
+        data_ptr_value = data_ptr() if data_ptr_callable else None
+        storage_offset_value = storage_offset() if storage_offset_callable else None
+        scalar_value = None
+
+        if compare_scalar_tensor and not shape:
+            item = value.item()
+            scalar_value = (type(item), item)
+
+        return cls(
+            True,
+            id(value),
+            type(value),
+            shape=shape,
+            stride=stride_value,
+            dtype=value.dtype,
+            device=device,
+            data_ptr=data_ptr_value,
+            storage_offset=storage_offset_value,
+            scalar_value=scalar_value,
+            stride_callable=stride_callable,
+            data_ptr_callable=data_ptr_callable,
+            storage_offset_callable=storage_offset_callable,
+            tensor_state=(
+                shape,
+                stride_value,
+                value.dtype,
+                device,
+                data_ptr_value,
+                storage_offset_value,
+            ),
+        )
+
+    def matches(self, value, *, identity_verified=False) -> bool:
+        if not self.is_tensor:
+            return type(value) is self.value_type and value == self.value
+
+        if not identity_verified and (
+            id(value) != self.identity or type(value) is not self.value_type
+        ):
+            return False
+
+        current_state = (
+            getattr(value, "shape", None),
+            value.stride() if self.stride_callable else None,
+            getattr(value, "dtype", None),
+            getattr(value, "device", None),
+            value.data_ptr() if self.data_ptr_callable else None,
+            value.storage_offset() if self.storage_offset_callable else None,
+        )
+
+        if current_state != self.tensor_state:
+            return False
+        if self.scalar_value is None:
+            return True
+
+        item = value.item()
+        return type(item) is self.scalar_value[0] and item == self.scalar_value[1]
+
+
+@dataclass(frozen=True)
+class _VerifiedRuntimeCall:
+    positional: tuple[_RuntimeValueContract, ...]
+    keywords: tuple[tuple[str, _RuntimeValueContract], ...]
+    two_tensor_state: tuple | None = None
+
+    @classmethod
+    def from_call(cls, abi, args, kwargs):
+        scalar_sources = {
+            binding.source
+            for binding in abi.kernel_args
+            if binding.kind in {"scalar", "constexpr", "meta"}
+        }
+        positional_names = abi.public_args[: len(args)]
+        positional = tuple(
+            _RuntimeValueContract.from_value(
+                value,
+                compare_scalar_tensor=name in scalar_sources,
+            )
+            for name, value in zip(positional_names, args)
+        )
+        keywords = tuple(
+            (
+                name,
+                _RuntimeValueContract.from_value(
+                    value,
+                    compare_scalar_tensor=name in scalar_sources,
+                ),
+            )
+            for name, value in kwargs.items()
+        )
+        two_tensor_state = None
+
+        if (
+            len(positional) == 2
+            and all(
+                contract.is_tensor
+                and contract.stride_callable
+                and contract.data_ptr_callable
+                and contract.storage_offset_callable
+                for contract in positional
+            )
+            and len(keywords) == 1
+            and not keywords[0][1].is_tensor
+        ):
+            scalar = keywords[0][1]
+
+            try:
+                hash(scalar.value)
+            except TypeError:
+                pass
+            else:
+                two_tensor_state = (
+                    keywords[0][0],
+                    scalar.value_type,
+                    scalar.value,
+                    positional[0].identity,
+                    positional[0].value_type,
+                    *positional[0].tensor_state,
+                    positional[1].identity,
+                    positional[1].value_type,
+                    *positional[1].tensor_state,
+                )
+        return cls(positional, keywords, two_tensor_state)
+
+    def call_key(self, args, kwargs):
+        if self.two_tensor_state is None or len(args) != 2 or len(kwargs) != 1:
+            return None
+
+        expected_name = self.keywords[0][0]
+
+        try:
+            scalar = kwargs[expected_name]
+        except KeyError:
+            return None
+
+        if type(scalar) is not self.keywords[0][1].value_type:
+            return None
+
+        first, second = args
+        return (
+            expected_name,
+            type(scalar),
+            scalar,
+            id(first),
+            type(first),
+            first.shape,
+            first.stride(),
+            first.dtype,
+            first.device,
+            first.data_ptr(),
+            first.storage_offset(),
+            id(second),
+            type(second),
+            second.shape,
+            second.stride(),
+            second.dtype,
+            second.device,
+            second.data_ptr(),
+            second.storage_offset(),
+        )
+
+    def matches(
+        self,
+        args,
+        kwargs,
+        *,
+        identity_verified=False,
+        call_key=None,
+    ) -> bool:
+        if len(args) != len(self.positional) or len(kwargs) != len(self.keywords):
+            return False
+
+        if self.two_tensor_state is not None:
+            if call_key is None:
+                call_key = self.call_key(args, kwargs)
+            return call_key == self.two_tensor_state
+
+        for contract, value in zip(self.positional, args):
+            if not contract.matches(value, identity_verified=identity_verified):
+                return False
+
+        for (name, value), (expected_name, contract) in zip(
+            kwargs.items(), self.keywords
+        ):
+            if name != expected_name or not contract.matches(
+                value,
+                identity_verified=identity_verified,
+            ):
+                return False
+        return True
+
+
+@dataclass(frozen=True)
+class _PreparedRuntimeLaunch:
+    guard: _VerifiedRuntimeCall
+    values: tuple
+    keepalive: tuple
+    empty: bool
+    invocation: Callable[[], Any] | None = None
+
+
+_VERIFIED_RUNTIME_CALL_CACHE_SIZE = 8
+
+
+def _runtime_call_identity(args, kwargs):
+    return (len(args), *map(id, args), *map(id, kwargs.values()))
+
+
+def _two_tensor_call_identity(call_key):
+    return (call_key[3], call_key[11], call_key[1], call_key[2])
+
+
+def _remember_verified_runtime_call(prepared_calls, identity, prepared):
+    prepared_calls.pop(identity, None)
+
+    if len(prepared_calls) >= _VERIFIED_RUNTIME_CALL_CACHE_SIZE:
+        prepared_calls.pop(next(iter(prepared_calls)))
+
+    prepared_calls[identity] = prepared
+
+
+def _verified_runtime_launch(launch):
+    active_identity = None
+    active = None
+    prepared_calls = {}
+
+    def activate(identity, prepared):
+        nonlocal active, active_identity
+        active_identity = identity
+        active = prepared
+
+    def remember(identity, prepared):
+        _remember_verified_runtime_call(prepared_calls, identity, prepared)
+        activate(identity, prepared)
+
+    def verified(*args, **kwargs):
+        call_key = (
+            active.guard.call_key(args, kwargs)
+            if active is not None and active.guard.two_tensor_state is not None
+            else None
+        )
+        identity = (
+            _two_tensor_call_identity(call_key)
+            if call_key is not None
+            else _runtime_call_identity(args, kwargs)
+        )
+
+        if (
+            active is not None
+            and identity == active_identity
+            and active.guard.matches(
+                args,
+                kwargs,
+                identity_verified=True,
+                call_key=call_key,
+            )
+        ):
+            return launch._ninetoothed_invoke_prepared(active, args, kwargs)
+
+        cached = prepared_calls.pop(identity, None)
+
+        if cached is not None and cached.guard.matches(
+            args,
+            kwargs,
+            identity_verified=True,
+            call_key=call_key,
+        ):
+            prepared_calls[identity] = cached
+            activate(identity, cached)
+            return launch._ninetoothed_invoke_prepared(cached, args, kwargs)
+
+        prepared = launch._ninetoothed_prepare(args, kwargs)
+        remember(
+            _two_tensor_call_identity(prepared.guard.two_tensor_state)
+            if prepared.guard.two_tensor_state is not None
+            else identity,
+            prepared,
+        )
+        return launch._ninetoothed_invoke_prepared(prepared, args, kwargs)
+
+    return verified
+
+
 def _runtime_wrapper(
     function,
     abi: LaunchABI,
     *,
     low_level: bool = True,
     specs=(),
+    binding_overrides=None,
+    prepare_invocation=None,
 ):
-    def launch(*args, **kwargs):
-        public = _public_values(abi, args, kwargs, specs=specs)
+    overrides = dict(binding_overrides or {})
+
+    def prepare(args, kwargs, *, public=None):
+        if public is None:
+            public = _public_values(abi, args, kwargs, specs=specs)
+
+        bound_public = dict(public) | overrides
 
         if _empty_launch(abi, public):
-            return _first_output(abi, public)
+            return _PreparedRuntimeLaunch(
+                _VerifiedRuntimeCall.from_call(abi, args, kwargs),
+                (),
+                (),
+                True,
+            )
 
-        values, keepalive = _bound_values(abi, public, scalar_mode="value")
+        values, keepalive = _bound_values(abi, bound_public, scalar_mode="value")
         bindings = abi.kernel_args
 
         if low_level:
             values, flattened = _flatten_ffi_tensor_args(bindings, values)
             keepalive.extend(flattened)
 
-        result = function(*values) if low_level else function(*args)
+        values = tuple(values)
+
+        return _PreparedRuntimeLaunch(
+            _VerifiedRuntimeCall.from_call(abi, args, kwargs),
+            values,
+            tuple(keepalive),
+            False,
+            prepare_invocation(values) if prepare_invocation is not None else None,
+        )
+
+    def invoke(prepared, args, kwargs):
+        if prepared.empty:
+            return _first_output_from_call(abi, args, kwargs)
+
+        if prepared.invocation is not None:
+            result = prepared.invocation()
+        else:
+            result = (
+                function(*prepared.values) if low_level else function(*args, **kwargs)
+            )
+
+        if result is not None and not abi.outputs:
+            return result
+        return _first_output_from_call(abi, args, kwargs)
+
+    def launch(*args, **kwargs):
+        public = _public_values(abi, args, kwargs, specs=specs)
+
+        if _empty_launch(abi, public):
+            return _first_output(abi, public)
+
+        values, keepalive = _bound_values(
+            abi,
+            dict(public) | overrides,
+            scalar_mode="value",
+        )
+
+        if low_level:
+            values, flattened = _flatten_ffi_tensor_args(abi.kernel_args, values)
+            keepalive.extend(flattened)
+
+        result = function(*values) if low_level else function(*args, **kwargs)
         del keepalive
 
-        if result is not None:
+        if result is not None and not abi.outputs:
             return result
         return _first_output(abi, public)
+
+    launch._ninetoothed_prepare = prepare
+    launch._ninetoothed_invoke_prepared = invoke
 
     return launch
 
@@ -509,6 +882,15 @@ def _jagged_binding_value(binding: LaunchBinding, value):
 
 def _first_output(abi, public):
     return public[abi.outputs[0]] if abi.outputs else None
+
+
+def _first_output_from_call(abi, args, kwargs):
+    if not abi.outputs:
+        return None
+
+    name = abi.outputs[0]
+    index = abi.public_args.index(name)
+    return args[index] if index < len(args) else kwargs[name]
 
 
 def _empty_launch(abi, public) -> bool:

--- a/src/ninetoothed/compiler/runtime.py
+++ b/src/ninetoothed/compiler/runtime.py
@@ -465,27 +465,30 @@ class _VerifiedRuntimeCall:
 
         first, second = args
 
-        return (
-            expected_name,
-            type(scalar),
-            scalar,
-            id(first),
-            type(first),
-            first.shape,
-            first.stride(),
-            first.dtype,
-            first.device,
-            first.data_ptr(),
-            first.storage_offset(),
-            id(second),
-            type(second),
-            second.shape,
-            second.stride(),
-            second.dtype,
-            second.device,
-            second.data_ptr(),
-            second.storage_offset(),
-        )
+        try:
+            return (
+                expected_name,
+                type(scalar),
+                scalar,
+                id(first),
+                type(first),
+                first.shape,
+                first.stride(),
+                first.dtype,
+                first.device,
+                first.data_ptr(),
+                first.storage_offset(),
+                id(second),
+                type(second),
+                second.shape,
+                second.stride(),
+                second.dtype,
+                second.device,
+                second.data_ptr(),
+                second.storage_offset(),
+            )
+        except (AttributeError, RuntimeError, TypeError):
+            return None
 
     def matches(
         self,

--- a/src/ninetoothed/compiler/runtime.py
+++ b/src/ninetoothed/compiler/runtime.py
@@ -279,7 +279,7 @@ def _is_cacheable_runtime_literal(value) -> bool:
     )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class _RuntimeValueContract:
     is_tensor: bool
     identity: int
@@ -306,7 +306,12 @@ class _RuntimeValueContract:
         shape = getattr(value, "shape", None)
 
         if shape is None or not hasattr(value, "dtype"):
-            return cls(False, 0, type(value), value=value)
+            return cls(
+                is_tensor=False,
+                identity=0,
+                value_type=type(value),
+                value=value,
+            )
 
         stride = getattr(value, "stride", None)
         data_ptr = getattr(value, "data_ptr", None)
@@ -326,9 +331,9 @@ class _RuntimeValueContract:
             scalar_value = (type(item), item)
 
         return cls(
-            True,
-            id(value),
-            type(value),
+            is_tensor=True,
+            identity=id(value),
+            value_type=type(value),
             shape=shape,
             stride=stride_value,
             dtype=value.dtype,
@@ -378,7 +383,7 @@ class _RuntimeValueContract:
         return type(item) is self.scalar_value[0] and item == self.scalar_value[1]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class _VerifiedRuntimeCall:
     positional: tuple[_RuntimeValueContract, ...]
     keywords: tuple[tuple[str, _RuntimeValueContract], ...]
@@ -447,7 +452,11 @@ class _VerifiedRuntimeCall:
                     positional[1].value_type,
                     *positional[1].tensor_state,
                 )
-        return cls(positional, keywords, two_tensor_state)
+        return cls(
+            positional=positional,
+            keywords=keywords,
+            two_tensor_state=two_tensor_state,
+        )
 
     def call_key(self, args, kwargs):
         if self.two_tensor_state is None or len(args) != 2 or len(kwargs) != 1:
@@ -537,7 +546,7 @@ def _jagged_tensor_state(value):
         return None
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class _JaggedOwnerContract:
     owner: weakref.ReferenceType
     values_state: tuple
@@ -555,7 +564,11 @@ class _JaggedOwnerContract:
         if values_state is None or offsets_state is None:
             return None
 
-        return cls(reference, values_state, offsets_state)
+        return cls(
+            owner=reference,
+            values_state=values_state,
+            offsets_state=offsets_state,
+        )
 
     def matches(self):
         owner = self.owner()
@@ -574,7 +587,7 @@ class _JaggedOwnerContract:
         return state == (self.values_state, self.offsets_state)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class _PreparedBoundValue:
     value: Any = None
     tensor: weakref.ReferenceType | None = None
@@ -646,7 +659,7 @@ class _PreparedBoundValue:
         return flattened, flattened
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class _RuntimeBindingPlan:
     values: tuple[_PreparedBoundValue, ...]
     jagged_owners: tuple[_JaggedOwnerContract, ...]
@@ -691,7 +704,7 @@ class _RuntimeBindingPlan:
             owner_ids.add(identity)
             jagged_owners.append(contract)
 
-        return cls(planned, tuple(jagged_owners))
+        return cls(values=planned, jagged_owners=tuple(jagged_owners))
 
     @property
     def owner_refs(self):
@@ -758,7 +771,7 @@ class _RuntimeBindingPlan:
         return tuple(values), tuple(keepalive)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class _PreparedRuntimeLaunch:
     guard: _VerifiedRuntimeCall
     binding_plan: _RuntimeBindingPlan | None
@@ -979,10 +992,10 @@ def _runtime_wrapper(
 
         if _empty_launch(abi, public):
             return _PreparedRuntimeLaunch(
-                _VerifiedRuntimeCall.from_call(abi, args, kwargs),
-                None,
-                _runtime_owner_refs(args, kwargs),
-                True,
+                guard=_VerifiedRuntimeCall.from_call(abi, args, kwargs),
+                binding_plan=None,
+                owner_refs=_runtime_owner_refs(args, kwargs),
+                empty=True,
             )
 
         values, _keepalive = _bound_values(abi, bound_public, scalar_mode="value")
@@ -1025,11 +1038,11 @@ def _runtime_wrapper(
         owner_refs = _runtime_owner_refs(args, kwargs, binding_plan)
 
         return _PreparedRuntimeLaunch(
-            _VerifiedRuntimeCall.from_call(abi, args, kwargs),
-            binding_plan,
-            owner_refs,
-            False,
-            invocation_plan,
+            guard=_VerifiedRuntimeCall.from_call(abi, args, kwargs),
+            binding_plan=binding_plan,
+            owner_refs=owner_refs,
+            empty=False,
+            invocation_plan=invocation_plan,
         )
 
     def invoke(prepared, args, kwargs):

--- a/src/ninetoothed/ir/kernel.py
+++ b/src/ninetoothed/ir/kernel.py
@@ -188,6 +188,11 @@ class LaunchBinding:
     source: str | None = None
     dim: int | None = None
     value: Any = None
+    access: str | None = None
+
+    def __post_init__(self):
+        if self.access not in {None, "read", "write", "read_write"}:
+            raise ValueError(f"Unsupported launch binding access `{self.access}`.")
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/tests/test_aot_auto_tuning.py
+++ b/tests/test_aot_auto_tuning.py
@@ -54,7 +54,7 @@ def test_auto_tuning(size, dtype, device, ninetoothed_dtype, rtol, atol):
     output_dir = CACHE_DIR / "test_auto_tuning"
 
     shutil.rmtree(output_dir, ignore_errors=True)
-    output_dir.mkdir()
+    output_dir.mkdir(parents=True)
 
     configs = (
         ((), {"size": 20260128, "dtype": ninetoothed.float16, "block_size": 256}, {}),

--- a/tests/test_auto_tuner.py
+++ b/tests/test_auto_tuner.py
@@ -84,6 +84,21 @@ def test_auto_tuner_reports_every_failed_candidate(_):
     with pytest.raises(RuntimeError, match="first.*_foo failed.*second.*_bar failed"):
         tuner(1)
 
+    def fail_after_benchmark(*_args, **_kwargs):
+        raise RuntimeError("Winner invocation failed.")
+
+    tuner = AutoTuner(
+        (fail_after_benchmark,),
+        ("winner",),
+        benchmark=lambda *_args: 1.0,
+        cache_namespace=f"winner_failure_{uuid.uuid4().hex}",
+    )
+
+    with pytest.raises(RuntimeError, match="Winner invocation failed"):
+        tuner(1)
+
+    assert tuner._best_func == {}
+
 
 def _foo_delay(*args, **kwargs):
     return 0.001 * (2 * len(args) + len(kwargs))

--- a/tests/test_triton_runtime_auto_tuning.py
+++ b/tests/test_triton_runtime_auto_tuning.py
@@ -88,6 +88,7 @@ class _FakeTuner:
         key = self._make_arg_key(args, kwargs)
         selected = self._funcs[0] if args[0].shape[0] == 4 else self._funcs[1]
         self._best_func[key] = selected
+
         return selected(*args, **kwargs)
 
 
@@ -125,6 +126,7 @@ def _runtime_fixture(*, with_constexpr=False):
         handle,
         compilation,
     )
+
     return launch, tuner, handle, calls
 
 
@@ -152,6 +154,7 @@ def test_triton_single_and_plain_materialization_use_verified_launch(
 
     def raw_launch(*values, **kwargs):
         raw_calls.append((values, kwargs))
+
         return values[0]
 
     class FakeHandle:
@@ -180,6 +183,7 @@ def test_triton_single_and_plain_materialization_use_verified_launch(
     def public(*args, **kwargs):
         nonlocal public_calls
         public_calls += 1
+
         return original_public(*args, **kwargs)
 
     monkeypatch.setattr(runtime, "Handle", FakeHandle)
@@ -228,6 +232,7 @@ def _verified_runtime_fixture(*, with_constexpr=False, outputs=()):
         lambda *values: calls.append(values),
         abi,
     )
+
     return runtime._verified_runtime_launch(wrapped), calls
 
 
@@ -238,6 +243,7 @@ def test_verified_runtime_launch_rebinds_zero_dimensional_value(monkeypatch):
     def bound(*args, **kwargs):
         nonlocal binding_calls
         binding_calls += 1
+
         return original_bound(*args, **kwargs)
 
     monkeypatch.setattr(runtime, "_bound_values", bound)
@@ -261,6 +267,7 @@ def test_verified_runtime_launch_keeps_eight_recent_identities(monkeypatch):
     def bound(*args, **kwargs):
         nonlocal binding_calls
         binding_calls += 1
+
         return original_bound(*args, **kwargs)
 
     monkeypatch.setattr(runtime, "_bound_values", bound)
@@ -297,8 +304,10 @@ def test_verified_runtime_launch_preserves_argument_errors():
 
     with pytest.raises(TypeError, match="passed twice"):
         launch(value, 2, scale=2)
+
     with pytest.raises(TypeError, match="Missing kernel arguments"):
         launch(value)
+
     with pytest.raises(TypeError, match="Unknown kernel arguments"):
         launch(value, 2, unknown=True)
 
@@ -366,6 +375,7 @@ def test_triton_prepared_invocation_caches_grid_without_launching(monkeypatch):
 
             def launch(*args, **kwargs):
                 kernel_calls.append((args, kwargs))
+
                 return object()
 
             return launch
@@ -375,13 +385,15 @@ def test_triton_prepared_invocation_caches_grid_without_launching(monkeypatch):
 
     def generated_launch(value, size, _ninetoothed_num_warps=4):
         if size <= 0:
-            raise ValueError("size must be positive")
+            raise ValueError("Size must be positive.")
+
         _prepared_test_kernel[(size,)](
             value,
             size,
             BLOCK=1,
             num_warps=_ninetoothed_num_warps,
         )
+
         return value
 
     function = functools.partial(generated_launch, _ninetoothed_num_warps=8)
@@ -413,11 +425,13 @@ def test_triton_direct_winner_reuses_verified_binding_and_restores_aba(monkeypat
     def public(*args, **kwargs):
         nonlocal public_calls
         public_calls += 1
+
         return original_public(*args, **kwargs)
 
     def bound(*args, **kwargs):
         nonlocal binding_calls
         binding_calls += 1
+
         return original_bound(*args, **kwargs)
 
     monkeypatch.setattr(runtime, "_public_values", public)
@@ -514,8 +528,10 @@ def test_triton_direct_winner_validates_constexpr_and_argument_errors():
 
     with pytest.raises(TypeError, match="passed twice"):
         launch(tensor, 2, scale=2)
+
     with pytest.raises(TypeError, match="Missing kernel arguments"):
         launch(tensor)
+
     with pytest.raises(TypeError, match="Unknown kernel arguments"):
         launch(tensor, 2, unknown=True)
 

--- a/tests/test_triton_runtime_auto_tuning.py
+++ b/tests/test_triton_runtime_auto_tuning.py
@@ -76,6 +76,9 @@ class _FakeTensor:
     def data_ptr(self):
         return self._data_ptr
 
+    def element_size(self):
+        return 4
+
     def storage_offset(self):
         return self._storage_offset
 
@@ -585,7 +588,9 @@ def test_triton_alias_selection_does_not_pollute_non_alias_tuning():
         public_args=("value", "output"),
         kernel_args=(
             LaunchBinding(name="value", kind="tensor", source="value"),
-            LaunchBinding(name="output", kind="tensor", source="output"),
+            LaunchBinding(
+                name="output", kind="tensor", source="output", access="write"
+            ),
         ),
         outputs=("output",),
     )
@@ -610,13 +615,23 @@ def test_triton_alias_selection_does_not_pollute_non_alias_tuning():
         handle,
         SimpleNamespace(launch_abi=abi, kernel=SimpleNamespace(tensors=())),
     )
+    first_value = _FakeTensor((4,))
+    first_output = _FakeTensor((4,))
+
+    assert launch(first_value, output=first_output) is first_output
+    assert tuner.calls == 1
+    assert [name for name, _ in calls] == ["first", "second", "second"]
+    assert tuner._best_func["shared-key"] is candidates[1]
+    assert handle._selected_tuning_candidate == {"id": "second"}
+
+    calls.clear()
     aliased = _FakeTensor((4,))
 
     assert launch(aliased, output=aliased) is aliased
-    assert tuner.calls == 0
+    assert tuner.calls == 1
     assert [name for name, _ in calls] == ["first"]
     assert handle._selected_tuning_candidate == {"id": "first"}
-    assert tuner._best_func == {}
+    assert tuner._best_func["shared-key"] is candidates[1]
 
     calls.clear()
     value = _FakeTensor((4,))
@@ -624,9 +639,100 @@ def test_triton_alias_selection_does_not_pollute_non_alias_tuning():
 
     assert launch(value, output=output) is output
     assert tuner.calls == 1
-    assert [name for name, _ in calls] == ["first", "second", "second"]
-    assert tuner._best_func["shared-key"] is candidates[1]
+    assert [name for name, _ in calls] == ["second"]
     assert handle._selected_tuning_candidate == {"id": "second"}
+
+
+@pytest.mark.parametrize("kind", ("scalar", "constexpr"))
+def test_triton_tensor_scalar_alias_uses_alias_safe_selection(kind):
+    abi = LaunchABI(
+        public_args=("scale", "output"),
+        kernel_args=(
+            LaunchBinding(name="scale", kind=kind, source="scale"),
+            LaunchBinding(
+                name="output",
+                kind="tensor",
+                source="output",
+                access="write",
+            ),
+        ),
+        outputs=("output",),
+    )
+    calls = []
+
+    def candidate(name):
+        return runtime._runtime_wrapper(
+            lambda *_values: calls.append(name),
+            abi,
+        )
+
+    candidates = (candidate("first"), candidate("second"))
+    tuner = _FakeTuner(candidates, lambda args, kwargs: "shared-key")
+    handle = SimpleNamespace(_selected_tuning_candidate=None)
+    launch = triton_materializer._tuned_runtime_launch(
+        tuner,
+        dict(zip(candidates, ({"id": "first"}, {"id": "second"}))),
+        handle,
+        SimpleNamespace(launch_abi=abi, kernel=SimpleNamespace(tensors=())),
+    )
+    output = torch.zeros(4)
+
+    assert launch(output[0], output) is output
+    assert calls == ["first"]
+    assert tuner.calls == 0
+
+
+def test_triton_alias_signature_uses_absolute_spans_and_fails_closed():
+    abi = LaunchABI(
+        public_args=("value", "output"),
+        kernel_args=(
+            LaunchBinding(name="value", kind="tensor", source="value", access="read"),
+            LaunchBinding(
+                name="output",
+                kind="tensor",
+                source="output",
+                access="write",
+            ),
+        ),
+        outputs=("output",),
+    )
+    output = _FakeTensor((4,), data_ptr=1024)
+
+    overlapping = _FakeTensor((4,), data_ptr=1032)
+    assert triton_materializer._runtime_alias_signature(
+        abi, {"value": overlapping, "output": output}
+    )
+
+    unknown = SimpleNamespace(
+        shape=(4,),
+        stride=lambda: (1,),
+        data_ptr=lambda: 2048,
+        device="cuda:0",
+    )
+    assert triton_materializer._runtime_alias_signature(
+        abi, {"value": unknown, "output": output}
+    )
+
+    legacy_output_abi = LaunchABI(
+        public_args=("output",),
+        kernel_args=(LaunchBinding(name="output", kind="tensor", source="output"),),
+        outputs=("output",),
+    )
+    assert triton_materializer._runtime_alias_signature(
+        legacy_output_abi, {"output": output}
+    )
+
+    mixed_access_abi = LaunchABI(
+        public_args=("output",),
+        kernel_args=(
+            LaunchBinding(name="read", kind="tensor", source="output", access="read"),
+            LaunchBinding(name="write", kind="tensor", source="output", access="write"),
+        ),
+        outputs=("output",),
+    )
+    assert triton_materializer._runtime_alias_signature(
+        mixed_access_abi, {"output": output}
+    )
 
 
 def test_triton_read_write_binding_uses_alias_safe_selection():
@@ -755,12 +861,14 @@ def test_triton_alias_selection_uses_jagged_binding_access():
     assert handle._selected_tuning_candidate == {"id": "second"}
 
 
-def test_triton_alias_selection_skips_failed_candidate():
+def test_triton_alias_selection_handles_candidate_failures_safely():
     abi = LaunchABI(
         public_args=("value", "output"),
         kernel_args=(
             LaunchBinding(name="value", kind="tensor", source="value"),
-            LaunchBinding(name="output", kind="tensor", source="output"),
+            LaunchBinding(
+                name="output", kind="tensor", source="output", access="write"
+            ),
         ),
         outputs=("output",),
     )
@@ -786,11 +894,51 @@ def test_triton_alias_selection_skips_failed_candidate():
     )
     value = _FakeTensor((4,))
 
-    assert launch(value, output=value) is value
-    assert calls == ["first", "second"]
+    with pytest.raises(RuntimeError, match="Candidate unavailable"):
+        launch(value, output=value)
+
+    assert calls == ["first"]
     assert tuner.calls == 0
     assert tuner._best_func == {}
-    assert handle._selected_tuning_candidate == {"id": "second"}
+    assert handle._selected_tuning_candidate is None
+
+    calls.clear()
+    candidates = (candidate("first"), candidate("second"))
+
+    def fail_prepare(*_args, **_kwargs):
+        raise RuntimeError("Candidate did not prepare.")
+
+    candidates[0]._ninetoothed_prepare = fail_prepare
+    tuner = _FakeTuner(candidates, lambda args, kwargs: "shared-key")
+    launch = triton_materializer._tuned_runtime_launch(
+        tuner,
+        dict(zip(candidates, ({"id": "first"}, {"id": "second"}))),
+        handle,
+        SimpleNamespace(launch_abi=abi, kernel=SimpleNamespace(tensors=())),
+    )
+
+    assert launch(value, output=value) is value
+    assert calls == ["first"]
+    assert handle._selected_tuning_candidate == {"id": "first"}
+
+    calls.clear()
+    candidates = (candidate("first"), candidate("second"))
+    candidates[0]._ninetoothed_prepare = fail_prepare
+    tuner = _FakeTuner(
+        candidates,
+        lambda args, kwargs: "shared-key",
+        selected_index=0,
+    )
+    launch = triton_materializer._tuned_runtime_launch(
+        tuner,
+        dict(zip(candidates, ({"id": "first"}, {"id": "second"}))),
+        handle,
+        SimpleNamespace(launch_abi=abi, kernel=SimpleNamespace(tensors=())),
+    )
+
+    assert launch(_FakeTensor((4,)), output=_FakeTensor((4,))) is not None
+    assert calls == ["first", "second", "first"]
+    assert handle._selected_tuning_candidate == {"id": "first"}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_triton_runtime_auto_tuning.py
+++ b/tests/test_triton_runtime_auto_tuning.py
@@ -72,10 +72,11 @@ def _contiguous_stride(shape):
 
 
 class _FakeTuner:
-    def __init__(self, candidates, key_function):
+    def __init__(self, candidates, key_function, *, selected_index=None):
         self._funcs = tuple(candidates)
         self._best_func = {}
         self._key_function = key_function
+        self._selected_index = selected_index
         self.calls = 0
 
     def _make_arg_key(self, args, kwargs):
@@ -88,7 +89,13 @@ class _FakeTuner:
             candidate(*args, **kwargs)
 
         key = self._make_arg_key(args, kwargs)
-        selected = self._funcs[0] if args[0].shape[0] == 4 else self._funcs[1]
+        selected = (
+            self._funcs[self._selected_index]
+            if self._selected_index is not None
+            else self._funcs[0]
+            if args[0].shape[0] == 4
+            else self._funcs[1]
+        )
         self._best_func[key] = selected
 
         return selected(*args, **kwargs)
@@ -518,7 +525,7 @@ def test_triton_direct_winner_reuses_verified_binding_and_restores_aba(monkeypat
     assert binding_calls == 0
 
 
-def test_triton_aliasing_output_uses_one_statically_ranked_candidate():
+def test_triton_alias_selection_does_not_pollute_non_alias_tuning():
     abi = LaunchABI(
         public_args=("value", "output"),
         kernel_args=(
@@ -536,7 +543,59 @@ def test_triton_aliasing_output_uses_one_statically_ranked_candidate():
         )
 
     candidates = (candidate("first"), candidate("second"))
-    tuner = _FakeTuner(candidates, lambda args, kwargs: "alias-key")
+    tuner = _FakeTuner(
+        candidates,
+        lambda args, kwargs: "shared-key",
+        selected_index=1,
+    )
+    handle = SimpleNamespace(_selected_tuning_candidate=None)
+    launch = triton_materializer._tuned_runtime_launch(
+        tuner,
+        dict(zip(candidates, ({"id": "first"}, {"id": "second"}))),
+        handle,
+        SimpleNamespace(launch_abi=abi, kernel=SimpleNamespace(tensors=())),
+    )
+    aliased = _FakeTensor((4,))
+
+    assert launch(aliased, output=aliased) is aliased
+    assert tuner.calls == 0
+    assert [name for name, _ in calls] == ["first"]
+    assert handle._selected_tuning_candidate == {"id": "first"}
+    assert tuner._best_func == {}
+
+    calls.clear()
+    value = _FakeTensor((4,))
+    output = _FakeTensor((4,))
+
+    assert launch(value, output=output) is output
+    assert tuner.calls == 1
+    assert [name for name, _ in calls] == ["first", "second", "second"]
+    assert tuner._best_func["shared-key"] is candidates[1]
+    assert handle._selected_tuning_candidate == {"id": "second"}
+
+
+def test_triton_alias_selection_skips_failed_candidate():
+    abi = LaunchABI(
+        public_args=("value", "output"),
+        kernel_args=(
+            LaunchBinding(name="value", kind="tensor", source="value"),
+            LaunchBinding(name="output", kind="tensor", source="output"),
+        ),
+        outputs=("output",),
+    )
+    calls = []
+
+    def candidate(name, *, fails=False):
+        def invoke(*_values):
+            calls.append(name)
+
+            if fails:
+                raise RuntimeError("Candidate unavailable.")
+
+        return runtime._runtime_wrapper(invoke, abi)
+
+    candidates = (candidate("first", fails=True), candidate("second"))
+    tuner = _FakeTuner(candidates, lambda args, kwargs: "shared-key")
     handle = SimpleNamespace(_selected_tuning_candidate=None)
     launch = triton_materializer._tuned_runtime_launch(
         tuner,
@@ -547,9 +606,10 @@ def test_triton_aliasing_output_uses_one_statically_ranked_candidate():
     value = _FakeTensor((4,))
 
     assert launch(value, output=value) is value
+    assert calls == ["first", "second"]
     assert tuner.calls == 0
-    assert [name for name, _ in calls] == ["first"]
-    assert handle._selected_tuning_candidate == {"id": "first"}
+    assert tuner._best_func == {}
+    assert handle._selected_tuning_candidate == {"id": "second"}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_triton_runtime_auto_tuning.py
+++ b/tests/test_triton_runtime_auto_tuning.py
@@ -1,6 +1,8 @@
 import functools
+import gc
 import inspect
 import uuid
+import weakref
 from types import SimpleNamespace
 
 import pytest
@@ -330,7 +332,51 @@ def test_verified_runtime_four_buffer_call_has_no_cached_output_field():
     prepared = inspect.getclosurevars(launch).nonlocals["active"]
     assert not hasattr(prepared, "output")
     assert not hasattr(prepared, "result")
-    assert all(contract.value is None for contract in prepared.guard.positional)
+
+
+def test_verified_runtime_cache_does_not_retain_tensor_or_flattened_view():
+    abi = LaunchABI(
+        public_args=("value",),
+        kernel_args=(LaunchBinding(name="value", kind="tensor", source="value"),),
+    )
+    view_refs = []
+    invoked_refs = []
+
+    def prepare_invocation(values, _static_values, _call_sources):
+        view_refs.append(weakref.ref(values[0]))
+
+        def invoke(current_values, _args, _kwargs):
+            invoked_refs.append(weakref.ref(current_values[0]))
+
+        return invoke
+
+    wrapped = runtime._runtime_wrapper(
+        lambda _value: None,
+        abi,
+        prepare_invocation=prepare_invocation,
+    )
+    launch = runtime._verified_runtime_launch(wrapped)
+    value = torch.arange(8)
+    value_ref = weakref.ref(value)
+
+    launch(value)
+    launch(value)
+    gc.collect()
+
+    nonlocals = inspect.getclosurevars(launch).nonlocals
+    assert len(nonlocals["prepared_calls"]) == 1
+    assert len(view_refs) == 1
+    assert all(reference() is None for reference in view_refs)
+    assert len(invoked_refs) == 2
+    assert all(reference() is None for reference in invoked_refs)
+    assert torch.equal(value, torch.arange(8))
+
+    del value
+    gc.collect()
+
+    assert value_ref() is None
+    assert nonlocals["prepared_calls"] == {}
+    assert inspect.getclosurevars(launch).nonlocals["active"] is None
 
 
 def test_verified_runtime_uses_prepared_low_level_invocation():
@@ -342,11 +388,11 @@ def test_verified_runtime_uses_prepared_low_level_invocation():
     invoked_values = []
     raw_calls = []
 
-    def prepare_invocation(values):
+    def prepare_invocation(values, _static_values, _call_sources):
         prepared_values.append(values)
 
-        def invoke():
-            invoked_values.append(values)
+        def invoke(current_values, _args, _kwargs):
+            invoked_values.append(current_values)
 
         return invoke
 
@@ -405,12 +451,28 @@ def test_triton_prepared_invocation_caches_grid_without_launching(monkeypatch):
     assert bound_grids == [(4,)]
     assert kernel_calls == []
 
-    assert invocation() is None
-    assert invocation() is None
+    assert invocation(("pointer", 4), (), {}) is None
+    assert invocation(("pointer", 4), (), {}) is None
     assert kernel_calls == [
         (("pointer", 4), {"BLOCK": 1, "num_warps": 8}),
         (("pointer", 4), {"BLOCK": 1, "num_warps": 8}),
     ]
+
+    value = _FakeTensor((4,))
+    value_ref = weakref.ref(value)
+    unowned_invocation = prepare(
+        (value, 4),
+        (None, 4),
+        (("positional", 0), None),
+    )
+    assert unowned_invocation((), (value,), {}) is None
+    kernel_calls.clear()
+    del value
+    gc.collect()
+
+    assert unowned_invocation is not None
+    assert not unowned_invocation.requires_values
+    assert value_ref() is None
 
     with pytest.raises(ValueError, match="positive"):
         prepare(("pointer", 0))
@@ -665,6 +727,48 @@ def test_triton_tuple_configurations_are_benchmarked_and_cached(device, monkeypa
 
     handle(input, other, output)
     assert len(benchmarked) == 2
+
+
+@pytest.mark.parametrize("device", get_available_devices())
+def test_triton_prepared_cache_releases_gpu_tensor_storage(device):
+    handle = ninetoothed.make(
+        _arrangement,
+        _application,
+        tuple(Tensor(shape=(1 << 20,), dtype=ninetoothed.float32) for _ in range(3)),
+        backend="triton",
+        kernel_name=f"runtime_weak_cache_{uuid.uuid4().hex}",
+    )
+    warm_input = torch.randn(1 << 20, device=device)
+    warm_other = torch.randn_like(warm_input)
+    warm_output = torch.empty_like(warm_input)
+    handle(warm_input, warm_other, warm_output)
+    torch.cuda.synchronize(device)
+    del warm_input, warm_other, warm_output
+    gc.collect()
+    baseline = torch.cuda.memory_allocated(device)
+
+    input = torch.randn(1 << 20, device=device)
+    other = torch.randn_like(input)
+    output = torch.empty_like(input)
+    references = tuple(weakref.ref(value) for value in (input, other, output))
+    handle(input, other, output)
+    torch.cuda.synchronize(device)
+    allocated = torch.cuda.memory_allocated(device)
+    del input, other, output
+    gc.collect()
+    torch.cuda.synchronize(device)
+
+    assert allocated > baseline
+    assert all(reference() is None for reference in references)
+    assert torch.cuda.memory_allocated(device) <= baseline
+
+    replacement_input = torch.randn(1 << 20, device=device)
+    replacement_other = torch.randn_like(replacement_input)
+    replacement_output = torch.empty_like(replacement_input)
+    handle(replacement_input, replacement_other, replacement_output)
+    torch.cuda.synchronize(device)
+
+    assert torch.allclose(replacement_output, replacement_input + replacement_other)
 
 
 def test_auto_tuner_validates_arguments_before_benchmark(tmp_path, monkeypatch):

--- a/tests/test_triton_runtime_auto_tuning.py
+++ b/tests/test_triton_runtime_auto_tuning.py
@@ -1,12 +1,20 @@
+import functools
+import inspect
 import uuid
+from types import SimpleNamespace
 
 import pytest
 import torch
 
 import ninetoothed
 import ninetoothed.auto_tuner as auto_tuner
+import ninetoothed.backends.materializers.triton as triton_materializer
+import ninetoothed.compiler.runtime as runtime
 from ninetoothed import Tensor
+from ninetoothed.ir import LaunchABI, LaunchBinding
 from tests.utils import get_available_devices
+
+_prepared_test_kernel = None
 
 
 def _arrangement(input, other, output):
@@ -15,6 +23,595 @@ def _arrangement(input, other, output):
 
 def _application(input, other, output):
     output = input + other  # noqa: F841
+
+
+class _FakeTensor:
+    def __init__(
+        self,
+        shape,
+        *,
+        stride=None,
+        dtype="float32",
+        device="cuda:0",
+        data_ptr=None,
+    ):
+        self.shape = tuple(shape)
+        self._stride = tuple(stride or _contiguous_stride(shape))
+        self.dtype = dtype
+        self.device = device
+        self._data_ptr = id(self) if data_ptr is None else data_ptr
+        self._storage_offset = 0
+
+    def stride(self):
+        return self._stride
+
+    def data_ptr(self):
+        return self._data_ptr
+
+    def storage_offset(self):
+        return self._storage_offset
+
+    def numel(self):
+        result = 1
+
+        for size in self.shape:
+            result *= size
+        return result
+
+
+def _contiguous_stride(shape):
+    result = []
+    stride = 1
+
+    for size in reversed(shape):
+        result.append(stride)
+        stride *= size
+    return tuple(reversed(result))
+
+
+class _FakeTuner:
+    def __init__(self, candidates, key_function):
+        self._funcs = tuple(candidates)
+        self._best_func = {}
+        self._key_function = key_function
+        self.calls = 0
+
+    def _make_arg_key(self, args, kwargs):
+        return self._key_function(args, kwargs)
+
+    def __call__(self, *args, **kwargs):
+        self.calls += 1
+
+        for candidate in self._funcs:
+            candidate(*args, **kwargs)
+
+        key = self._make_arg_key(args, kwargs)
+        selected = self._funcs[0] if args[0].shape[0] == 4 else self._funcs[1]
+        self._best_func[key] = selected
+        return selected(*args, **kwargs)
+
+
+def _runtime_fixture(*, with_constexpr=False):
+    public_args = ("value", "scale") if with_constexpr else ("value",)
+    bindings = [LaunchBinding(name="value", kind="tensor", source="value")]
+
+    if with_constexpr:
+        bindings.append(LaunchBinding(name="scale", kind="constexpr", source="scale"))
+
+    abi = LaunchABI(public_args=public_args, kernel_args=tuple(bindings))
+    calls = []
+
+    def candidate(name):
+        return runtime._runtime_wrapper(
+            lambda *values: calls.append((name, values)) or values[0],
+            abi,
+        )
+
+    candidates = (candidate("first"), candidate("second"))
+    compilation = SimpleNamespace(
+        launch_abi=abi,
+        kernel=SimpleNamespace(tensors=()),
+    )
+    tuner = _FakeTuner(
+        candidates,
+        lambda args, kwargs: triton_materializer._triton_specialization_key(
+            compilation, args, kwargs
+        ),
+    )
+    handle = SimpleNamespace(_selected_tuning_candidate=None)
+    launch = triton_materializer._tuned_runtime_launch(
+        tuner,
+        dict(zip(candidates, ({"id": "first"}, {"id": "second"}))),
+        handle,
+        compilation,
+    )
+    return launch, tuner, handle, calls
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    (
+        None,
+        {
+            "id": "single",
+            "num_warps": 4,
+            "num_stages": 1,
+            "meta_parameters": {},
+        },
+    ),
+    ids=("plain", "single-candidate"),
+)
+def test_triton_single_and_plain_materialization_use_verified_launch(
+    candidate, tmp_path, monkeypatch
+):
+    abi = LaunchABI(
+        public_args=("value",),
+        kernel_args=(LaunchBinding(name="value", kind="tensor", source="value"),),
+    )
+    raw_calls = []
+
+    def raw_launch(*values, **kwargs):
+        raw_calls.append((values, kwargs))
+        return values[0]
+
+    class FakeHandle:
+        def __init__(self, compilation, kernel, launch, source):
+            del compilation, kernel, source
+            self._launch = launch
+
+        def __call__(self, *args, **kwargs):
+            return self._launch(*args, **kwargs)
+
+    compilation = SimpleNamespace(
+        artifact=SimpleNamespace(
+            kernel_name="verified_runtime",
+            primary_source="",
+            entrypoint="launch",
+        ),
+        launch_abi=abi,
+        launch_plan=SimpleNamespace(
+            tuning_candidates=() if candidate is None else (candidate,)
+        ),
+        kernel=SimpleNamespace(tensors=()),
+    )
+    public_calls = 0
+    original_public = runtime._public_values
+
+    def public(*args, **kwargs):
+        nonlocal public_calls
+        public_calls += 1
+        return original_public(*args, **kwargs)
+
+    monkeypatch.setattr(runtime, "Handle", FakeHandle)
+    monkeypatch.setattr(runtime, "_public_values", public)
+    monkeypatch.setattr(triton_materializer, "_ensure_c_compiler", lambda: None)
+    monkeypatch.setattr(
+        triton_materializer,
+        "compilation_cache_key",
+        lambda compilation: "verified-runtime",
+    )
+    monkeypatch.setattr(
+        triton_materializer,
+        "write_source",
+        lambda *args, **kwargs: tmp_path / "verified_runtime.py",
+    )
+    monkeypatch.setattr(
+        runtime,
+        "import_python_module",
+        lambda source: SimpleNamespace(launch=raw_launch),
+    )
+    monkeypatch.setattr(triton_materializer, "TRITON_CACHE_DIR", tmp_path / "cache")
+    handle = triton_materializer._materialize(compilation)
+    value = _FakeTensor((4,))
+
+    assert handle(value) is value
+    assert handle(value) is value
+    assert len(raw_calls) == 2
+    assert public_calls == 1
+    assert len(inspect.getclosurevars(handle._launch).nonlocals["prepared_calls"]) == 1
+
+
+def _verified_runtime_fixture(*, with_constexpr=False, outputs=()):
+    public_args = ("value", "scale") if with_constexpr else ("value",)
+    bindings = [LaunchBinding(name="value", kind="tensor", source="value")]
+
+    if with_constexpr:
+        bindings.append(LaunchBinding(name="scale", kind="constexpr", source="scale"))
+
+    abi = LaunchABI(
+        public_args=public_args,
+        kernel_args=tuple(bindings),
+        outputs=outputs,
+    )
+    calls = []
+    wrapped = runtime._runtime_wrapper(
+        lambda *values: calls.append(values),
+        abi,
+    )
+    return runtime._verified_runtime_launch(wrapped), calls
+
+
+def test_verified_runtime_launch_rebinds_zero_dimensional_value(monkeypatch):
+    binding_calls = 0
+    original_bound = runtime._bound_values
+
+    def bound(*args, **kwargs):
+        nonlocal binding_calls
+        binding_calls += 1
+        return original_bound(*args, **kwargs)
+
+    monkeypatch.setattr(runtime, "_bound_values", bound)
+    launch, calls = _verified_runtime_fixture(with_constexpr=True)
+    value = _FakeTensor((4,))
+    scale = torch.tensor(2)
+
+    launch(value, scale)
+    launch(value, scale)
+    scale.fill_(3)
+    launch(value, scale)
+
+    assert [values[-1] for values in calls] == [2, 2, 3]
+    assert binding_calls == 2
+
+
+def test_verified_runtime_launch_keeps_eight_recent_identities(monkeypatch):
+    binding_calls = 0
+    original_bound = runtime._bound_values
+
+    def bound(*args, **kwargs):
+        nonlocal binding_calls
+        binding_calls += 1
+        return original_bound(*args, **kwargs)
+
+    monkeypatch.setattr(runtime, "_bound_values", bound)
+    launch, _ = _verified_runtime_fixture()
+    values = [_FakeTensor((size,)) for size in range(1, 18)]
+
+    for value in values:
+        launch(value)
+
+    nonlocals = inspect.getclosurevars(launch).nonlocals
+    assert len(nonlocals["prepared_calls"]) == 8
+    assert binding_calls == 17
+
+    launch(values[0])
+    assert binding_calls == 18
+
+
+def test_verified_runtime_launch_handles_zero_without_calling_kernel():
+    launch, calls = _verified_runtime_fixture()
+    nonempty = _FakeTensor((4,))
+    empty = _FakeTensor((0,))
+
+    assert launch(nonempty) is None
+    assert launch(empty) is None
+    assert launch(nonempty) is None
+    assert calls == [(nonempty,), (nonempty,)]
+
+
+def test_verified_runtime_launch_preserves_argument_errors():
+    launch, _ = _verified_runtime_fixture(with_constexpr=True)
+    value = _FakeTensor((4,))
+
+    launch(value, 2)
+
+    with pytest.raises(TypeError, match="passed twice"):
+        launch(value, 2, scale=2)
+    with pytest.raises(TypeError, match="Missing kernel arguments"):
+        launch(value)
+    with pytest.raises(TypeError, match="Unknown kernel arguments"):
+        launch(value, 2, unknown=True)
+
+
+def test_verified_runtime_four_buffer_call_has_no_cached_output_field():
+    names = ("first", "second", "third", "output")
+    abi = LaunchABI(
+        public_args=names,
+        kernel_args=tuple(
+            LaunchBinding(name=name, kind="tensor", source=name) for name in names
+        ),
+        outputs=("output",),
+    )
+    wrapped = runtime._runtime_wrapper(lambda *values: None, abi)
+    launch = runtime._verified_runtime_launch(wrapped)
+    buffers = tuple(_FakeTensor((4,)) for _ in names)
+
+    assert launch(*buffers) is buffers[-1]
+    assert launch(*buffers) is buffers[-1]
+    prepared = inspect.getclosurevars(launch).nonlocals["active"]
+    assert not hasattr(prepared, "output")
+    assert not hasattr(prepared, "result")
+    assert all(contract.value is None for contract in prepared.guard.positional)
+
+
+def test_verified_runtime_uses_prepared_low_level_invocation():
+    abi = LaunchABI(
+        public_args=("value",),
+        kernel_args=(LaunchBinding(name="value", kind="tensor", source="value"),),
+    )
+    prepared_values = []
+    invoked_values = []
+    raw_calls = []
+
+    def prepare_invocation(values):
+        prepared_values.append(values)
+
+        def invoke():
+            invoked_values.append(values)
+
+        return invoke
+
+    wrapped = runtime._runtime_wrapper(
+        lambda *values: raw_calls.append(values),
+        abi,
+        prepare_invocation=prepare_invocation,
+    )
+    launch = runtime._verified_runtime_launch(wrapped)
+    value = _FakeTensor((4,))
+
+    assert launch(value) is None
+    assert launch(value) is None
+    assert prepared_values == [(value,)]
+    assert invoked_values == [(value,), (value,)]
+    assert raw_calls == []
+
+
+def test_triton_prepared_invocation_caches_grid_without_launching(monkeypatch):
+    bound_grids = []
+    kernel_calls = []
+
+    class FakeKernel:
+        def __getitem__(self, grid):
+            bound_grids.append(grid)
+
+            def launch(*args, **kwargs):
+                kernel_calls.append((args, kwargs))
+                return object()
+
+            return launch
+
+    kernel = FakeKernel()
+    monkeypatch.setitem(globals(), "_prepared_test_kernel", kernel)
+
+    def generated_launch(value, size, _ninetoothed_num_warps=4):
+        if size <= 0:
+            raise ValueError("size must be positive")
+        _prepared_test_kernel[(size,)](
+            value,
+            size,
+            BLOCK=1,
+            num_warps=_ninetoothed_num_warps,
+        )
+        return value
+
+    function = functools.partial(generated_launch, _ninetoothed_num_warps=8)
+    prepare = triton_materializer._triton_prepare_invocation(function, kernel)
+
+    assert prepare is not None
+    assert bound_grids == []
+    invocation = prepare(("pointer", 4))
+    assert bound_grids == [(4,)]
+    assert kernel_calls == []
+
+    assert invocation() is None
+    assert invocation() is None
+    assert kernel_calls == [
+        (("pointer", 4), {"BLOCK": 1, "num_warps": 8}),
+        (("pointer", 4), {"BLOCK": 1, "num_warps": 8}),
+    ]
+
+    with pytest.raises(ValueError, match="positive"):
+        prepare(("pointer", 0))
+
+
+def test_triton_direct_winner_reuses_verified_binding_and_restores_aba(monkeypatch):
+    public_calls = 0
+    binding_calls = 0
+    original_public = runtime._public_values
+    original_bound = runtime._bound_values
+
+    def public(*args, **kwargs):
+        nonlocal public_calls
+        public_calls += 1
+        return original_public(*args, **kwargs)
+
+    def bound(*args, **kwargs):
+        nonlocal binding_calls
+        binding_calls += 1
+        return original_bound(*args, **kwargs)
+
+    monkeypatch.setattr(runtime, "_public_values", public)
+    monkeypatch.setattr(runtime, "_bound_values", bound)
+    launch, tuner, handle, calls = _runtime_fixture()
+    first = _FakeTensor((4,))
+    second = _FakeTensor((8,), stride=(2,))
+
+    assert launch(first) is first
+    assert handle._selected_tuning_candidate == {"id": "first"}
+    assert launch(second) is second
+    assert handle._selected_tuning_candidate == {"id": "second"}
+    assert tuner.calls == 2
+    public_calls = binding_calls = 0
+    calls.clear()
+
+    assert launch(first) is first
+    assert handle._selected_tuning_candidate == {"id": "first"}
+    assert calls == [("first", (first,))]
+    assert tuner.calls == 2
+    assert public_calls == 0
+    assert binding_calls == 0
+
+
+def test_triton_aliasing_output_uses_one_statically_ranked_candidate():
+    abi = LaunchABI(
+        public_args=("value", "output"),
+        kernel_args=(
+            LaunchBinding(name="value", kind="tensor", source="value"),
+            LaunchBinding(name="output", kind="tensor", source="output"),
+        ),
+        outputs=("output",),
+    )
+    calls = []
+
+    def candidate(name):
+        return runtime._runtime_wrapper(
+            lambda *values: calls.append((name, values)) or object(),
+            abi,
+        )
+
+    candidates = (candidate("first"), candidate("second"))
+    tuner = _FakeTuner(candidates, lambda args, kwargs: "alias-key")
+    handle = SimpleNamespace(_selected_tuning_candidate=None)
+    launch = triton_materializer._tuned_runtime_launch(
+        tuner,
+        dict(zip(candidates, ({"id": "first"}, {"id": "second"}))),
+        handle,
+        SimpleNamespace(launch_abi=abi, kernel=SimpleNamespace(tensors=())),
+    )
+    value = _FakeTensor((4,))
+
+    assert launch(value, output=value) is value
+    assert tuner.calls == 0
+    assert [name for name, _ in calls] == ["first"]
+    assert handle._selected_tuning_candidate == {"id": "first"}
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected_tuner_calls"),
+    (
+        ("shape", (4, 1), 2),
+        ("_stride", (2,), 2),
+        ("dtype", "float16", 2),
+        ("device", "cuda:1", 2),
+        ("_data_ptr", 1, 1),
+        ("_storage_offset", 1, 1),
+    ),
+)
+def test_prepared_launch_rebinds_after_tensor_contract_change(
+    field, value, expected_tuner_calls
+):
+    launch, tuner, _, _ = _runtime_fixture()
+    tensor = _FakeTensor((4,))
+
+    assert launch(tensor) is tensor
+    assert tuner.calls == 1
+    setattr(tensor, field, value)
+    assert launch(tensor) is tensor
+    assert tuner.calls == expected_tuner_calls
+
+
+def test_triton_direct_winner_validates_constexpr_and_argument_errors():
+    launch, tuner, _, _ = _runtime_fixture(with_constexpr=True)
+    tensor = _FakeTensor((4,))
+
+    assert launch(tensor, 2) is tensor
+    assert launch(tensor, 2) is tensor
+    assert tuner.calls == 1
+    assert launch(tensor, 3) is tensor
+    assert tuner.calls == 2
+    assert launch(tensor, 2) is tensor
+    assert tuner.calls == 2
+
+    with pytest.raises(TypeError, match="passed twice"):
+        launch(tensor, 2, scale=2)
+    with pytest.raises(TypeError, match="Missing kernel arguments"):
+        launch(tensor)
+    with pytest.raises(TypeError, match="Unknown kernel arguments"):
+        launch(tensor, 2, unknown=True)
+
+
+def test_zero_dimensional_constexpr_mutation_rebinds_current_value():
+    launch, tuner, _, calls = _runtime_fixture(with_constexpr=True)
+    tensor = _FakeTensor((4,))
+    scale = torch.tensor(2)
+
+    assert launch(tensor, scale) is tensor
+    calls.clear()
+    assert launch(tensor, scale) is tensor
+    assert calls == [("first", (tensor, 2))]
+
+    scale.fill_(3)
+    calls.clear()
+    assert launch(tensor, scale) is tensor
+    assert [values[-1] for _, values in calls] == [3, 3, 3]
+    assert tuner.calls == 2
+
+    abi = LaunchABI(
+        public_args=("value", "scale"),
+        kernel_args=(
+            LaunchBinding(name="value", kind="tensor", source="value"),
+            LaunchBinding(name="scale", kind="constexpr", source="scale"),
+        ),
+    )
+    compilation = SimpleNamespace(launch_abi=abi)
+    scale.fill_(2)
+    first_key = triton_materializer._triton_specialization_key(
+        compilation, (tensor, scale), {}
+    )
+    scale.fill_(3)
+    second_key = triton_materializer._triton_specialization_key(
+        compilation, (tensor, scale), {}
+    )
+    assert first_key != second_key
+
+
+def test_triton_winner_proofs_share_the_bounded_prepared_lru():
+    launch, tuner, _, _ = _runtime_fixture()
+
+    for size in range(1, 18):
+        tensor = _FakeTensor((size,))
+        assert launch(tensor) is tensor
+
+    nonlocals = inspect.getclosurevars(launch).nonlocals
+    assert "selected_by_key" not in nonlocals
+    assert len(nonlocals["prepared_calls"]) == 8
+    assert tuner.calls == 17
+
+    first = _FakeTensor((1,))
+    assert launch(first) is first
+    assert tuner.calls == 18
+
+
+def test_prepared_launch_resolves_output_from_the_current_call():
+    abi = LaunchABI(
+        public_args=("value", "output"),
+        kernel_args=(
+            LaunchBinding(name="value", kind="tensor", source="value"),
+            LaunchBinding(name="output", kind="tensor", source="output"),
+        ),
+        outputs=("output",),
+    )
+    internal_result = object()
+    wrapped = runtime._runtime_wrapper(
+        lambda value, output: internal_result,
+        abi,
+    )
+    value = _FakeTensor((4,))
+    output = _FakeTensor((4,))
+    prepared = wrapped._ninetoothed_prepare((value, output), {})
+
+    assert wrapped(value, output) is output
+    assert not hasattr(prepared, "output")
+    assert not hasattr(prepared, "args")
+    assert not hasattr(prepared, "kwargs")
+    assert prepared.guard.positional[1].identity == id(output)
+    assert prepared.guard.positional[1].value is None
+    assert wrapped._ninetoothed_invoke_prepared(prepared, (value, output), {}) is output
+
+
+def test_triton_zero_size_does_not_disturb_nonempty_prepared_call():
+    launch, tuner, _, calls = _runtime_fixture()
+    nonempty = _FakeTensor((4,))
+    empty = _FakeTensor((0,))
+
+    assert launch(nonempty) is nonempty
+    assert tuner.calls == 1
+    calls.clear()
+    assert launch(empty) is None
+    assert calls == []
+    assert tuner.calls == 1
+    assert launch(nonempty) is nonempty
+    assert tuner.calls == 1
 
 
 @pytest.mark.parametrize("device", get_available_devices())

--- a/tests/test_triton_runtime_auto_tuning.py
+++ b/tests/test_triton_runtime_auto_tuning.py
@@ -13,6 +13,7 @@ import ninetoothed.auto_tuner as auto_tuner
 import ninetoothed.backends.materializers.triton as triton_materializer
 import ninetoothed.compiler.runtime as runtime
 from ninetoothed import Tensor
+from ninetoothed.compiler import DEFAULT_COMPILER, CompileRequest
 from ninetoothed.ir import LaunchABI, LaunchBinding
 from tests.utils import get_available_devices
 
@@ -25,6 +26,14 @@ def _arrangement(input, other, output):
 
 def _application(input, other, output):
     output = input + other  # noqa: F841
+
+
+def _inplace_arrangement(output):
+    return (output.tile((64,)),)
+
+
+def _inplace_application(output):
+    output = output + 1  # noqa: F841
 
 
 class _FakeTensor:
@@ -603,15 +612,72 @@ def test_triton_alias_selection_does_not_pollute_non_alias_tuning():
     assert handle._selected_tuning_candidate == {"id": "second"}
 
 
-def test_triton_alias_selection_uses_jagged_physical_bindings():
+def test_triton_read_write_binding_uses_alias_safe_selection():
+    compilation = DEFAULT_COMPILER.compile(
+        CompileRequest(
+            arrangement=_inplace_arrangement,
+            application=_inplace_application,
+            tensors=(Tensor(1),),
+            backend="triton",
+            num_warps=(4, 8),
+        )
+    )
+    abi = compilation.launch_abi
+    binding = next(binding for binding in abi.kernel_args if binding.kind == "tensor")
+    calls = []
+
+    def candidate(name):
+        def increment(value, *_metadata):
+            calls.append(name)
+            return value.add_(1)
+
+        return runtime._runtime_wrapper(increment, abi)
+
+    candidates = (candidate("first"), candidate("second"))
+    tuner = _FakeTuner(candidates, lambda args, kwargs: "shared-key")
+    handle = SimpleNamespace(_selected_tuning_candidate=None)
+    launch = triton_materializer._tuned_runtime_launch(
+        tuner,
+        dict(zip(candidates, ({"id": "first"}, {"id": "second"}))),
+        handle,
+        SimpleNamespace(launch_abi=abi, kernel=SimpleNamespace(tensors=())),
+    )
+    output = torch.zeros(4)
+
+    assert binding.access == "read_write"
+    assert launch(output) is output
+    assert torch.equal(output, torch.ones(4))
+    assert calls == ["first"]
+    assert tuner.calls == 0
+
+
+def test_triton_alias_selection_uses_jagged_binding_access():
     abi = LaunchABI(
         public_args=("value", "output"),
         kernel_args=(
-            LaunchBinding(name="value_values", kind="jagged_values", source="value"),
-            LaunchBinding(name="value_offsets", kind="jagged_offsets", source="value"),
-            LaunchBinding(name="output_values", kind="jagged_values", source="output"),
             LaunchBinding(
-                name="output_offsets", kind="jagged_offsets", source="output"
+                name="value_values",
+                kind="jagged_values",
+                source="value",
+                access="read",
+            ),
+            LaunchBinding(
+                name="value_offsets",
+                kind="jagged_offsets",
+                source="value",
+                access="read",
+            ),
+            LaunchBinding(
+                name="output_values",
+                kind="jagged_values",
+                source="output",
+                access="write",
+            ),
+            LaunchBinding(
+                name="output_offsets",
+                kind="jagged_offsets",
+                source="output",
+                access="read",
             ),
         ),
         outputs=("output",),
@@ -641,6 +707,16 @@ def test_triton_alias_selection_uses_jagged_physical_bindings():
     assert tuner.calls == 0
     assert [name for name, _ in calls] == ["first"]
     assert handle._selected_tuning_candidate == {"id": "first"}
+
+    calls.clear()
+    offsets = torch.tensor((0, 4, 8))
+    value = torch.nested.nested_tensor_from_jagged(torch.arange(8.0), offsets)
+    output = torch.nested.nested_tensor_from_jagged(torch.empty(8), offsets)
+
+    assert launch(value, output=output) is output
+    assert tuner.calls == 1
+    assert [name for name, _ in calls] == ["first", "second", "second"]
+    assert handle._selected_tuning_candidate == {"id": "second"}
 
 
 def test_triton_alias_selection_skips_failed_candidate():

--- a/tests/test_triton_runtime_auto_tuning.py
+++ b/tests/test_triton_runtime_auto_tuning.py
@@ -28,12 +28,29 @@ def _application(input, other, output):
     output = input + other  # noqa: F841
 
 
-def _inplace_arrangement(output):
-    return (output.tile((64,)),)
+def _control_dependent_inplace_arrangement(output):
+    return (output.tile((1,)),)
 
 
-def _inplace_application(output):
-    output = output + 1  # noqa: F841
+def _loop_carried_arrangement(input, output):
+    return (input.tile((1,)), output.tile((1,)))
+
+
+def _control_dependent_inplace_application(output):
+    if output[0] > 1:
+        output[0] = 0
+    elif output[0] > 0:
+        output[0] = 2
+    else:
+        output[0] = 1
+
+
+def _loop_carried_application(input, output):
+    value = input
+
+    for _ in range(2):
+        output = value  # noqa: F841
+        value = value + 1
 
 
 class _FakeTensor:
@@ -615,8 +632,8 @@ def test_triton_alias_selection_does_not_pollute_non_alias_tuning():
 def test_triton_read_write_binding_uses_alias_safe_selection():
     compilation = DEFAULT_COMPILER.compile(
         CompileRequest(
-            arrangement=_inplace_arrangement,
-            application=_inplace_application,
+            arrangement=_control_dependent_inplace_arrangement,
+            application=_control_dependent_inplace_application,
             tensors=(Tensor(1),),
             backend="triton",
             num_warps=(4, 8),
@@ -629,6 +646,7 @@ def test_triton_read_write_binding_uses_alias_safe_selection():
     def candidate(name):
         def increment(value, *_metadata):
             calls.append(name)
+
             return value.add_(1)
 
         return runtime._runtime_wrapper(increment, abi)
@@ -649,6 +667,24 @@ def test_triton_read_write_binding_uses_alias_safe_selection():
     assert torch.equal(output, torch.ones(4))
     assert calls == ["first"]
     assert tuner.calls == 0
+
+
+def test_triton_loop_carried_binding_access_preserves_input_dependency():
+    compilation = DEFAULT_COMPILER.compile(
+        CompileRequest(
+            arrangement=_loop_carried_arrangement,
+            application=_loop_carried_application,
+            tensors=(Tensor(1), Tensor(1)),
+            backend="triton",
+        )
+    )
+    access = {
+        binding.source: binding.access
+        for binding in compilation.launch_abi.kernel_args
+        if binding.kind == "tensor"
+    }
+
+    assert access == {"input": "read", "output": "write"}
 
 
 def test_triton_alias_selection_uses_jagged_binding_access():

--- a/tests/test_triton_runtime_auto_tuning.py
+++ b/tests/test_triton_runtime_auto_tuning.py
@@ -321,6 +321,35 @@ def test_verified_runtime_launch_preserves_argument_errors():
         launch(value, 2, unknown=True)
 
 
+def test_verified_runtime_fast_key_defers_invalid_tensor_to_validation():
+    abi = LaunchABI(
+        public_args=("first", "second", "scale"),
+        kernel_args=(
+            LaunchBinding(name="first", kind="tensor", source="first"),
+            LaunchBinding(name="second", kind="tensor", source="second"),
+            LaunchBinding(name="scale", kind="scalar", source="scale"),
+        ),
+    )
+    specs = tuple(
+        SimpleNamespace(
+            name=name,
+            ndim=1,
+            dtype=None,
+            attrs={"source_ndim": 1},
+        )
+        for name in ("first", "second")
+    )
+    wrapped = runtime._runtime_wrapper(lambda *_values: None, abi, specs=specs)
+    launch = runtime._verified_runtime_launch(wrapped)
+    first = _FakeTensor((4,))
+    second = _FakeTensor((4,))
+
+    launch(first, second, scale=1)
+
+    with pytest.raises(TypeError, match="`first` must be a tensor"):
+        launch(None, second, scale=1)
+
+
 def test_verified_runtime_four_buffer_call_has_no_cached_output_field():
     names = ("first", "second", "third", "output")
     abi = LaunchABI(
@@ -572,6 +601,46 @@ def test_triton_alias_selection_does_not_pollute_non_alias_tuning():
     assert [name for name, _ in calls] == ["first", "second", "second"]
     assert tuner._best_func["shared-key"] is candidates[1]
     assert handle._selected_tuning_candidate == {"id": "second"}
+
+
+def test_triton_alias_selection_uses_jagged_physical_bindings():
+    abi = LaunchABI(
+        public_args=("value", "output"),
+        kernel_args=(
+            LaunchBinding(name="value_values", kind="jagged_values", source="value"),
+            LaunchBinding(name="value_offsets", kind="jagged_offsets", source="value"),
+            LaunchBinding(name="output_values", kind="jagged_values", source="output"),
+            LaunchBinding(
+                name="output_offsets", kind="jagged_offsets", source="output"
+            ),
+        ),
+        outputs=("output",),
+    )
+    calls = []
+
+    def candidate(name):
+        return runtime._runtime_wrapper(
+            lambda *values: calls.append((name, values)),
+            abi,
+        )
+
+    candidates = (candidate("first"), candidate("second"))
+    tuner = _FakeTuner(candidates, lambda args, kwargs: "shared-key")
+    handle = SimpleNamespace(_selected_tuning_candidate=None)
+    launch = triton_materializer._tuned_runtime_launch(
+        tuner,
+        dict(zip(candidates, ({"id": "first"}, {"id": "second"}))),
+        handle,
+        SimpleNamespace(launch_abi=abi, kernel=SimpleNamespace(tensors=())),
+    )
+    values = torch.arange(8.0)
+    value = torch.nested.nested_tensor_from_jagged(values, torch.tensor((0, 4, 8)))
+    output = torch.nested.nested_tensor_from_jagged(values, torch.tensor((0, 2, 8)))
+
+    assert launch(value, output=output) is output
+    assert tuner.calls == 0
+    assert [name for name, _ in calls] == ["first"]
+    assert handle._selected_tuning_candidate == {"id": "first"}
 
 
 def test_triton_alias_selection_skips_failed_candidate():


### PR DESCRIPTION
`pytest` output:

```
·$ pytest -n 16
========================================================= test session starts =========================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/haojie/ntbackend/.merge-ready/triton-runtime-fastpath
configfile: pyproject.toml
plugins: xdist-3.8.0, anyio-4.13.0, cov-7.1.0
16 workers [375 items]    
............................................................................................................................... [ 33%]
......................................................................................................s........................ [ 67%]
........................................................................................................s................       [100%]
============================================= 373 passed, 2 skipped in 167.53s (0:02:47) ==============================================
```
两个 skip 的是需要多卡环境，在单卡环境上测试被自动跳过了。


## 背景与问题

PR #164 将 NineToothed 切换到新的 SSA lowering 编译链路后，Triton kernel 的公开调用路径增加了较多固定开销。

在当前 `master` 中，每次调用 kernel 都会重复执行：

- 参数与 Launch ABI 绑定
- dtype、device、rank、shape 和 stride 校验
- specialization key 计算
- autotune winner 查找
- Python launcher 参数重组
- Triton kernel launch 对象解析

这些操作不会改善 kernel 本身，却会显著增加端到端延迟。对于 Add、Pow、小型 Matmul 等启动受限算子，运行时固定开销可能高于 kernel 执行时间。

原有调优和 prepared launcher 路径还存在两个正确性风险：

- prepared launcher 的内部返回值可能泄露为公开 API 返回值，而不是返回 Launch ABI 声明的输出 tensor。
- 输入和输出共享存储时，多个候选可能在同一用户 buffer 上依次 benchmark，导致前一个候选修改后一个候选的输入。

## 对比版本

| 名称 | 版本 | 说明 |
|---|---|---|
| **Current** | `triton-runtime-fastpath`，基于 `b29a7e1e674cbeaf9e89be5885d218743a8c4d83`，staged patch SHA256：`92a6553900eba3a533fbdd26c81ac0783a7a25c283c43ebe6c4097a8e1e579c5` | 本 PR 准备合并的版本 |
| **Master** | `b29a7e1e674cbeaf9e89be5885d218743a8c4d83` | PR #164 合入后的干净 master |
| **Old Master** | `c9ebd4950a185beed8d4c1db9ff4a1fd133934ae` | PR #164 合入前的 Triton 实现 |

> Current 尚未 commit，因此暂时使用分支名、base commit 和 staged patch SHA256 唯一标识。创建 commit 后，可将 Current 的版本号替换为实际的 PR HEAD commit。

## 修改内容

本 PR 为 Triton runtime 增加经过验证的快速调用路径。

第一次调用仍执行完整检查，并记录：

- 公开参数与 Launch ABI 的绑定关系
- tensor 的 dtype、device、rank、shape 和 stride
- scalar、constexpr 和 keyword 参数
- specialization identity
- 已选择的 autotune candidate
- 已绑定的底层 Triton launcher

后续调用满足相同运行时契约时，直接复用 prepared launcher，避免重复完成上述工作。参数契约发生变化时会回到完整校验路径，不会跳过安全检查。

具体修改包括：

- 缓存已验证的 runtime call contract。
- 缓存已经完成参数绑定的 prepared launch。
- 为常见 tensor 调用建立低成本 specialization identity。
- 缓存并直接激活 autotune winner。
- 保证公开调用始终返回 Launch ABI 声明的输出 tensor。
- 支持动态 shape、动态 stride、keyword 参数和零尺寸 tensor。
- 检测输入输出存储别名。
- 输入输出存在别名时，不在用户数据上依次 benchmark 多个候选。
- 别名场景选择静态排序最高的合法候选，并只执行一次。
- 修复 xdist worker 缓存父目录未创建的问题。

本 PR 不缓存计算结果，不跳过 kernel 执行，也不根据算子名称替换 kernel。

## 性能指标说明

本文比较的是端到端调用延迟，数值越小越好。

表格中的比值定义为：

```text
Current 延迟 / 对比版本延迟
```

因此：

- 小于 `1.0`：Current 更快。
- 等于 `1.0`：性能基本相同。
- 大于 `1.0`：Current 更慢。

例如：

- `Current / Master = 0.50x` 表示 Current 延迟为 Master 的 50%，即快约 50%。
- `Current / Old Master = 1.20x` 表示 Current 延迟为 Old Master 的 1.2 倍，即慢约 20%。

## 测试方法

测试平台：

- GPU：NVIDIA L20
- Compute Capability：SM89
- Backend：Triton
- 所有性能任务使用同一 GPU 文件锁串行执行

每个测试点：

- 使用 4 个轮换输出 buffer
- 预热 20 次
- 测量 5 轮
- 每轮累计测量时间不少于 30 ms
- 同时记录 wall latency 和 CUDA Event latency
- 测量前执行 PyTorch 数值正确性对比

三个版本使用独立的 `HOME`、NineToothed cache、Triton cache 和 CUDA cache。

Old Master 执行 A1/A2 两次测量，两次结果的整体几何平均漂移为 `1.0005x`。

## 整体性能结果

Current 和 Master 共有 43 个可执行性能点。

| 对比 | 几何平均延迟比 | 性能变化 | Current 获胜点 |
|---|---:|---:|---:|
| **Current / Master** | **0.5088x** | **Current 快约 49.1%** | **43/43** |
| **Current / Old Master** | **0.9004x** | **Current 快约 10.0%** | **28/43** |

Current 与 Master 的生成 Triton 源码 SHA256 在 43 个共同可执行点上完全一致：

```text
43/43 source SHA256 identical
```

因此，Current 相对 Master 的提升来自 runtime 调用路径，而不是生成不同的 kernel。

## 分类性能结果

| 算子类别 | 有效点数 | Current / Master | 相对 Master | Current / Old Master | 相对 Old Master |
|---|---:|---:|---:|---:|---:|
| Add | 6 | `0.4370x` | 快 56.3% | `0.9233x` | 快 7.7% |
| Pow | 6 | `0.4397x` | 快 56.0% | `0.9206x` | 快 7.9% |
| Transpose | 6 | `0.5748x` | 快 42.5% | `2.1354x` | 慢 113.5% |
| Softmax | 0/6 | N/A | 当前不可执行 | N/A | 当前不可执行 |
| LayerNorm | 0/6 | N/A | 当前不可执行 | N/A | 当前不可执行 |
| MaxPool | 5 | `0.3569x` | 快 64.3% | `0.3009x` | 快 69.9% |
| Matmul | 5 | `0.6521x` | 快 34.8% | `0.9573x` | 快 4.3% |
| Addmm | 5 | `0.6494x` | 快 35.1% | `0.9909x` | 快 0.9% |
| Conv | 5 | `0.7245x` | 快 27.5% | `1.0547x` | 慢 5.5% |
| Attention | 5 | `0.3844x` | 快 61.6% | `0.6591x` | 快 34.1% |
| **整体** | **43** | **0.5088x** | **快 49.1%** | **0.9004x** | **快 10.0%** |

## 代表性结果

延迟单位为微秒，数值越小越好。

| 测试点 | Old Master | Master | Current | Current / Master | Current / Old Master |
|---|---:|---:|---:|---:|---:|
| Add 1M | 17.559 us | 58.698 us | 14.948 us | `0.255x` | `0.851x` |
| Pow 1M | 17.578 us | 59.870 us | 14.849 us | `0.248x` | `0.845x` |
| Matmul 512³ | 22.471 us | 64.695 us | 16.291 us | `0.252x` | `0.725x` |
| Addmm 512³ | 27.739 us | 80.224 us | 19.693 us | `0.245x` | `0.710x` |
| Attention B1/H4/S256/D64 | 45.237 us | 90.705 us | 21.229 us | `0.234x` | `0.469x` |
| Transpose 4096² | 66.965 us | 396.525 us | 395.993 us | `0.999x` | `5.913x` |

## 正确性验证

额外验证覆盖：

- 4 个轮换输出 buffer
- 每轮变化的输入数据
- NaN 预填充输出
- 动态 shape
- 动态 stride
- keyword 参数
- 零尺寸 tensor
- 输入输出完全别名
- 部分共享存储
- 交错 view
- 公开返回值身份
- kernel 确实被执行

输入输出存在别名时，Current 不会使用同一用户 buffer 依次 benchmark 多个候选，避免前一个候选修改后一个候选的输入。


## 已知限制

本 PR 只优化 Triton runtime，不修改 SSA lowering、布局规划或生成的 kernel。

Master 与 Current 都有 12 个性能矩阵点无法编译：

- 6 个 Softmax
- 6 个 LayerNorm

失败原因为现有 Triton reduction emitter 生成了 block mask 与 scalar pointer 不匹配的 `tl.load`。

这 12 个点：

- 在 Master 和 Current 中失败集合完全一致。
- 不是本 PR 引入的回归。
- 未计入性能几何平均值。
- 将会在下一个PR修复。

此外：

- Transpose 1024 及更大规模仍明显慢于 Old Master。
- 部分中大型 Conv 仍比 Old Master 慢约 4% 到 77%。
- 当前 SSA Conv 单点冷编译约需 4 到 5 分钟，Old Master 约需 1.5 到 2 分钟。

这些问题属于 layout、contraction lowering 和生成源码复杂度，不能通过 runtime fastpath 解决。