### PR TITLE
Fix jagged test oracles

### DIFF
--- a/tests/capabilities/jagged.py
+++ b/tests/capabilities/jagged.py
@@ -1,0 +1,36 @@
+"""Probe PyTorch jagged layout construction support."""
+
+import functools
+
+from tests.capabilities import run_python_probe
+
+
+def _probe(jagged_dim):
+    shapes = ((2, 3), (4, 3)) if jagged_dim == 1 else ((2, 3), (2, 5))
+    source = f"""
+import json
+import torch
+
+try:
+    batches = tuple(torch.randn(shape, device="cuda") for shape in {shapes!r})
+    torch.nested.nested_tensor(batches, layout=torch.jagged)
+except Exception as error:
+    print(json.dumps({{"status": "unavailable", "reason": str(error)}}))
+else:
+    print(json.dumps({{"status": "supported"}}))
+"""
+
+    return run_python_probe(f"torch jagged_dim={jagged_dim}", source)
+
+
+@functools.cache
+def jagged_dim_1():
+    return _probe(1)
+
+
+@functools.cache
+def jagged_dim_2():
+    return _probe(2)
+
+
+__all__ = ["jagged_dim_1", "jagged_dim_2"]

--- a/tests/test_jagged.py
+++ b/tests/test_jagged.py
@@ -120,8 +120,7 @@ def test_to_padded_tensor(ndim, jagged_dim, num_batches, padding, device):
 
     expected = _padded_from_batches(batches, padding, jagged_dim)
 
-    assert output.shape == expected.shape
-    torch.testing.assert_close(output, expected)
+    assert output.shape == expected.shape and torch.allclose(output, expected)
 
 
 class Copy:
@@ -216,4 +215,6 @@ def test_expand(ndim, jagged_dim, num_batches, device):
 
     expected = _expanded_values_from_batches(batches, src, jagged_dim)
 
-    torch.testing.assert_close(dst.values(), expected)
+    assert dst.values().shape == expected.shape and torch.allclose(
+        dst.values(), expected
+    )

--- a/tests/test_jagged.py
+++ b/tests/test_jagged.py
@@ -52,10 +52,48 @@ def to_padded_tensor(input, padding, jagged_dim, block_size=32):
     return output
 
 
+def _padded_from_batches(batches, padding, jagged_dim):
+    batch_jagged_dim = jagged_dim - 1
+    max_length = max(batch.shape[batch_jagged_dim] for batch in batches)
+    output_shape = (len(batches),) + tuple(
+        max_length if dim == batch_jagged_dim else size
+        for dim, size in enumerate(batches[0].shape)
+    )
+    output = torch.full(
+        output_shape,
+        padding,
+        dtype=batches[0].dtype,
+        device=batches[0].device,
+    )
+
+    for batch_index, batch in enumerate(batches):
+        slices = [slice(None)] * batch.ndim
+        slices[batch_jagged_dim] = slice(0, batch.shape[batch_jagged_dim])
+        output[(batch_index, *slices)] = batch
+
+    return output
+
+
 @pytest.mark.parametrize("device", get_available_devices())
 @pytest.mark.parametrize("padding", (-1,))
 @pytest.mark.parametrize("num_batches", (2, 3, 7, 16))
-@pytest.mark.parametrize("jagged_dim", (1, 2))
+@pytest.mark.parametrize(
+    "jagged_dim",
+    (
+        pytest.param(
+            1,
+            marks=pytest.mark.requires_capability(
+                "tests.capabilities.jagged:jagged_dim_1"
+            ),
+        ),
+        pytest.param(
+            2,
+            marks=pytest.mark.requires_capability(
+                "tests.capabilities.jagged:jagged_dim_2"
+            ),
+        ),
+    ),
+)
 @pytest.mark.parametrize("ndim", (3,))
 def test_to_padded_tensor(ndim, jagged_dim, num_batches, padding, device):
     def _random_size(lower_bound=1, upper_bound=1024):
@@ -80,9 +118,10 @@ def test_to_padded_tensor(ndim, jagged_dim, num_batches, padding, device):
 
     output = to_padded_tensor(input, padding=padding, jagged_dim=jagged_dim)
 
-    expected = torch.nested.to_padded_tensor(input, padding)
+    expected = _padded_from_batches(batches, padding, jagged_dim)
 
-    assert output.shape == expected.shape and torch.allclose(output, expected)
+    assert output.shape == expected.shape
+    torch.testing.assert_close(output, expected)
 
 
 class Copy:
@@ -120,9 +159,32 @@ def copy(dst, src, jagged_dim, block_size=32):
     kernel(dst, src, block_size=block_size)
 
 
+def _expanded_values_from_batches(batches, source, jagged_dim):
+    return torch.cat(
+        tuple(source[index].expand_as(batch) for index, batch in enumerate(batches)),
+        dim=jagged_dim - 1,
+    )
+
+
 @pytest.mark.parametrize("device", get_available_devices())
 @pytest.mark.parametrize("num_batches", (2, 3, 7, 16))
-@pytest.mark.parametrize("jagged_dim", (1, 2))
+@pytest.mark.parametrize(
+    "jagged_dim",
+    (
+        pytest.param(
+            1,
+            marks=pytest.mark.requires_capability(
+                "tests.capabilities.jagged:jagged_dim_1"
+            ),
+        ),
+        pytest.param(
+            2,
+            marks=pytest.mark.requires_capability(
+                "tests.capabilities.jagged:jagged_dim_2"
+            ),
+        ),
+    ),
+)
 @pytest.mark.parametrize("ndim", (3,))
 def test_expand(ndim, jagged_dim, num_batches, device):
     def _random_size(lower_bound=1, upper_bound=1024):
@@ -152,7 +214,6 @@ def test_expand(ndim, jagged_dim, num_batches, device):
 
     copy(dst, src, jagged_dim)
 
-    dst = torch.nested.to_padded_tensor(dst, 0)
-    src = src.expand_as(dst)
+    expected = _expanded_values_from_batches(batches, src, jagged_dim)
 
-    assert dst.shape == src.shape and torch.allclose(dst[dst != 0], src[dst != 0])
+    torch.testing.assert_close(dst.values(), expected)

--- a/tests/test_jagged_capability.py
+++ b/tests/test_jagged_capability.py
@@ -1,0 +1,101 @@
+import pytest
+import torch
+
+from tests.capabilities import CapabilityResult, jagged
+from tests.test_jagged import (
+    _expanded_values_from_batches,
+    _padded_from_batches,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_jagged_probe_caches():
+    probes = (jagged.jagged_dim_1, jagged.jagged_dim_2)
+
+    for probe in probes:
+        probe.cache_clear()
+
+    yield
+
+    for probe in probes:
+        probe.cache_clear()
+
+
+def test_jagged_layout_probes_are_distinct_and_cached(monkeypatch):
+    calls = []
+
+    def fake_run(name, source, *, timeout=60):
+        calls.append((name, source, timeout))
+
+        return CapabilityResult(True)
+
+    monkeypatch.setattr(jagged, "run_python_probe", fake_run)
+    jagged.jagged_dim_1()
+    jagged.jagged_dim_1()
+    jagged.jagged_dim_2()
+
+    assert [name for name, _source, _timeout in calls] == [
+        "torch jagged_dim=1",
+        "torch jagged_dim=2",
+    ]
+    assert all("layout=torch.jagged" in source for _name, source, _timeout in calls)
+
+
+def test_padded_oracle_uses_original_batches():
+    batches = (
+        torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+        torch.tensor([[5.0, 6.0]]),
+    )
+
+    actual = _padded_from_batches(batches, padding=-1, jagged_dim=1)
+    expected = torch.tensor(
+        [
+            [[1.0, 2.0], [3.0, 4.0]],
+            [[5.0, 6.0], [-1.0, -1.0]],
+        ]
+    )
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_padded_oracle_supports_second_jagged_dimension():
+    batches = (
+        torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+        torch.tensor([[5.0], [6.0]]),
+    )
+
+    actual = _padded_from_batches(batches, padding=0, jagged_dim=2)
+    expected = torch.tensor(
+        [
+            [[1.0, 2.0], [3.0, 4.0]],
+            [[5.0, 0.0], [6.0, 0.0]],
+        ]
+    )
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_expanded_values_oracle_uses_batch_lengths():
+    batches = (
+        torch.empty((2, 2)),
+        torch.empty((1, 2)),
+    )
+    source = torch.tensor([[[1.0, 2.0]], [[3.0, 4.0]]])
+
+    actual = _expanded_values_from_batches(batches, source, jagged_dim=1)
+    expected = torch.cat((source[0].expand(2, 2), source[1].expand(1, 2)))
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_expanded_values_oracle_supports_second_jagged_dimension():
+    batches = (
+        torch.empty((2, 2)),
+        torch.empty((2, 1)),
+    )
+    source = torch.tensor([[[1.0], [2.0]], [[3.0], [4.0]]])
+
+    actual = _expanded_values_from_batches(batches, source, jagged_dim=2)
+    expected = torch.tensor([[1.0, 1.0, 3.0], [2.0, 2.0, 4.0]])
+
+    torch.testing.assert_close(actual, expected)


### PR DESCRIPTION
## Summary

- replace jagged test expectations with explicit padded and values oracles
- probe `jagged_dim=1` and `jagged_dim=2` independently before collecting GPU cases
- skip only layouts the installed PyTorch runtime cannot construct

Functional implementation validation before restoring the original assertion API:

`pytest` output:

```
NVIDIA: 21 passed in 34.05s
Hygon: 21 passed in 64.76s
Iluvatar: 13 passed, 8 skipped in 12.74s
```

Latest head `b6aced9a` validation after restoring the two pre-existing `torch.allclose` assertions:

```
NVIDIA: 21 passed in 25.24s
Iluvatar: 13 passed, 8 skipped in 12.07s
Hygon: not rerun because the host was temporarily unreachable via SSH
```

The Iluvatar skips are limited to `jagged_dim=2`, which its PyTorch runtime reports cannot be represented with the jagged layout.
