### PR TITLE
Gate unsupported `float8` tests

### DIFF
--- a/tests/capabilities/float8.py
+++ b/tests/capabilities/float8.py
@@ -1,0 +1,131 @@
+"""Probe vendor Triton float8 lowering without importing NineToothed."""
+
+import functools
+import subprocess
+
+from tests.capabilities.model import CapabilityResult
+from tests.capabilities.runner import run_python_probe
+
+_PROBE_SOURCE = r"""
+import importlib.util
+import json
+import tempfile
+from pathlib import Path
+
+DEVICE = None
+PHASE = None
+
+try:
+    import torch
+
+    if DEVICE == "mlu":
+        importlib.import_module("torch_mlu")
+
+    directory = tempfile.TemporaryDirectory()
+    module_path = Path(directory.name) / "float8_capability_probe.py"
+    module_path.write_text(
+        '''import triton
+import triton.language as tl
+
+
+@triton.jit
+def copy_as_float32(input, output, size: tl.constexpr):
+    offsets = tl.arange(0, size)
+    values = tl.load(input + offsets).to(tl.float32)
+    tl.store(output + offsets, values)
+''',
+        encoding="utf-8",
+    )
+    spec = importlib.util.spec_from_file_location(
+        "float8_capability_probe",
+        module_path,
+    )
+
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Could not load the float8 capability probe module.")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    def run(dtype):
+        source = torch.arange(32, device=DEVICE, dtype=torch.float16).to(dtype)
+        output = torch.empty(32, device=DEVICE, dtype=torch.float32)
+        module.copy_as_float32[(1,)](source, output, 32)
+        getattr(torch, DEVICE).synchronize()
+        torch.testing.assert_close(output, source.float())
+except Exception as error:
+    print(json.dumps({"status": "error", "reason": f"probe setup failed: {error}"}))
+else:
+    if PHASE == "control":
+        try:
+            run(torch.float16)
+        except Exception as error:
+            print(json.dumps({"status": "error", "reason": f"FP16 control failed: {error}"}))
+        else:
+            print(json.dumps({"status": "supported"}))
+    elif PHASE == "float8":
+        try:
+            run(torch.float8_e5m2)
+        except Exception as error:
+            print(json.dumps({"status": "unavailable", "reason": str(error)}))
+        else:
+            print(json.dumps({"status": "supported"}))
+    else:
+        print(json.dumps({"status": "error", "reason": f"invalid probe phase: {PHASE!r}"}))
+"""
+
+
+def _source_for(device, phase):
+    return _PROBE_SOURCE.replace(
+        "DEVICE = None",
+        f"DEVICE = {device!r}",
+        1,
+    ).replace(
+        "PHASE = None",
+        f"PHASE = {phase!r}",
+        1,
+    )
+
+
+def _run_float8_e5m2_probe(device, timeout=60):
+    control_name = f"triton {device} FP16 control"
+    control = run_python_probe(
+        control_name,
+        _source_for(device, "control"),
+        timeout=timeout,
+    )
+
+    if not control.supported:
+        raise RuntimeError(
+            f"Capability probe {control_name!r} failed: {control.reason}."
+        )
+
+    float8_name = f"triton {device} float8_e5m2"
+
+    try:
+        return run_python_probe(
+            float8_name,
+            _source_for(device, "float8"),
+            timeout=timeout,
+        )
+    except RuntimeError as error:
+        if not isinstance(error.__cause__, subprocess.TimeoutExpired):
+            raise
+
+        return CapabilityResult(
+            supported=False,
+            reason=f"{float8_name}: probe timed out after {timeout} seconds",
+        )
+
+
+@functools.cache
+def float8_e5m2_cuda():
+    return _run_float8_e5m2_probe("cuda")
+
+
+@functools.cache
+def float8_e5m2_mlu():
+    return _run_float8_e5m2_probe("mlu")
+
+
+__all__ = ["float8_e5m2_cuda", "float8_e5m2_mlu"]

--- a/tests/test_addmm.py
+++ b/tests/test_addmm.py
@@ -54,9 +54,9 @@ def addmm(input, mat1, mat2, beta=1, alpha=1):
     return output
 
 
-@pytest.mark.parametrize("device", get_available_devices())
 @pytest.mark.parametrize(
-    "dtype, atol", ((torch.float16, 0.075),) + matmul._FLOAT8_E5M2_CONFIG
+    "device, dtype, atol",
+    matmul._device_dtype_config(get_available_devices(), fp16_atol=0.075),
 )
 @pytest.mark.parametrize("k", (512,))
 @pytest.mark.parametrize("n", (512,))

--- a/tests/test_float8_capability.py
+++ b/tests/test_float8_capability.py
@@ -1,0 +1,227 @@
+import pytest
+import torch
+
+from tests.capabilities import float8
+from tests.capabilities.model import CapabilityResult
+from tests.capabilities.runner import run_python_probe
+
+
+@pytest.fixture(autouse=True)
+def clear_float8_probe_cache():
+    probe_names = (
+        "float8_e5m2_cuda",
+        "float8_e5m2_mlu",
+    )
+
+    for name in probe_names:
+        probe = getattr(float8, name, None)
+
+        if probe is not None:
+            probe.cache_clear()
+
+    yield
+
+    for name in probe_names:
+        probe = getattr(float8, name, None)
+
+        if probe is not None:
+            probe.cache_clear()
+
+
+@pytest.mark.parametrize("device", ("cuda", "mlu"))
+def test_float8_probe_uses_device_specific_external_child(device, monkeypatch):
+    control = CapabilityResult(supported=True)
+    expected = CapabilityResult(False, "triton float8: unsupported lowering")
+    calls = []
+
+    def fake_run(name, source, *, timeout=60):
+        calls.append((name, source, timeout))
+
+        return control if "FP16 control" in name else expected
+
+    monkeypatch.setattr(float8, "run_python_probe", fake_run)
+    probe = getattr(float8, f"float8_e5m2_{device}")
+
+    assert probe() is expected
+    assert tuple(name for name, _, _ in calls) == (
+        f"triton {device} FP16 control",
+        f"triton {device} float8_e5m2",
+    )
+    assert f"DEVICE = {device!r}" in calls[0][1]
+    assert "PHASE = 'control'" in calls[0][1]
+    assert f"DEVICE = {device!r}" in calls[1][1]
+    assert "PHASE = 'float8'" in calls[1][1]
+    assert all("@triton.jit" in source for _, source, _ in calls)
+
+
+def test_float8_probe_caches_per_device(monkeypatch):
+    expected = CapabilityResult(supported=True)
+    calls = []
+
+    def fake_run(name, source, *, timeout=60):
+        calls.append((name, source, timeout))
+
+        return expected
+
+    monkeypatch.setattr(float8, "run_python_probe", fake_run)
+
+    for device in ("cuda", "mlu"):
+        probe = getattr(float8, f"float8_e5m2_{device}")
+
+        assert probe() is expected
+        assert probe() is expected
+
+    assert tuple(name for name, _, _ in calls) == (
+        "triton cuda FP16 control",
+        "triton cuda float8_e5m2",
+        "triton mlu FP16 control",
+        "triton mlu float8_e5m2",
+    )
+
+
+def test_float8_probe_fp16_control_failure_is_an_error():
+    source = float8._source_for("cuda", "control").replace(
+        "    run(torch.float16)",
+        '    raise RuntimeError("control")',
+        1,
+    )
+
+    with pytest.raises(RuntimeError, match="FP16 control failed: control"):
+        run_python_probe("triton float8_e5m2", source)
+
+
+@pytest.mark.parametrize("phase", ("control", "float8"))
+def test_float8_probe_setup_failure_is_an_error(phase):
+    source = float8._source_for("cuda", phase).replace(
+        "directory = tempfile.TemporaryDirectory()",
+        'raise RuntimeError("setup")',
+        1,
+    )
+
+    with pytest.raises(RuntimeError, match="probe setup failed: setup"):
+        run_python_probe("triton float8_e5m2", source)
+
+
+def test_float8_probe_fp8_failure_is_unavailable():
+    source = float8._source_for("cuda", "float8").replace(
+        "        run(torch.float8_e5m2)",
+        '        raise RuntimeError("float8")',
+        1,
+    )
+
+    result = run_python_probe("triton float8_e5m2", source)
+
+    assert result == CapabilityResult(
+        supported=False,
+        reason="triton float8_e5m2: float8",
+    )
+
+
+def _supported_source():
+    return 'import json; print(json.dumps({"status": "supported"}))'
+
+
+def test_float8_probe_control_abnormal_exit_is_an_error(monkeypatch):
+    phases = []
+
+    def source_for(device, phase):
+        del device
+        phases.append(phase)
+
+        return "import os; os._exit(17)"
+
+    monkeypatch.setattr(float8, "_source_for", source_for, raising=False)
+
+    with pytest.raises(RuntimeError, match="code 17"):
+        float8._run_float8_e5m2_probe("cuda", timeout=1)
+
+    assert phases == ["control"]
+
+
+def test_float8_probe_control_timeout_is_an_error(monkeypatch):
+    def source_for(device, phase):
+        del device, phase
+
+        return "import time; time.sleep(10)"
+
+    monkeypatch.setattr(float8, "_source_for", source_for, raising=False)
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        float8._run_float8_e5m2_probe("cuda", timeout=0.01)
+
+
+@pytest.mark.parametrize(
+    "float8_source, reason",
+    (
+        ("import os; os._exit(19)", "code 19"),
+        ("import time; time.sleep(10)", "timed out"),
+    ),
+)
+def test_float8_probe_abnormal_exit_or_timeout_is_unavailable(
+    float8_source,
+    reason,
+    monkeypatch,
+):
+    phases = []
+
+    def source_for(device, phase):
+        del device
+        phases.append(phase)
+
+        return _supported_source() if phase == "control" else float8_source
+
+    monkeypatch.setattr(float8, "_source_for", source_for, raising=False)
+
+    result = float8._run_float8_e5m2_probe("cuda", timeout=1)
+
+    assert not result.supported
+    assert reason in result.reason
+    assert phases == ["control", "float8"]
+
+
+def _parameter_capabilities(parameters):
+    capabilities = {}
+
+    for parameter in parameters:
+        device, dtype, atol = parameter.values
+        references = tuple(
+            mark.args[0]
+            for mark in parameter.marks
+            if mark.name == "requires_capability"
+        )
+        capabilities[(device, dtype)] = (atol, references)
+
+    return capabilities
+
+
+def test_float8_parameters_use_device_specific_capabilities():
+    import tests.test_matmul as matmul
+
+    capabilities = _parameter_capabilities(
+        matmul._device_dtype_config(("cuda", "mlu"), fp16_atol=0.25)
+    )
+
+    assert capabilities[("cuda", torch.float16)] == (0.25, ())
+    assert capabilities[("mlu", torch.float16)] == (0.25, ())
+    assert capabilities[("cuda", torch.float8_e5m2)] == (
+        0.125,
+        ("tests.capabilities.float8:float8_e5m2_cuda",),
+    )
+    assert capabilities[("mlu", torch.float8_e5m2)] == (
+        0.125,
+        ("tests.capabilities.float8:float8_e5m2_mlu",),
+    )
+
+
+def test_matmul_and_addmm_use_joint_device_dtype_parameters():
+    import tests.test_addmm as addmm
+    import tests.test_matmul as matmul
+
+    for function in (matmul.test, addmm.test):
+        parameter_names = tuple(
+            mark.args[0] for mark in function.pytestmark if mark.name == "parametrize"
+        )
+
+        assert "device, dtype, atol" in parameter_names
+        assert "device" not in parameter_names
+        assert "dtype, atol" not in parameter_names

--- a/tests/test_matmul.py
+++ b/tests/test_matmul.py
@@ -61,13 +61,31 @@ def matmul(lhs, rhs):
     return output
 
 
-_FLOAT8_E5M2_CONFIG = (
-    ((torch.float8_e5m2, 0.125),) if hasattr(torch, "float8_e5m2") else ()
+def _device_dtype_config(devices, fp16_atol):
+    config = []
+
+    for device in devices:
+        config.append(pytest.param(device, torch.float16, fp16_atol))
+
+        if hasattr(torch, "float8_e5m2"):
+            config.append(
+                pytest.param(
+                    device,
+                    torch.float8_e5m2,
+                    0.125,
+                    marks=pytest.mark.requires_capability(
+                        f"tests.capabilities.float8:float8_e5m2_{device}"
+                    ),
+                )
+            )
+
+    return tuple(config)
+
+
+@pytest.mark.parametrize(
+    "device, dtype, atol",
+    _device_dtype_config(get_available_devices(), fp16_atol=1e-8),
 )
-
-
-@pytest.mark.parametrize("device", get_available_devices())
-@pytest.mark.parametrize("dtype, atol", ((torch.float16, 1e-8),) + _FLOAT8_E5M2_CONFIG)
 @pytest.mark.parametrize("k", (512,))
 @pytest.mark.parametrize("n", (512,))
 @pytest.mark.parametrize("m", (512,))


### PR DESCRIPTION
## Summary

- probe vendor Triton float8 support per device in isolated child processes
- keep FP16 control failures hard while treating only FP8 failures as unavailable
- apply capability markers only to float8 matmul and addmm parameters

`pytest` output:
```
NVIDIA targeted matrix: 17 passed in 475.89s
Hygon float8 matmul/addmm parameters: 2 passed
Iluvatar CoreX 4.3 targeted matrix: 15 passed, 2 skipped in 258.80s

Integration SHA e5a06f01 (contains this commit with an identical stable patch-id):
NVIDIA: 450 passed, 2 skipped in 1917.03s
Hygon: 431 passed, 21 skipped in 2044.69s
Iluvatar CoreX 4.4: 423 passed, 29 skipped in 1377.08s
```

The Hygon FP8 cases execute and pass. Its former mandatory FP16 matmul tolerance failure is isolated and fixed by #205. The CoreX 4.3 skips are limited to float8 and report `PassManager::run failed` from the vendor Triton compiler; CoreX 4.4 is covered by the backend fallback in #206.
