### PR TITLE
Adjust FP16 `matmul` tolerance

### DIFF
--- a/tests/test_addmm.py
+++ b/tests/test_addmm.py
@@ -55,13 +55,17 @@ def addmm(input, mat1, mat2, beta=1, alpha=1):
 
 
 @pytest.mark.parametrize(
-    "device, dtype, atol",
-    matmul._device_dtype_config(get_available_devices(), fp16_atol=0.075),
+    "device, dtype, rtol, atol",
+    matmul._device_dtype_config(
+        get_available_devices(),
+        fp16_rtol=1e-5,
+        fp16_atol=0.075,
+    ),
 )
 @pytest.mark.parametrize("k", (512,))
 @pytest.mark.parametrize("n", (512,))
 @pytest.mark.parametrize("m", (512,))
-def test(m, n, k, dtype, device, atol):
+def test(m, n, k, dtype, device, rtol, atol):
     randn_dtype = dtype if dtype != torch.float8_e5m2 else torch.float16
 
     input = torch.randn((m, n), dtype=randn_dtype, device=device)
@@ -87,4 +91,4 @@ def test(m, n, k, dtype, device, atol):
         output = addmm(input, mat1, mat2, beta=beta, alpha=alpha)
         expected = torch.addmm(input, mat1, mat2, beta=beta, alpha=alpha)
 
-    assert torch.allclose(output, expected, atol=atol)
+    assert torch.allclose(output, expected, rtol=rtol, atol=atol)

--- a/tests/test_float8_capability.py
+++ b/tests/test_float8_capability.py
@@ -183,13 +183,13 @@ def _parameter_capabilities(parameters):
     capabilities = {}
 
     for parameter in parameters:
-        device, dtype, atol = parameter.values
+        device, dtype, rtol, atol = parameter.values
         references = tuple(
             mark.args[0]
             for mark in parameter.marks
             if mark.name == "requires_capability"
         )
-        capabilities[(device, dtype)] = (atol, references)
+        capabilities[(device, dtype)] = ((rtol, atol), references)
 
     return capabilities
 
@@ -198,17 +198,21 @@ def test_float8_parameters_use_device_specific_capabilities():
     import tests.test_matmul as matmul
 
     capabilities = _parameter_capabilities(
-        matmul._device_dtype_config(("cuda", "mlu"), fp16_atol=0.25)
+        matmul._device_dtype_config(
+            ("cuda", "mlu"),
+            fp16_rtol=0.5,
+            fp16_atol=0.25,
+        )
     )
 
-    assert capabilities[("cuda", torch.float16)] == (0.25, ())
-    assert capabilities[("mlu", torch.float16)] == (0.25, ())
+    assert capabilities[("cuda", torch.float16)] == ((0.5, 0.25), ())
+    assert capabilities[("mlu", torch.float16)] == ((0.5, 0.25), ())
     assert capabilities[("cuda", torch.float8_e5m2)] == (
-        0.125,
+        (1e-5, 0.125),
         ("tests.capabilities.float8:float8_e5m2_cuda",),
     )
     assert capabilities[("mlu", torch.float8_e5m2)] == (
-        0.125,
+        (1e-5, 0.125),
         ("tests.capabilities.float8:float8_e5m2_mlu",),
     )
 
@@ -222,6 +226,6 @@ def test_matmul_and_addmm_use_joint_device_dtype_parameters():
             mark.args[0] for mark in function.pytestmark if mark.name == "parametrize"
         )
 
-        assert "device, dtype, atol" in parameter_names
+        assert "device, dtype, rtol, atol" in parameter_names
         assert "device" not in parameter_names
-        assert "dtype, atol" not in parameter_names
+        assert "dtype, rtol, atol" not in parameter_names

--- a/tests/test_matmul.py
+++ b/tests/test_matmul.py
@@ -10,6 +10,9 @@ BLOCK_SIZE_M = Symbol("BLOCK_SIZE_M", meta=True)
 BLOCK_SIZE_N = Symbol("BLOCK_SIZE_N", meta=True)
 BLOCK_SIZE_K = Symbol("BLOCK_SIZE_K", meta=True)
 
+_FP16_RTOL = 0.001
+_FP16_ATOL = 0.001
+
 
 def arrangement(
     lhs,
@@ -84,7 +87,7 @@ def _device_dtype_config(devices, fp16_atol):
 
 @pytest.mark.parametrize(
     "device, dtype, atol",
-    _device_dtype_config(get_available_devices(), fp16_atol=1e-8),
+    _device_dtype_config(get_available_devices(), fp16_atol=_FP16_ATOL),
 )
 @pytest.mark.parametrize("k", (512,))
 @pytest.mark.parametrize("n", (512,))
@@ -105,4 +108,12 @@ def test(m, n, k, dtype, device, atol):
         output = matmul(input, other)
         expected = torch.matmul(input, other)
 
-    assert torch.allclose(output, expected, atol=atol)
+    if dtype == torch.float16:
+        torch.testing.assert_close(
+            output,
+            expected,
+            rtol=_FP16_RTOL,
+            atol=atol,
+        )
+    else:
+        assert torch.allclose(output, expected, atol=atol)

--- a/tests/test_matmul.py
+++ b/tests/test_matmul.py
@@ -108,12 +108,5 @@ def test(m, n, k, dtype, device, atol):
         output = matmul(input, other)
         expected = torch.matmul(input, other)
 
-    if dtype == torch.float16:
-        assert torch.allclose(
-            output,
-            expected,
-            rtol=_FP16_RTOL,
-            atol=atol,
-        )
-    else:
-        assert torch.allclose(output, expected, atol=atol)
+    rtol = _FP16_RTOL if dtype == torch.float16 else 1e-5
+    assert torch.allclose(output, expected, rtol=rtol, atol=atol)

--- a/tests/test_matmul.py
+++ b/tests/test_matmul.py
@@ -109,7 +109,7 @@ def test(m, n, k, dtype, device, atol):
         expected = torch.matmul(input, other)
 
     if dtype == torch.float16:
-        torch.testing.assert_close(
+        assert torch.allclose(
             output,
             expected,
             rtol=_FP16_RTOL,

--- a/tests/test_matmul.py
+++ b/tests/test_matmul.py
@@ -64,17 +64,18 @@ def matmul(lhs, rhs):
     return output
 
 
-def _device_dtype_config(devices, fp16_atol):
+def _device_dtype_config(devices, *, fp16_rtol, fp16_atol):
     config = []
 
     for device in devices:
-        config.append(pytest.param(device, torch.float16, fp16_atol))
+        config.append(pytest.param(device, torch.float16, fp16_rtol, fp16_atol))
 
         if hasattr(torch, "float8_e5m2"):
             config.append(
                 pytest.param(
                     device,
                     torch.float8_e5m2,
+                    1e-5,
                     0.125,
                     marks=pytest.mark.requires_capability(
                         f"tests.capabilities.float8:float8_e5m2_{device}"
@@ -86,13 +87,17 @@ def _device_dtype_config(devices, fp16_atol):
 
 
 @pytest.mark.parametrize(
-    "device, dtype, atol",
-    _device_dtype_config(get_available_devices(), fp16_atol=_FP16_ATOL),
+    "device, dtype, rtol, atol",
+    _device_dtype_config(
+        get_available_devices(),
+        fp16_rtol=_FP16_RTOL,
+        fp16_atol=_FP16_ATOL,
+    ),
 )
 @pytest.mark.parametrize("k", (512,))
 @pytest.mark.parametrize("n", (512,))
 @pytest.mark.parametrize("m", (512,))
-def test(m, n, k, dtype, device, atol):
+def test(m, n, k, dtype, device, rtol, atol):
     randn_dtype = dtype if dtype != torch.float8_e5m2 else torch.float16
 
     input = torch.randn((m, k), dtype=randn_dtype, device=device)
@@ -108,5 +113,4 @@ def test(m, n, k, dtype, device, atol):
         output = matmul(input, other)
         expected = torch.matmul(input, other)
 
-    rtol = _FP16_RTOL if dtype == torch.float16 else 1e-5
     assert torch.allclose(output, expected, rtol=rtol, atol=atol)


### PR DESCRIPTION
## Summary

- compare FP16 matmul results with explicit `0.001` relative and absolute tolerances
- keep the existing float8 comparison behavior unchanged
- parameterize relative and absolute tolerances together for matmul and addmm
- accommodate vendor accumulation differences without platform-specific branches or skips

Functional implementation validation before restoring the original assertion API:

`pytest` output:

```
NVIDIA: 17 passed in 460.87s
Hygon: 17 passed in 716.24s
Iluvatar: 15 passed, 2 skipped in 260.17s
```

Latest head `6b25e119` validation after restoring the pre-existing `torch.allclose` assertion and parameterizing both tolerances together:

```
NVIDIA capability, matmul, and addmm selection: 17 passed in 468.54s
Iluvatar matmul and addmm FP16 selection: 2 passed, 2 deselected in 266.86s
Hygon: not rerun because the host was temporarily unreachable via SSH
```

Ruff format, Ruff check, the project contributing style checker, and `git diff --check` also pass on the latest head.

The Hygon output from NineToothed matches the equivalent vendor Triton kernel bit-for-bit; both differ from the PyTorch/rocBLAS reference at the largest reduction size. The new tolerance passed characterization on all three platforms while still rejecting a `0.125` perturbation.

The Hygon full pytest run completed all 17 tests before a CRLF artifact in the remote wrapper changed the outer container status. The previously failing FP16 node was therefore rerun with a clean wrapper and passed in 168.86s with pytest, Docker, and container exit codes all equal to zero. The Iluvatar skips remain limited to float8 and report `PassManager::run failed` from the vendor Triton compiler.
