### PR TITLE
Fix CoreX FP8 `dot` lowering

### DIFF
--- a/src/ninetoothed/backends/emitters/base.py
+++ b/src/ninetoothed/backends/emitters/base.py
@@ -90,6 +90,11 @@ class EmitterTarget(ABC):
 
         return args
 
+    def coerce_block_dot_operands(self, operation, operands, context):
+        del operation, context
+
+        return operands
+
     def emit_dot_operand(self, name, coords, context):
         del name, coords, context
 

--- a/src/ninetoothed/backends/emitters/ssa.py
+++ b/src/ninetoothed/backends/emitters/ssa.py
@@ -1083,8 +1083,9 @@ def _emit_linalg_dot(
     if ctx.block_program and len(lhs_axes) == 2 and len(rhs_axes) == 2:
         lhs_value = _emit_element(lhs, ctx.target.block_coords(lhs_axes), ctx)
         rhs_value = _emit_element(rhs, ctx.target.block_coords(rhs_axes), ctx)
+        operands = ctx.target.coerce_block_dot_operands(op, (lhs_value, rhs_value), ctx)
 
-        return ctx.target.call("block_dot", (lhs_value, rhs_value))
+        return ctx.target.call("block_dot", operands)
 
     if not lhs_axes or not rhs_axes:
         return ctx.target.call(

--- a/src/ninetoothed/backends/emitters/triton.py
+++ b/src/ninetoothed/backends/emitters/triton.py
@@ -17,6 +17,7 @@ class TritonTarget(EmitterTarget):
     suffix: str = "triton.py"
     source_route: str = "ssa-unified-triton-emitter"
     vector_value_semantics: bool = True
+    fp8_dot_fallback: str = "none"
 
     def program_id(self, axis: int = 0) -> str:
         return f"tl.program_id({axis})"
@@ -26,6 +27,26 @@ class TritonTarget(EmitterTarget):
 
     def vector_splat(self, shape: str, value: str, dtype: str) -> str:
         return f"tl.full({shape}, {value}, tl.{common.normalize_dtype(dtype)})"
+
+    def coerce_block_dot_operands(self, operation, operands, context):
+        if self.fp8_dot_fallback != "float16":
+            return operands
+
+        coerced = []
+        result = common.local_symbol(operation.results[0].name, context)
+
+        for label, value in zip(("lhs", "rhs"), operands):
+            local = f"{result}_fp8_{label}"
+            context.lines.extend(
+                (
+                    f"{local} = {value}",
+                    f"if {local}.dtype == tl.float8e5:",
+                    f"    {local} = {local}.to(tl.float16)",
+                )
+            )
+            coerced.append(local)
+
+        return tuple(coerced)
 
     def literal(self, value: Any) -> str:
         if isinstance(value, float) and math.isinf(value):
@@ -300,7 +321,12 @@ TARGET = TritonTarget()
 
 
 def emit(kernel: Kernel):
-    return common.emit(kernel, TARGET)
+    backend_options = kernel.compiler_options.get("backend_options", {})
+    target = TritonTarget(
+        fp8_dot_fallback=backend_options.get("fp8_dot_fallback", "none")
+    )
+
+    return common.emit(kernel, target)
 
 
 __all__ = ["TARGET", "TritonTarget", "emit"]

--- a/src/ninetoothed/backends/triton.py
+++ b/src/ninetoothed/backends/triton.py
@@ -5,6 +5,7 @@ by operator family before emitting code; it delegates to the unified SSA
 emitter, whose dispatch unit is a single SSA operation.
 """
 
+import importlib.metadata
 from typing import TYPE_CHECKING, Any, Mapping
 
 from ninetoothed.backends.core import (
@@ -27,6 +28,7 @@ if TYPE_CHECKING:
 
 class TritonBackend(Backend):
     name = Target.TRITON
+    supported_options = frozenset({"fp8_dot_fallback"})
     capability = Capability(
         name=name,
         emits_source=True,
@@ -37,6 +39,35 @@ class TritonBackend(Backend):
             "No source passthrough or kernel-specialized fallback is used.",
         ),
     )
+
+    def normalize_options(self, options: Mapping[str, Any]) -> Mapping[str, Any]:
+        normalized = dict(super().normalize_options(options))
+        fallback = normalized.get("fp8_dot_fallback", "auto")
+
+        if not isinstance(fallback, str):
+            raise TypeError(
+                "The Triton `fp8_dot_fallback` backend option must be a string."
+            )
+
+        fallback = fallback.strip().lower()
+
+        if fallback not in {"auto", "none", "float16"}:
+            raise ValueError(
+                "The Triton `fp8_dot_fallback` backend option must be `auto`, "
+                "`none`, or `float16`."
+            )
+
+        if fallback == "auto":
+            try:
+                triton_version = importlib.metadata.version("triton").lower()
+            except importlib.metadata.PackageNotFoundError:
+                fallback = "none"
+            else:
+                fallback = "float16" if "+corex." in triton_version else "none"
+
+        normalized["fp8_dot_fallback"] = fallback
+
+        return normalized
 
     def emit(self, kernel: Kernel) -> Artifact:
         return emit(kernel)

--- a/tests/test_triton_fp8_dot_fallback.py
+++ b/tests/test_triton_fp8_dot_fallback.py
@@ -1,0 +1,304 @@
+import ast
+import importlib.metadata
+import re
+from types import SimpleNamespace
+
+import pytest
+
+import ninetoothed.language as ntl
+from ninetoothed import Symbol, Tensor
+from ninetoothed.backends.core import Target
+from ninetoothed.backends.emitters.triton import TritonTarget
+from ninetoothed.backends.triton import TritonBackend
+from ninetoothed.compiler import CompileRequest, compile_kernel
+from ninetoothed.compiler.cache import compilation_cache_key
+from ninetoothed.ir import ssa
+
+BLOCK_SIZE_M = Symbol("BLOCK_SIZE_M", meta=True)
+BLOCK_SIZE_N = Symbol("BLOCK_SIZE_N", meta=True)
+BLOCK_SIZE_K = Symbol("BLOCK_SIZE_K", meta=True)
+
+
+def _matmul_arrangement(
+    lhs,
+    rhs,
+    output,
+    BLOCK_SIZE_M=BLOCK_SIZE_M,
+    BLOCK_SIZE_N=BLOCK_SIZE_N,
+    BLOCK_SIZE_K=BLOCK_SIZE_K,
+):
+    output_tiled = output.tile((BLOCK_SIZE_M, BLOCK_SIZE_N))
+    lhs_tiled = (
+        lhs.tile((BLOCK_SIZE_M, BLOCK_SIZE_K))
+        .tile((1, -1))
+        .expand((-1, output_tiled.shape[1]))
+    )
+    lhs_tiled.dtype = lhs_tiled.dtype.squeeze(0)
+    rhs_tiled = (
+        rhs.tile((BLOCK_SIZE_K, BLOCK_SIZE_N))
+        .tile((-1, 1))
+        .expand((output_tiled.shape[0], -1))
+    )
+    rhs_tiled.dtype = rhs_tiled.dtype.squeeze(1)
+
+    return lhs_tiled, rhs_tiled, output_tiled
+
+
+def _matmul_application(lhs, rhs, output):
+    accumulator = ntl.zeros(output.shape, dtype=ntl.float32)
+
+    for k in range(lhs.shape[0]):
+        accumulator += ntl.dot(lhs[k], rhs[k])
+
+    output = accumulator.to(ntl.float16)  # noqa: F841
+
+
+def _matmul_tensors(dtype):
+    return (
+        Tensor(2, dtype=dtype),
+        Tensor(2, dtype=dtype),
+        Tensor(2, dtype="float16"),
+    )
+
+
+def _compile_matmul(dtype, backend_options=None, *, tensors=None):
+    return compile_kernel(
+        CompileRequest(
+            arrangement=_matmul_arrangement,
+            application=_matmul_application,
+            tensors=tensors or _matmul_tensors(dtype),
+            backend="triton",
+            backend_options=backend_options,
+        )
+    )
+
+
+def _dot_operation(dtype):
+    operand_type = ssa.Type(kind="tensor", shape=("M", "K"), dtype=dtype)
+
+    return ssa.Operation(
+        opcode="linalg.dot",
+        operands=("%lhs", "%rhs"),
+        results=(
+            ssa.Value(
+                name="%result",
+                type=ssa.Type(kind="tensor", shape=("M", "N"), dtype="float32"),
+            ),
+        ),
+    ), {
+        "%lhs": operand_type,
+        "%rhs": operand_type,
+    }
+
+
+def _coercion_context(value_types, target, *, local_suffix=""):
+    return SimpleNamespace(
+        target=target,
+        value_types=value_types,
+        lines=[],
+        temp_counter=[0],
+        local_suffix=local_suffix,
+    )
+
+
+def _cache_compilation(backend_options):
+    return SimpleNamespace(
+        request=SimpleNamespace(
+            backend_options=backend_options,
+            pipeline=None,
+            pass_options=None,
+        ),
+        artifact=SimpleNamespace(
+            backend=Target.TRITON,
+            sources={"kernel": "source"},
+        ),
+        kernel=SimpleNamespace(
+            ssa=(),
+            compiler_options={"backend_options": backend_options},
+        ),
+        launch_plan=(),
+    )
+
+
+@pytest.mark.parametrize(
+    "triton_version, expected",
+    (
+        ("3.1.0+corex.4.4.0", "float16"),
+        ("3.5.1", "none"),
+        ("3.3.0+rocm6.3", "none"),
+    ),
+)
+@pytest.mark.parametrize("options", ({}, {"fp8_dot_fallback": "auto"}))
+def test_auto_fallback_uses_triton_distribution_metadata(
+    triton_version, expected, options, monkeypatch
+):
+    calls = []
+
+    def distribution_version(package):
+        calls.append(package)
+
+        return triton_version
+
+    monkeypatch.setattr(importlib.metadata, "version", distribution_version)
+
+    assert TritonBackend().normalize_options(options) == {"fp8_dot_fallback": expected}
+    assert calls == ["triton"]
+
+
+def test_auto_fallback_defaults_to_none_without_distribution_metadata(monkeypatch):
+    def missing_distribution(package):
+        raise importlib.metadata.PackageNotFoundError(package)
+
+    monkeypatch.setattr(importlib.metadata, "version", missing_distribution)
+
+    assert TritonBackend().normalize_options({}) == {"fp8_dot_fallback": "none"}
+
+
+@pytest.mark.parametrize("fallback", ("none", "float16"))
+def test_explicit_fallback_does_not_query_triton_metadata(fallback, monkeypatch):
+    def unexpected_query(package):
+        raise AssertionError(f"Explicit fallback queried `{package}` metadata.")
+
+    monkeypatch.setattr(importlib.metadata, "version", unexpected_query)
+
+    assert TritonBackend().normalize_options({"fp8_dot_fallback": fallback}) == {
+        "fp8_dot_fallback": fallback
+    }
+
+
+def test_invalid_fallback_is_rejected():
+    backend = TritonBackend()
+
+    with pytest.raises(TypeError, match="must be a string"):
+        backend.normalize_options({"fp8_dot_fallback": None})
+
+    with pytest.raises(ValueError, match="`auto`, `none`, or `float16`"):
+        backend.normalize_options({"fp8_dot_fallback": "fp16"})
+
+
+def test_corex_auto_fallback_is_carried_into_compilation_and_guards_both_operands(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        importlib.metadata,
+        "version",
+        lambda package: "3.1.0+corex.4.4.0",
+    )
+
+    compilation = _compile_matmul("float8_e5m2")
+    expected_options = {"fp8_dot_fallback": "float16"}
+    assert compilation.request.backend_options == expected_options
+    assert compilation.kernel.compiler_options["backend_options"] == expected_options
+
+    source = compilation.artifact.primary_source
+    guards = re.findall(
+        r"if ([A-Za-z_]\w*_fp8_(?:lhs|rhs))\.dtype == tl\.float8e5:\n"
+        r"\s+\1 = \1\.to\(tl\.float16\)",
+        source,
+    )
+    dot = re.search(
+        r"tl\.dot\(([A-Za-z_]\w*_fp8_lhs), ([A-Za-z_]\w*_fp8_rhs)\)",
+        source,
+    )
+    assert len(guards) == 2
+    assert dot is not None
+    assert set(dot.groups()) == set(guards)
+    ast.parse(source)
+
+
+def test_explicit_float16_fallback_reaches_source_without_distribution_metadata(
+    monkeypatch,
+):
+    def missing_distribution(package):
+        raise importlib.metadata.PackageNotFoundError(package)
+
+    monkeypatch.setattr(importlib.metadata, "version", missing_distribution)
+
+    compilation = _compile_matmul("float8_e5m2", {"fp8_dot_fallback": "float16"})
+
+    assert compilation.request.backend_options == {"fp8_dot_fallback": "float16"}
+    assert compilation.artifact.primary_source.count(".dtype == tl.float8e5") == 2
+
+
+@pytest.mark.parametrize("triton_version", ("3.5.1", "3.3.0+rocm6.3", None))
+def test_non_corex_auto_fallback_preserves_original_dot_source(
+    triton_version, monkeypatch
+):
+    def distribution_version(package):
+        if triton_version is None:
+            raise importlib.metadata.PackageNotFoundError(package)
+
+        return triton_version
+
+    monkeypatch.setattr(importlib.metadata, "version", distribution_version)
+
+    tensors = _matmul_tensors("float8_e5m2")
+    compilation = _compile_matmul("float8_e5m2", tensors=tensors)
+    explicit_none = _compile_matmul(
+        "float8_e5m2",
+        {"fp8_dot_fallback": "none"},
+        tensors=tensors,
+    )
+    expected_options = {"fp8_dot_fallback": "none"}
+    assert compilation.request.backend_options == expected_options
+    assert compilation.kernel.compiler_options["backend_options"] == expected_options
+    assert "tl.dot(" in compilation.artifact.primary_source
+    assert ".dtype == tl.float8e5" not in compilation.artifact.primary_source
+    assert compilation.artifact.primary_source == explicit_none.artifact.primary_source
+
+
+def test_unknown_ssa_dtype_is_guarded_by_float16_fallback():
+    operation, value_types = _dot_operation(None)
+    target = TritonTarget(fp8_dot_fallback="float16")
+    context = _coercion_context(value_types, target, local_suffix="_loop_body")
+    operands = target.coerce_block_dot_operands(
+        operation, ("lhs_value", "rhs_value"), context
+    )
+    source = "\n".join(
+        (*context.lines, f"result = tl.dot({operands[0]}, {operands[1]})")
+    )
+
+    assert source.count(".dtype == tl.float8e5") == 2
+    assert operands == (
+        "vresult_loop_body_fp8_lhs",
+        "vresult_loop_body_fp8_rhs",
+    )
+    ast.parse(source)
+
+
+def test_known_float16_operands_keep_jit_static_guards():
+    operation, value_types = _dot_operation("float16")
+    target = TritonTarget(fp8_dot_fallback="float16")
+    context = _coercion_context(value_types, target)
+    operands = target.coerce_block_dot_operands(
+        operation, ("lhs_value", "rhs_value"), context
+    )
+
+    assert operands == ("vresult_fp8_lhs", "vresult_fp8_rhs")
+    assert "\n".join(context.lines).count(".dtype == tl.float8e5") == 2
+
+
+def test_default_target_does_not_guard_block_dot_operands():
+    operation, value_types = _dot_operation("float8_e5m2")
+    target = TritonTarget()
+    context = _coercion_context(value_types, target)
+    operands = target.coerce_block_dot_operands(
+        operation, ("lhs_value", "rhs_value"), context
+    )
+
+    assert operands == ("lhs_value", "rhs_value")
+    assert not context.lines
+
+
+def test_effective_fallback_is_part_of_compilation_cache_key(monkeypatch):
+    import ninetoothed.compiler.cache as cache
+
+    monkeypatch.setattr(cache, "_architecture", lambda compilation: {})
+    monkeypatch.setattr(cache, "_compiler_versions", lambda: {"triton": "fixed"})
+    backend = TritonBackend()
+    none = backend.normalize_options({"fp8_dot_fallback": "none"})
+    float16 = backend.normalize_options({"fp8_dot_fallback": "float16"})
+
+    assert compilation_cache_key(_cache_compilation(none)) != compilation_cache_key(
+        _cache_compilation(float16)
+    )


### PR DESCRIPTION
## Summary

- add an `auto|none|float16` Triton backend option for CoreX E5M2 block-dot lowering
- select the float16 operand fallback from CoreX Triton package metadata while leaving non-CoreX source unchanged
- cover option validation, cache behavior, source generation, unknown SSA dtypes, and repeated dot operands

CoreX Triton 3.1.0+corex.4.4.0 miscompiles direct E5M2 `tl.dot`, while E5M2 loads, conversions, and scalar FMAs are correct. The fallback upcasts only E5M2 block-dot operands to FP16 before `tl.dot`; it is limited to source/JIT generation and does not claim FP8 AOT support. Cross-host source generation can opt in explicitly with `fp8_dot_fallback="float16"`.

The three-host full run used integration SHA `e5a06f01db6db817d139620be8433da9858dd95b`, which contains this commit with an identical stable patch-id plus the separately submitted adaptation fixes.

`pytest` output:
```
Backend/compiler/cache/SSA tests: 83 passed
NVIDIA focused fallback tests: 19 passed; FP8/FP16 matmul and addmm: 4 passed
Hygon focused fallback tests: 19 passed; FP8 matmul/addmm and FP16 addmm: 3 passed
Iluvatar CoreX 4.4 focused fallback tests: 19 passed; FP8/FP16 matmul and addmm: 4 passed

Integration SHA e5a06f01:
NVIDIA: 450 passed, 2 skipped in 1917.03s
Hygon: 431 passed, 21 skipped in 2044.69s
Iluvatar CoreX 4.4: 423 passed, 29 skipped in 1377.08s
```
