### PR TITLE
Reduction domain triton schedule

### DIFF
--- a/src/ninetoothed/auto_tuner.py
+++ b/src/ninetoothed/auto_tuner.py
@@ -68,7 +68,10 @@ class AutoTuner:
                 best_timing = min(timings)
                 best_timing_index = timings.index(best_timing)
                 best_func = self._funcs[best_timing_index]
+                result = best_func(*args, **kwargs)
                 self._best_func[arg_key] = best_func
+
+                return result
 
         return best_func(*args, **kwargs)
 

--- a/src/ninetoothed/backends/emitters/context.py
+++ b/src/ninetoothed/backends/emitters/context.py
@@ -65,6 +65,7 @@ class EmitContext:
     native_block_program: bool = False
     layout_contiguous: bool = False
     vector_program: bool = False
+    reduction_lane: str | None = None
 
     def child(
         self,
@@ -104,6 +105,7 @@ class EmitContext:
             "native_block_program": self.native_block_program,
             "layout_contiguous": self.layout_contiguous,
             "vector_program": self.vector_program,
+            "reduction_lane": self.reduction_lane,
         }
         data.update(kwargs)
 

--- a/src/ninetoothed/backends/emitters/ssa.py
+++ b/src/ninetoothed/backends/emitters/ssa.py
@@ -187,6 +187,29 @@ def emit(kernel: Kernel, target: EmitterTarget) -> Artifact:
     )
 
 
+def _row_reduction_schedule(program: ssa.Program) -> Mapping[str, Any] | None:
+    schedule = program.metadata.get("schedule", {})
+
+    if not isinstance(schedule, Mapping):
+        return None
+
+    reduction = schedule.get("reduction", {})
+
+    if not isinstance(reduction, Mapping):
+        return None
+
+    if reduction.get("mode") == "scalar-fallback" and not reduction.get(
+        "emittable", True
+    ):
+        raise ValueError(
+            "Reduction outputs with different domains require separate kernels."
+        )
+
+    if reduction.get("mode") != "row-vector":
+        return None
+    return reduction
+
+
 def _render_source(
     kernel: Kernel,
     target: _Target,
@@ -195,6 +218,7 @@ def _render_source(
 ) -> tuple[str, ModuleRenderContext]:
     program = kernel.ssa
     assert program is not None
+    reduction_schedule = _row_reduction_schedule(program)
     block = program.blocks[0] if program.blocks else ssa.Block()
     tensor_infos = {tensor.name: _tensor_info(tensor) for tensor in kernel.tensors}
     auxiliary_bindings = _auxiliary_pointer_bindings(kernel.tensors)
@@ -271,6 +295,11 @@ def _render_source(
     else:
         value_axes = store_value_axes
 
+    if target.vector_value_semantics and reduction_schedule is not None:
+        value_axes = tuple(
+            str(axis) for axis in reduction_schedule.get("value_shape", ())
+        )
+
     output_attrs = output_info.attrs or {} if output_info is not None else {}
     split_outer_inner = bool(
         value_axes
@@ -291,10 +320,8 @@ def _render_source(
     )
     vector_reduction_program = bool(
         target.vector_value_semantics
-        and split_outer_inner
+        and reduction_schedule is not None
         and not vector_block_program
-        and sum(str(axis).strip("() ") != "1" for axis in value_axes) <= 1
-        and any(op.opcode.startswith("reduce.") for op in walked_ops)
     )
     native_block_program = bool(
         target.native_block_matmul
@@ -318,10 +345,52 @@ def _render_source(
         inner_index_expr = "0"
     elif vector_reduction_program:
         axes = value_axes
-        total = _target_index_expr(target, _product(value_axes))
-        grid_total = _target_index_expr(target, _product(outer_axes))
-        outer_index_expr = target.program_id(0)
-        inner_index_expr = "offsets"
+        reduction_axis = int(reduction_schedule["axis"])
+        parallel_shape = tuple(
+            str(axis) for axis in reduction_schedule.get("parallel_shape", ())
+        )
+        parallel_total = _product(parallel_shape)
+        program_index = target.program_id(0)
+        parallel_index = (
+            "0"
+            if _is_one_expr(parallel_total)
+            else _target_index_expr(target, f"({program_index}) % ({parallel_total})")
+        )
+        coordinate_exprs = []
+        parallel_dim = 0
+
+        for dim in range(len(value_axes)):
+            if dim == reduction_axis:
+                coordinate_exprs.append("offsets")
+                continue
+
+            coordinate_exprs.append(
+                _axis_offset_expr(
+                    parallel_shape,
+                    parallel_dim,
+                    parallel_index,
+                    target,
+                )
+            )
+            parallel_dim += 1
+
+        coordinate_exprs = tuple(coordinate_exprs)
+        total = _target_index_expr(target, str(reduction_schedule["extent"]))
+        outer_program_shape = outer_axes if split_outer_inner else ()
+        grid_total = _target_index_expr(
+            target,
+            _product((*outer_program_shape, *parallel_shape)),
+        )
+        outer_index_expr = (
+            "0"
+            if not outer_program_shape
+            else program_index
+            if _is_one_expr(parallel_total)
+            else _target_index_expr(
+                target, f"floor(({program_index})/({parallel_total}))"
+            )
+        )
+        inner_index_expr = _linearized_index(coordinate_exprs, value_axes)
     elif native_block_program:
         axes = value_axes
         total = _target_index_expr(target, _product(value_axes))
@@ -367,6 +436,8 @@ def _render_source(
         block_program=vector_block_program,
         native_block_program=native_block_program,
         vector_program=vector_reduction_program,
+        coordinate_exprs=(coordinate_exprs if vector_reduction_program else ()),
+        reduction_schedule=(reduction_schedule if vector_reduction_program else None),
     )
     body = _with_contiguous_1d_fast_path(
         kernel,
@@ -443,6 +514,9 @@ def _with_contiguous_1d_fast_path(
     vector_program: bool,
 ) -> str:
     logical_infos = tuple(tensor_infos[tensor.name] for tensor in kernel.tensors)
+
+    if vector_program:
+        return generic_body
 
     if not logical_infos or any(
         info.ndim != 1
@@ -560,10 +634,11 @@ def _render_body(
     native_block_program: bool = False,
     layout_contiguous: bool = False,
     vector_program: bool = False,
+    coordinate_exprs: tuple[str, ...] = (),
+    reduction_schedule: Mapping[str, Any] | None = None,
 ) -> str:
     output = outputs[0] if outputs else "out"
     lines: list[str] = []
-    coordinate_exprs: tuple[str, ...] = ()
     enable_index_cse = (
         not target.vector_value_semantics and outer_index_expr != inner_index_expr
     )
@@ -641,6 +716,7 @@ def _render_body(
         native_block_program=native_block_program,
         layout_contiguous=layout_contiguous,
         vector_program=vector_program,
+        reduction_lane="offsets" if reduction_schedule is not None else None,
     )
 
     for op in operations:
@@ -680,6 +756,24 @@ def _nested_local_suffix(ctx: _EmitContext, label: str) -> str:
     suffix = f"_{clean}_body"
 
     return f"{ctx.local_suffix}{suffix}" if ctx.local_suffix else suffix
+
+
+def _coords_use_reduction_lane(coords: tuple[str, ...], ctx: _EmitContext) -> bool:
+    return bool(
+        ctx.vector_program
+        and ctx.reduction_lane is not None
+        and ctx.reduction_lane in coords
+    )
+
+
+def _mask_for_coords(coords: tuple[str, ...], ctx: _EmitContext) -> str | None:
+    if not ctx.vector_program:
+        return ctx.mask_expr
+    return ctx.mask_expr if _coords_use_reduction_lane(coords, ctx) else None
+
+
+def _mask_for_axes(axes: tuple[str, ...], ctx: _EmitContext) -> str | None:
+    return _mask_for_coords(_current_coords(axes, ctx), ctx)
 
 
 def _emit_operation(op: ssa.Operation, ctx: _EmitContext) -> None:
@@ -753,7 +847,7 @@ def _emit_operation(op: ssa.Operation, ctx: _EmitContext) -> None:
         else:
             mask = _store_mask(
                 ctx.target,
-                ctx.mask_expr,
+                _mask_for_axes(_value_axes(tensor, ctx), ctx),
                 info,
                 view_index,
                 ctx=ctx,
@@ -804,6 +898,27 @@ def _emit_value(name: str, ctx: _EmitContext) -> str:
     local = _local_symbol(name, ctx)
 
     if op.opcode.startswith("reduce."):
+        if ctx.vector_program:
+            operator = op.opcode[len("reduce.") :]
+            operand_axes = _value_axes(op.operands[0], ctx)
+            operand = _emit_element(
+                op.operands[0], _current_coords(operand_axes, ctx), ctx
+            )
+            result_type = ssa.Type(
+                kind="scalar",
+                dtype=op.results[0].type.dtype if op.results else "float32",
+            )
+            identity = _reduction_identity(operator, result_type, ctx.target)
+
+            if ctx.mask_expr is not None:
+                operand = ctx.target.where(ctx.mask_expr, operand, identity)
+
+            expr = ctx.target.vector_reduce(operator, operand, 0)
+            ctx.lines.append(ctx.target.local_decl(result_type, local, expr))
+            ctx.memo[name] = local
+
+            return local
+
         if ctx.block_program:
             operator = op.opcode[len("reduce.") :]
             operand = _emit_value(op.operands[0], ctx)
@@ -1306,7 +1421,7 @@ def _emit_element(name: str, coords: tuple[str, ...], ctx: _EmitContext) -> str:
         )
 
     if op.opcode.startswith("reduce."):
-        if ctx.block_program:
+        if ctx.block_program or ctx.vector_program:
             return _emit_value(name, ctx)
         return _emit_reduce_element(op, coords, ctx)
 
@@ -1401,11 +1516,18 @@ def _emit_pointer_load(pointer: str, coords: tuple[str, ...], ctx: _EmitContext)
     address = _pointer_address(pointer, coords, ctx)
 
     if address is None:
+        if ctx.vector_program:
+            raise ValueError(
+                "Row-vector reductions require a decomposable pointer address."
+            )
+
         return ctx.target.call("load", (_emit_element(pointer, coords, ctx),))
 
     base, offset = address
 
-    return ctx.target.load(base, offset)
+    mask = _mask_for_coords(coords, ctx) if ctx.vector_program else None
+
+    return ctx.target.load(base, offset, mask=mask)
 
 
 def _pointer_address(
@@ -1446,21 +1568,19 @@ def _pointer_address(
 
 
 def _reduction_identity(operator: str, type_: ssa.Type, target: _Target) -> str:
-    if operator == "sum":
-        return "0.0"
-
     dtype = _normalize_dtype(type_.dtype or "float32")
+
+    if operator == "sum":
+        return target.literal(0.0 if "float" in dtype else 0)
 
     if dtype == "bool":
         return target.literal(operator == "min")
 
+    if dtype in {"float8_e5m2", "float16", "bfloat16", "float32", "float64"}:
+        return target.literal(float("-inf") if operator == "max" else float("inf"))
+
     limits: Mapping[str, tuple[int | float, int | float]] = {
         "float8_e4m3fn": (-448.0, 448.0),
-        "float8_e5m2": (-57344.0, 57344.0),
-        "float16": (-65504.0, 65504.0),
-        "bfloat16": (-3.3895313892515355e38, 3.3895313892515355e38),
-        "float32": (-3.4028234663852886e38, 3.4028234663852886e38),
-        "float64": (-1.7976931348623157e308, 1.7976931348623157e308),
         "int8": (-128, 127),
         "uint8": (0, 255),
         "int16": (-32768, 32767),
@@ -1631,7 +1751,7 @@ def _load_tensor_at(
     source_index = _materialize_index_expr(source_index, ctx)
     mask = _combined_mask(
         ctx.target,
-        ctx.mask_expr if ctx.target.vector_value_semantics else None,
+        (_mask_for_coords(coords, ctx) if ctx.target.vector_value_semantics else None),
         info,
         view_index,
         ctx=ctx,
@@ -1779,6 +1899,11 @@ def _current_coords(axes: tuple[str, ...], ctx: _EmitContext) -> tuple[str, ...]
             _axis_offset_expr(output_axes, dim, ctx.inner_index_expr, ctx.target)
             for dim in range(len(output_axes))
         )
+        vector_reduction_axis = (
+            output_coords.index(ctx.reduction_lane)
+            if ctx.vector_program and ctx.reduction_lane in output_coords
+            else None
+        )
         coords: tuple[str, ...] | None = None
 
         if len(axes) == len(output_axes):
@@ -1786,6 +1911,18 @@ def _current_coords(axes: tuple[str, ...], ctx: _EmitContext) -> tuple[str, ...]
                 "0" if axis == "1" else output_coords[index]
                 for index, axis in enumerate(axes)
             )
+        elif vector_reduction_axis is not None and len(axes) == len(output_axes) - 1:
+            parallel_dims = tuple(
+                index
+                for index in range(len(output_axes))
+                if index != vector_reduction_axis
+            )
+
+            if axes == tuple(output_axes[index] for index in parallel_dims):
+                coords = tuple(
+                    "0" if axis == "1" else output_coords[parallel_dim]
+                    for axis, parallel_dim in zip(axes, parallel_dims)
+                )
         elif len(axes) < len(output_axes):
             if _axes_compatible_prefix(axes, output_axes):
                 coords = tuple(
@@ -2457,9 +2594,10 @@ def _source_bounds_mask(
     info: _TensorInfo | None, indices: tuple[str, ...], ctx: _EmitContext
 ) -> str | None:
     checks = []
+    base_mask = _mask_for_coords(indices, ctx)
 
-    if ctx.mask_expr:
-        checks.append(ctx.mask_expr)
+    if base_mask:
+        checks.append(base_mask)
 
     shape = () if info is None else info.source_shape
 
@@ -2959,6 +3097,12 @@ def _store_index(op: ssa.Operation, ctx: _EmitContext) -> str:
         rendered = tuple(_emit_index_value(str(index), ctx) for index in indices)
 
         return _linearized_index(rendered, _value_axes(op.operands[1], ctx))
+
+    if ctx.vector_program:
+        axes = _value_axes(op.operands[1], ctx)
+        coords = _current_coords(axes, ctx)
+
+        return _linearized_index(coords, axes) if coords else "0"
 
     if ctx.block_program and ctx.coordinate_exprs:
         return _linearized_index(ctx.coordinate_exprs, ctx.output_axes)

--- a/src/ninetoothed/backends/materializers/triton.py
+++ b/src/ninetoothed/backends/materializers/triton.py
@@ -379,14 +379,19 @@ def _triton_prepare_invocation(function, kernel):
 
 def _tensor_memory_span(value):
     try:
+        device = value.device
+    except (AttributeError, RuntimeError, TypeError):
+        device = None
+
+    try:
         shape = tuple(value.shape)
 
         if any(size == 0 for size in shape):
-            return None
+            return (device, 0, 0)
 
         element_size = value.element_size()
-        storage = value.untyped_storage().data_ptr()
-        lower = upper = value.storage_offset()
+        data_ptr = value.data_ptr()
+        lower = upper = 0
 
         for size, stride in zip(shape, value.stride()):
             extent = (size - 1) * stride
@@ -394,65 +399,95 @@ def _tensor_memory_span(value):
             upper += max(0, extent)
 
         return (
-            value.device,
-            storage,
-            storage + lower * element_size,
-            storage + (upper + 1) * element_size,
+            device,
+            data_ptr + lower * element_size,
+            data_ptr + (upper + 1) * element_size,
         )
     except (AttributeError, RuntimeError, TypeError):
-        return None
+        return (device, None, None)
+
+
+def _memory_spans_overlap(first, second):
+    first_device, first_start, first_end = first
+    second_device, second_start, second_end = second
+
+    if (
+        first_device is not None
+        and second_device is not None
+        and first_device != second_device
+    ):
+        return False
+
+    if None in (first_start, first_end, second_start, second_end):
+        return True
+
+    if first_start == first_end or second_start == second_end:
+        return False
+
+    return first_start < second_end and second_start < first_end
 
 
 def _runtime_alias_signature(abi, public):
     from ninetoothed.compiler.runtime import _binding_value
 
     output_names = set(abi.outputs)
-    physical_tensors = []
-    seen = set()
+    physical_tensors = {}
     aliases = []
 
     for binding in abi.kernel_args:
-        if (
-            binding.kind not in {"tensor", "jagged_values", "jagged_offsets"}
-            or binding.source not in public
+        if binding.source not in public or binding.kind not in {
+            "tensor",
+            "scalar",
+            "constexpr",
+            "jagged_values",
+            "jagged_offsets",
+        }:
+            continue
+
+        value = _binding_value(binding, public)
+
+        if binding.kind in {"scalar", "constexpr"} and not all(
+            hasattr(value, attribute) for attribute in ("data_ptr", "shape", "stride")
         ):
             continue
 
         identity = (binding.source, binding.kind)
-
-        if identity in seen:
-            continue
-
-        seen.add(identity)
-        value = _binding_value(binding, public)
         access = binding.access or (
             "read"
-            if binding.kind == "jagged_offsets"
-            else "write"
+            if binding.kind in {"scalar", "constexpr", "jagged_offsets"}
+            else "read_write"
             if binding.source in output_names
             else "read"
         )
-        physical_tensors.append((*identity, access, value, _tensor_memory_span(value)))
+        previous = physical_tensors.get(identity)
+
+        if previous is not None and previous[2] != access:
+            access = "read_write"
+
+        physical_tensors[identity] = (
+            *identity,
+            access,
+            value,
+            _tensor_memory_span(value),
+        )
 
     writers = tuple(
-        tensor for tensor in physical_tensors if tensor[2] in {"write", "read_write"}
+        tensor
+        for tensor in physical_tensors.values()
+        if tensor[2] in {"write", "read_write"}
     )
     readers = tuple(
-        tensor for tensor in physical_tensors if tensor[2] in {"read", "read_write"}
+        tensor
+        for tensor in physical_tensors.values()
+        if tensor[2] in {"read", "read_write"}
     )
 
     for writer_name, writer_kind, _access, writer, writer_span in writers:
         for reader_name, reader_kind, _access, reader, reader_span in readers:
             overlaps = writer is reader
 
-            if not overlaps and (
-                writer_span is not None
-                and reader_span is not None
-                and writer_span[:2] == reader_span[:2]
-                and writer_span[2] < reader_span[3]
-                and reader_span[2] < writer_span[3]
-            ):
-                overlaps = True
+            if not overlaps:
+                overlaps = _memory_spans_overlap(writer_span, reader_span)
 
             if overlaps:
                 aliases.append((writer_name, writer_kind, reader_name, reader_kind))
@@ -489,7 +524,10 @@ def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
         nonlocal active, active_identity
         active_identity = identity
         active = entry
-        handle._selected_tuning_candidate = candidates_by_launch[entry[1]]
+        record(entry[1])
+
+    def record(selected):
+        handle._selected_tuning_candidate = candidates_by_launch[selected]
 
     def remember(identity, selection_key, selected, prepared):
         token = object()
@@ -507,6 +545,12 @@ def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
         activate(identity, entry)
 
         return prepared
+
+    def remember_best_effort(identity, selection_key, selected, prepared):
+        try:
+            return remember(identity, selection_key, selected, prepared)
+        except TypeError:
+            return None
 
     def launch(*args, **kwargs):
         active_snapshot = active
@@ -566,49 +610,64 @@ def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
             selected = cached[1]
 
         if selected is None and alias_signature:
-            failures = []
+            selected = tuner._funcs[0]
 
-            for candidate in tuner._funcs:
-                try:
-                    prepared = candidate._ninetoothed_prepare(
-                        args,
-                        kwargs,
-                        public=public,
-                    )
-                    result = candidate._ninetoothed_invoke_prepared(
-                        prepared,
-                        args,
-                        kwargs,
-                    )
-                except Exception as exc:  # noqa: BLE001
-                    candidate_id = candidates_by_launch[candidate].get("id", "unknown")
-                    failures.append(f"{candidate_id}: {type(exc).__name__}: {exc}")
-                    continue
+            try:
+                prepared = selected._ninetoothed_prepare(
+                    args,
+                    kwargs,
+                    public=public,
+                )
+            except Exception:  # noqa: BLE001
+                result = selected(*args, **kwargs)
+            else:
+                result = selected._ninetoothed_invoke_prepared(
+                    prepared,
+                    args,
+                    kwargs,
+                )
+                remember_best_effort(
+                    identity,
+                    selection_key,
+                    selected,
+                    prepared,
+                )
 
-                remember(identity, selection_key, candidate, prepared)
+            record(selected)
 
-                return result
-
-            raise RuntimeError(
-                "All alias-safe Triton candidates failed: " + "; ".join(failures)
-            )
+            return result
 
         if selected is None:
             result = tuner(*args, **kwargs)
             selected = tuner._best_func[key]
-            prepared = selected._ninetoothed_prepare(args, kwargs, public=public)
-            remember(identity, selection_key, selected, prepared)
+            record(selected)
+
+            try:
+                prepared = selected._ninetoothed_prepare(args, kwargs, public=public)
+            except Exception:  # noqa: BLE001
+                return result
+
+            remember_best_effort(identity, selection_key, selected, prepared)
 
             return result
 
-        prepared = selected._ninetoothed_prepare(args, kwargs, public=public)
-        cached_prepared = remember(identity, selection_key, selected, prepared)
+        try:
+            prepared = selected._ninetoothed_prepare(args, kwargs, public=public)
+        except Exception:  # noqa: BLE001
+            result = selected(*args, **kwargs)
+            record(selected)
 
-        return selected._ninetoothed_invoke_prepared(
-            cached_prepared or prepared,
+            return result
+
+        result = selected._ninetoothed_invoke_prepared(
+            prepared,
             args,
             kwargs,
         )
+        record(selected)
+        remember_best_effort(identity, selection_key, selected, prepared)
+
+        return result
 
     return launch
 

--- a/src/ninetoothed/backends/materializers/triton.py
+++ b/src/ninetoothed/backends/materializers/triton.py
@@ -181,6 +181,7 @@ def _candidate_launch(compilation, launch, kernel, candidate):
         _ninetoothed_num_warps=int(candidate["num_warps"]),
         _ninetoothed_num_stages=int(candidate["num_stages"]),
     )
+
     return _runtime_wrapper(
         function,
         compilation.launch_abi,
@@ -324,6 +325,7 @@ def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
         ):
             prepared_calls[identity] = cached
             activate(identity, cached)
+
             return cached[1]._ninetoothed_invoke_prepared(cached[2], args, kwargs)
 
         public = _public_values(
@@ -361,10 +363,12 @@ def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
             selected = tuner._best_func[key]
             prepared = selected._ninetoothed_prepare(args, kwargs, public=public)
             remember(identity, key, selected, prepared)
+
             return result
 
         prepared = selected._ninetoothed_prepare(args, kwargs, public=public)
         remember(identity, key, selected, prepared)
+
         return selected._ninetoothed_invoke_prepared(prepared, args, kwargs)
 
     return launch
@@ -393,6 +397,7 @@ def _triton_specialization_key(compilation, args, kwargs):
         scalar_values.append((binding.source, type(value).__name__, repr(value)))
 
     base = AutoTuner._make_arg_key(args, kwargs)
+
     return f"{base}, specialization={tuple(scalar_values)!r}"
 
 

--- a/src/ninetoothed/backends/materializers/triton.py
+++ b/src/ninetoothed/backends/materializers/triton.py
@@ -8,6 +8,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import types
 from dataclasses import replace
 from pathlib import Path
 
@@ -99,6 +100,7 @@ def _materialize(compilation):
     from ninetoothed.compiler.runtime import (
         Handle,
         _runtime_wrapper,
+        _verified_runtime_launch,
         import_python_module,
     )
 
@@ -115,16 +117,23 @@ def _materialize(compilation):
     os.environ.setdefault("TRITON_CACHE_DIR", str(TRITON_CACHE_DIR))
     module = import_python_module(source)
     launch = getattr(module, artifact.entrypoint)
+    kernel = getattr(module, f"{artifact.kernel_name}_kernel", None)
     candidates = tuple(compilation.launch_plan.tuning_candidates)
     candidate_launches = tuple(
-        _candidate_launch(compilation, launch, candidate) for candidate in candidates
+        _candidate_launch(compilation, launch, kernel, candidate)
+        for candidate in candidates
     )
     tuner = None
 
     if len(candidate_launches) > 1:
         from ninetoothed.auto_tuner import AutoTuner
 
-        tuner = AutoTuner(
+        class TritonAutoTuner(AutoTuner):
+            @staticmethod
+            def _make_arg_key(args, kwargs):
+                return _triton_specialization_key(compilation, args, kwargs)
+
+        tuner = TritonAutoTuner(
             candidate_launches,
             tuple((cache_key, candidate["id"]) for candidate in candidates),
             cache_namespace=f"jit_{cache_key}",
@@ -132,59 +141,259 @@ def _materialize(compilation):
         )
         wrapped = tuner
     elif candidate_launches:
-        wrapped = candidate_launches[0]
+        wrapped = _verified_runtime_launch(candidate_launches[0])
     else:
-        wrapped = _runtime_wrapper(
-            launch,
-            compilation.launch_abi,
-            specs=compilation.kernel.tensors,
+        wrapped = _verified_runtime_launch(
+            _runtime_wrapper(
+                launch,
+                compilation.launch_abi,
+                specs=compilation.kernel.tensors,
+                prepare_invocation=_triton_prepare_invocation(launch, kernel),
+            )
         )
 
-    kernel = getattr(module, f"{artifact.kernel_name}_kernel", None)
     handle = Handle(compilation, kernel, wrapped, source)
     handle._tuner = tuner
     handle._selected_tuning_candidate = candidates[0] if len(candidates) == 1 else None
 
     if tuner is not None:
         by_launch = dict(zip(candidate_launches, candidates))
-
-        def tuned_launch(*args, **kwargs):
-            result = tuner(*args, **kwargs)
-            arg_key = tuner._make_arg_key(args, kwargs)
-            handle._selected_tuning_candidate = by_launch[tuner._best_func[arg_key]]
-
-            return result
-
-        handle._launch = tuned_launch
+        handle._launch = _tuned_runtime_launch(
+            tuner,
+            by_launch,
+            handle,
+            compilation,
+        )
 
     return handle
 
 
-def _candidate_launch(compilation, launch, candidate):
+def _candidate_launch(compilation, launch, kernel, candidate):
     from ninetoothed.compiler.runtime import _runtime_wrapper
 
-    wrapped = _runtime_wrapper(
-        functools.partial(
-            launch,
-            _ninetoothed_num_warps=int(candidate["num_warps"]),
-            _ninetoothed_num_stages=int(candidate["num_stages"]),
-        ),
-        compilation.launch_abi,
-        specs=compilation.kernel.tensors,
-    )
     bindings = {binding.name: binding for binding in compilation.launch_abi.kernel_args}
-    meta_kwargs = {
+    meta_values = {
         str(bindings[name].source): value
         for name, value in dict(candidate.get("meta_parameters", {})).items()
     }
+    function = functools.partial(
+        launch,
+        _ninetoothed_num_warps=int(candidate["num_warps"]),
+        _ninetoothed_num_stages=int(candidate["num_stages"]),
+    )
+    return _runtime_wrapper(
+        function,
+        compilation.launch_abi,
+        specs=compilation.kernel.tensors,
+        binding_overrides=meta_values,
+        prepare_invocation=_triton_prepare_invocation(function, kernel),
+    )
 
-    if not meta_kwargs:
-        return wrapped
 
-    def launch_candidate(*args, **kwargs):
-        return wrapped(*args, **(dict(kwargs) | meta_kwargs))
+def _triton_prepare_invocation(function, kernel):
+    if kernel is None:
+        return None
 
-    return launch_candidate
+    target = getattr(function, "func", function)
+
+    if not isinstance(target, types.FunctionType):
+        return None
+
+    kernel_names = tuple(
+        name
+        for name in target.__code__.co_names
+        if target.__globals__.get(name) is kernel
+    )
+
+    if len(kernel_names) != 1:
+        return None
+
+    kernel_name = kernel_names[0]
+    partial_args = getattr(function, "args", ())
+    partial_keywords = getattr(function, "keywords", None) or {}
+
+    def prepare(values):
+        calls = []
+
+        class KernelProxy:
+            def __getitem__(self, grid):
+                bound_kernel = kernel[grid]
+
+                def capture(*args, **kwargs):
+                    calls.append((bound_kernel, args, kwargs))
+
+                return capture
+
+        globals_copy = dict(target.__globals__)
+        globals_copy[kernel_name] = KernelProxy()
+        dry_launch = types.FunctionType(
+            target.__code__,
+            globals_copy,
+            target.__name__,
+            target.__defaults__,
+            target.__closure__,
+        )
+        dry_launch.__kwdefaults__ = target.__kwdefaults__
+        functools.partial(
+            dry_launch,
+            *partial_args,
+            **partial_keywords,
+        )(*values)
+        bound_calls = tuple(calls)
+
+        if not bound_calls:
+            return None
+
+        def invoke():
+            for bound_kernel, args, kwargs in bound_calls:
+                bound_kernel(*args, **kwargs)
+
+        return invoke
+
+    return prepare
+
+
+def _runtime_outputs_alias_inputs(abi, public):
+    outputs = {
+        name: public[name]
+        for name in abi.outputs
+        if name in public and hasattr(public[name], "data_ptr")
+    }
+
+    for output_name, output in outputs.items():
+        for input_name, value in public.items():
+            if input_name == output_name or not hasattr(value, "data_ptr"):
+                continue
+
+            if output is value:
+                return True
+
+            try:
+                same_device = output.device == value.device
+                output_storage = output.untyped_storage().data_ptr()
+                input_storage = value.untyped_storage().data_ptr()
+            except (AttributeError, RuntimeError, TypeError):
+                continue
+
+            if same_device and output_storage == input_storage:
+                return True
+
+    return False
+
+
+def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
+    from ninetoothed.compiler.runtime import (
+        _empty_launch,
+        _first_output,
+        _public_values,
+        _remember_verified_runtime_call,
+        _runtime_call_identity,
+    )
+
+    active_identity = None
+    active = None
+    prepared_calls = {}
+
+    def activate(identity, entry):
+        nonlocal active, active_identity
+        active_identity = identity
+        active = entry
+        handle._selected_tuning_candidate = candidates_by_launch[entry[1]]
+
+    def remember(identity, key, selected, prepared):
+        entry = (key, selected, prepared)
+        _remember_verified_runtime_call(prepared_calls, identity, entry)
+        activate(identity, entry)
+
+    def launch(*args, **kwargs):
+        identity = _runtime_call_identity(args, kwargs)
+
+        if (
+            active is not None
+            and identity == active_identity
+            and active[2].guard.matches(args, kwargs, identity_verified=True)
+        ):
+            return active[1]._ninetoothed_invoke_prepared(active[2], args, kwargs)
+
+        cached = prepared_calls.pop(identity, None)
+
+        if cached is not None and cached[2].guard.matches(
+            args,
+            kwargs,
+            identity_verified=True,
+        ):
+            prepared_calls[identity] = cached
+            activate(identity, cached)
+            return cached[1]._ninetoothed_invoke_prepared(cached[2], args, kwargs)
+
+        public = _public_values(
+            compilation.launch_abi,
+            args,
+            kwargs,
+            specs=compilation.kernel.tensors,
+        )
+
+        if _empty_launch(compilation.launch_abi, public):
+            return _first_output(compilation.launch_abi, public)
+
+        key = tuner._make_arg_key(args, kwargs)
+        selected = next(
+            (
+                entry[1]
+                for entry in reversed(tuple(prepared_calls.values()))
+                if entry[0] == key
+            ),
+            None,
+        )
+
+        if selected is None and cached is not None and cached[0] == key:
+            selected = cached[1]
+
+        if selected is None and _runtime_outputs_alias_inputs(
+            compilation.launch_abi,
+            public,
+        ):
+            selected = tuner._funcs[0]
+            tuner._best_func[key] = selected
+
+        if selected is None:
+            result = tuner(*args, **kwargs)
+            selected = tuner._best_func[key]
+            prepared = selected._ninetoothed_prepare(args, kwargs, public=public)
+            remember(identity, key, selected, prepared)
+            return result
+
+        prepared = selected._ninetoothed_prepare(args, kwargs, public=public)
+        remember(identity, key, selected, prepared)
+        return selected._ninetoothed_invoke_prepared(prepared, args, kwargs)
+
+    return launch
+
+
+def _triton_specialization_key(compilation, args, kwargs):
+    from ninetoothed.auto_tuner import AutoTuner
+
+    public = dict(zip(compilation.launch_abi.public_args, args))
+    public.update(kwargs)
+    scalar_values = []
+
+    for binding in compilation.launch_abi.kernel_args:
+        if (
+            binding.kind not in {"scalar", "constexpr", "meta"}
+            or binding.source not in public
+        ):
+            continue
+
+        value = public[binding.source]
+        shape = getattr(value, "shape", None)
+
+        if shape is not None and not tuple(shape) and hasattr(value, "item"):
+            value = value.item()
+
+        scalar_values.append((binding.source, type(value).__name__, repr(value)))
+
+    base = AutoTuner._make_arg_key(args, kwargs)
+    return f"{base}, specialization={tuple(scalar_values)!r}"
 
 
 def _runtime_validator(compilation):

--- a/src/ninetoothed/backends/materializers/triton.py
+++ b/src/ninetoothed/backends/materializers/triton.py
@@ -425,28 +425,37 @@ def _runtime_alias_signature(abi, public):
 
         seen.add(identity)
         value = _binding_value(binding, public)
-        physical_tensors.append((*identity, value, _tensor_memory_span(value)))
+        access = binding.access or (
+            "read"
+            if binding.kind == "jagged_offsets"
+            else "write"
+            if binding.source in output_names
+            else "read"
+        )
+        physical_tensors.append((*identity, access, value, _tensor_memory_span(value)))
 
-    outputs = tuple(tensor for tensor in physical_tensors if tensor[0] in output_names)
-    inputs = tuple(
-        tensor for tensor in physical_tensors if tensor[0] not in output_names
+    writers = tuple(
+        tensor for tensor in physical_tensors if tensor[2] in {"write", "read_write"}
+    )
+    readers = tuple(
+        tensor for tensor in physical_tensors if tensor[2] in {"read", "read_write"}
     )
 
-    for output_name, output_kind, output, output_span in outputs:
-        for input_name, input_kind, value, input_span in inputs:
-            overlaps = output is value
+    for writer_name, writer_kind, _access, writer, writer_span in writers:
+        for reader_name, reader_kind, _access, reader, reader_span in readers:
+            overlaps = writer is reader
 
             if not overlaps and (
-                output_span is not None
-                and input_span is not None
-                and output_span[:2] == input_span[:2]
-                and output_span[2] < input_span[3]
-                and input_span[2] < output_span[3]
+                writer_span is not None
+                and reader_span is not None
+                and writer_span[:2] == reader_span[:2]
+                and writer_span[2] < reader_span[3]
+                and reader_span[2] < writer_span[3]
             ):
                 overlaps = True
 
             if overlaps:
-                aliases.append((output_name, output_kind, input_name, input_kind))
+                aliases.append((writer_name, writer_kind, reader_name, reader_kind))
 
     return tuple(aliases)
 

--- a/src/ninetoothed/backends/materializers/triton.py
+++ b/src/ninetoothed/backends/materializers/triton.py
@@ -292,6 +292,7 @@ def _triton_prepare_invocation(function, kernel):
         def expression(value):
             if isinstance(value, CallRef):
                 container = "_args" if value.kind == "positional" else "_kwargs"
+
                 return f"{container}[{value.key!r}]"
 
             name = f"_value_{len(namespace)}"
@@ -376,32 +377,64 @@ def _triton_prepare_invocation(function, kernel):
     return prepare
 
 
-def _runtime_outputs_alias_inputs(abi, public):
-    outputs = {
-        name: public[name]
-        for name in abi.outputs
-        if name in public and hasattr(public[name], "data_ptr")
-    }
+def _tensor_memory_span(value):
+    try:
+        shape = tuple(value.shape)
 
-    for output_name, output in outputs.items():
+        if any(size == 0 for size in shape):
+            return None
+
+        element_size = value.element_size()
+        storage = value.untyped_storage().data_ptr()
+        lower = upper = value.storage_offset()
+
+        for size, stride in zip(shape, value.stride()):
+            extent = (size - 1) * stride
+            lower += min(0, extent)
+            upper += max(0, extent)
+
+        return (
+            value.device,
+            storage,
+            storage + lower * element_size,
+            storage + (upper + 1) * element_size,
+        )
+    except (AttributeError, RuntimeError, TypeError):
+        return None
+
+
+def _runtime_alias_signature(abi, public):
+    output_names = set(abi.outputs)
+    aliases = []
+
+    for output_name in abi.outputs:
+        output = public.get(output_name)
+
+        if output is None or not hasattr(output, "data_ptr"):
+            continue
+
+        output_span = _tensor_memory_span(output)
+
         for input_name, value in public.items():
-            if input_name == output_name or not hasattr(value, "data_ptr"):
+            if input_name in output_names or not hasattr(value, "data_ptr"):
                 continue
 
             if output is value:
-                return True
-
-            try:
-                same_device = output.device == value.device
-                output_storage = output.untyped_storage().data_ptr()
-                input_storage = value.untyped_storage().data_ptr()
-            except (AttributeError, RuntimeError, TypeError):
+                aliases.append((output_name, input_name))
                 continue
 
-            if same_device and output_storage == input_storage:
-                return True
+            input_span = _tensor_memory_span(value)
 
-    return False
+            if (
+                output_span is not None
+                and input_span is not None
+                and output_span[:2] == input_span[:2]
+                and output_span[2] < input_span[3]
+                and input_span[2] < output_span[3]
+            ):
+                aliases.append((output_name, input_name))
+
+    return tuple(aliases)
 
 
 def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
@@ -435,7 +468,7 @@ def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
         active = entry
         handle._selected_tuning_candidate = candidates_by_launch[entry[1]]
 
-    def remember(identity, key, selected, prepared):
+    def remember(identity, selection_key, selected, prepared):
         token = object()
 
         def collected(_reference):
@@ -446,7 +479,7 @@ def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
         if prepared is None:
             return None
 
-        entry = (key, selected, prepared)
+        entry = (selection_key, selected, prepared)
         _remember_verified_runtime_call(prepared_calls, identity, entry)
         activate(identity, entry)
 
@@ -495,35 +528,58 @@ def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
             return _first_output(compilation.launch_abi, public)
 
         key = tuner._make_arg_key(args, kwargs)
+        alias_signature = _runtime_alias_signature(compilation.launch_abi, public)
+        selection_key = (key, alias_signature)
         selected = next(
             (
                 entry[1]
                 for entry in reversed(tuple(prepared_calls.values()))
-                if entry[0] == key
+                if entry[0] == selection_key
             ),
             None,
         )
 
-        if selected is None and cached is not None and cached[0] == key:
+        if selected is None and cached is not None and cached[0] == selection_key:
             selected = cached[1]
 
-        if selected is None and _runtime_outputs_alias_inputs(
-            compilation.launch_abi,
-            public,
-        ):
-            selected = tuner._funcs[0]
-            tuner._best_func[key] = selected
+        if selected is None and alias_signature:
+            failures = []
+
+            for candidate in tuner._funcs:
+                try:
+                    prepared = candidate._ninetoothed_prepare(
+                        args,
+                        kwargs,
+                        public=public,
+                    )
+                    result = candidate._ninetoothed_invoke_prepared(
+                        prepared,
+                        args,
+                        kwargs,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    candidate_id = candidates_by_launch[candidate].get("id", "unknown")
+                    failures.append(f"{candidate_id}: {type(exc).__name__}: {exc}")
+                    continue
+
+                remember(identity, selection_key, candidate, prepared)
+
+                return result
+
+            raise RuntimeError(
+                "All alias-safe Triton candidates failed: " + "; ".join(failures)
+            )
 
         if selected is None:
             result = tuner(*args, **kwargs)
             selected = tuner._best_func[key]
             prepared = selected._ninetoothed_prepare(args, kwargs, public=public)
-            remember(identity, key, selected, prepared)
+            remember(identity, selection_key, selected, prepared)
 
             return result
 
         prepared = selected._ninetoothed_prepare(args, kwargs, public=public)
-        cached_prepared = remember(identity, key, selected, prepared)
+        cached_prepared = remember(identity, selection_key, selected, prepared)
 
         return selected._ninetoothed_invoke_prepared(
             cached_prepared or prepared,

--- a/src/ninetoothed/backends/materializers/triton.py
+++ b/src/ninetoothed/backends/materializers/triton.py
@@ -404,35 +404,49 @@ def _tensor_memory_span(value):
 
 
 def _runtime_alias_signature(abi, public):
+    from ninetoothed.compiler.runtime import _binding_value
+
     output_names = set(abi.outputs)
+    physical_tensors = []
+    seen = set()
     aliases = []
 
-    for output_name in abi.outputs:
-        output = public.get(output_name)
-
-        if output is None or not hasattr(output, "data_ptr"):
+    for binding in abi.kernel_args:
+        if (
+            binding.kind not in {"tensor", "jagged_values", "jagged_offsets"}
+            or binding.source not in public
+        ):
             continue
 
-        output_span = _tensor_memory_span(output)
+        identity = (binding.source, binding.kind)
 
-        for input_name, value in public.items():
-            if input_name in output_names or not hasattr(value, "data_ptr"):
-                continue
+        if identity in seen:
+            continue
 
-            if output is value:
-                aliases.append((output_name, input_name))
-                continue
+        seen.add(identity)
+        value = _binding_value(binding, public)
+        physical_tensors.append((*identity, value, _tensor_memory_span(value)))
 
-            input_span = _tensor_memory_span(value)
+    outputs = tuple(tensor for tensor in physical_tensors if tensor[0] in output_names)
+    inputs = tuple(
+        tensor for tensor in physical_tensors if tensor[0] not in output_names
+    )
 
-            if (
+    for output_name, output_kind, output, output_span in outputs:
+        for input_name, input_kind, value, input_span in inputs:
+            overlaps = output is value
+
+            if not overlaps and (
                 output_span is not None
                 and input_span is not None
                 and output_span[:2] == input_span[:2]
                 and output_span[2] < input_span[3]
                 and input_span[2] < output_span[3]
             ):
-                aliases.append((output_name, input_name))
+                overlaps = True
+
+            if overlaps:
+                aliases.append((output_name, output_kind, input_name, input_kind))
 
     return tuple(aliases)
 

--- a/src/ninetoothed/backends/materializers/triton.py
+++ b/src/ninetoothed/backends/materializers/triton.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 import tempfile
 import types
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 from ninetoothed.backends.core import BuiltArtifact, Target
@@ -192,6 +192,8 @@ def _candidate_launch(compilation, launch, kernel, candidate):
 
 
 def _triton_prepare_invocation(function, kernel):
+    from ninetoothed.compiler.runtime import _is_cacheable_runtime_literal
+
     if kernel is None:
         return None
 
@@ -213,7 +215,100 @@ def _triton_prepare_invocation(function, kernel):
     partial_args = getattr(function, "args", ())
     partial_keywords = getattr(function, "keywords", None) or {}
 
-    def prepare(values):
+    @dataclass(frozen=True)
+    class ValueRef:
+        index: int
+
+        def resolve(self, values, _args, _kwargs):
+            return values[self.index]
+
+    @dataclass(frozen=True)
+    class CallRef:
+        kind: str
+        key: object
+
+        def resolve(self, _values, args, kwargs):
+            return args[self.key] if self.kind == "positional" else kwargs[self.key]
+
+    @dataclass(frozen=True)
+    class Literal:
+        value: object
+
+        def resolve(self, _values, _args, _kwargs):
+            return self.value
+
+    @dataclass(frozen=True)
+    class BoundCall:
+        function: object
+        args: tuple
+        kwargs: tuple
+
+        def invoke(self, values, args, kwargs):
+            self.function(
+                *(value.resolve(values, args, kwargs) for value in self.args),
+                **{
+                    name: value.resolve(values, args, kwargs)
+                    for name, value in self.kwargs
+                },
+            )
+
+    @dataclass(frozen=True)
+    class InvocationPlan:
+        call: object
+        requires_values: bool
+
+        def __call__(self, values, args, kwargs):
+            if self.requires_values:
+                self.call.invoke(values, args, kwargs)
+            else:
+                self.call(args, kwargs)
+
+    def plan_value(value, values, static_values, call_sources):
+        for index, candidate in enumerate(values):
+            if value is candidate:
+                if call_sources is not None and call_sources[index] is not None:
+                    return CallRef(*call_sources[index])
+
+                return (
+                    Literal(static_values[index])
+                    if static_values is not None
+                    else ValueRef(index)
+                )
+
+        if hasattr(value, "data_ptr") or (
+            hasattr(value, "shape") and hasattr(value, "dtype")
+        ):
+            return None
+
+        if _is_cacheable_runtime_literal(value):
+            return Literal(value)
+
+        return None
+
+    def build_direct_invocation(function, args, kwargs):
+        namespace = {"_function": function}
+        expressions = []
+
+        def expression(value):
+            if isinstance(value, CallRef):
+                container = "_args" if value.kind == "positional" else "_kwargs"
+                return f"{container}[{value.key!r}]"
+
+            name = f"_value_{len(namespace)}"
+            namespace[name] = value.value
+
+            return name
+
+        expressions.extend(expression(value) for value in args)
+        expressions.extend(f"{name}={expression(value)}" for name, value in kwargs)
+        source = (
+            "def invoke(_args, _kwargs):\n    _function(" + ", ".join(expressions) + ")"
+        )
+        exec(compile(source, "<ninetoothed-triton-invocation>", "exec"), namespace)
+
+        return namespace["invoke"]
+
+    def prepare(values, static_values=None, call_sources=None):
         calls = []
 
         class KernelProxy:
@@ -240,16 +335,43 @@ def _triton_prepare_invocation(function, kernel):
             *partial_args,
             **partial_keywords,
         )(*values)
-        bound_calls = tuple(calls)
 
-        if not bound_calls:
+        if len(calls) != 1:
             return None
 
-        def invoke():
-            for bound_kernel, args, kwargs in bound_calls:
-                bound_kernel(*args, **kwargs)
+        bound_kernel, args, kwargs = calls[0]
+        planned_args = tuple(
+            plan_value(value, values, static_values, call_sources) for value in args
+        )
+        planned_kwargs = tuple(
+            (
+                name,
+                plan_value(value, values, static_values, call_sources),
+            )
+            for name, value in kwargs.items()
+        )
 
-        return invoke
+        if any(value is None for value in planned_args) or any(
+            value is None for _name, value in planned_kwargs
+        ):
+            return None
+
+        planned_call = BoundCall(bound_kernel, planned_args, planned_kwargs)
+
+        requires_values = any(
+            isinstance(value, ValueRef) for value in planned_args
+        ) or any(isinstance(value, ValueRef) for _name, value in planned_kwargs)
+
+        if requires_values:
+            return InvocationPlan(planned_call, True)
+
+        direct_call = build_direct_invocation(
+            planned_call.function,
+            planned_call.args,
+            planned_call.kwargs,
+        )
+
+        return InvocationPlan(direct_call, False)
 
     return prepare
 
@@ -284,6 +406,7 @@ def _runtime_outputs_alias_inputs(abi, public):
 
 def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
     from ninetoothed.compiler.runtime import (
+        _arm_prepared_runtime_launch,
         _empty_launch,
         _first_output,
         _public_values,
@@ -295,6 +418,17 @@ def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
     active = None
     prepared_calls = {}
 
+    def evict(identity, token):
+        nonlocal active, active_identity
+        cached = prepared_calls.get(identity)
+
+        if cached is not None and cached[2].cache_token is token:
+            prepared_calls.pop(identity, None)
+
+        if active is not None and active[2].cache_token is token:
+            active = None
+            active_identity = None
+
     def activate(identity, entry):
         nonlocal active, active_identity
         active_identity = identity
@@ -302,23 +436,45 @@ def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
         handle._selected_tuning_candidate = candidates_by_launch[entry[1]]
 
     def remember(identity, key, selected, prepared):
+        token = object()
+
+        def collected(_reference):
+            evict(identity, token)
+
+        prepared = _arm_prepared_runtime_launch(prepared, collected, token)
+
+        if prepared is None:
+            return None
+
         entry = (key, selected, prepared)
         _remember_verified_runtime_call(prepared_calls, identity, entry)
         activate(identity, entry)
 
+        return prepared
+
     def launch(*args, **kwargs):
+        active_snapshot = active
+        active_identity_snapshot = active_identity
         identity = _runtime_call_identity(args, kwargs)
 
         if (
-            active is not None
-            and identity == active_identity
-            and active[2].guard.matches(args, kwargs, identity_verified=True)
+            active_snapshot is not None
+            and identity == active_identity_snapshot
+            and active_snapshot[2].matches(
+                args,
+                kwargs,
+                identity_verified=True,
+            )
         ):
-            return active[1]._ninetoothed_invoke_prepared(active[2], args, kwargs)
+            return active_snapshot[1]._ninetoothed_invoke_prepared(
+                active_snapshot[2],
+                args,
+                kwargs,
+            )
 
         cached = prepared_calls.pop(identity, None)
 
-        if cached is not None and cached[2].guard.matches(
+        if cached is not None and cached[2].matches(
             args,
             kwargs,
             identity_verified=True,
@@ -367,9 +523,13 @@ def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
             return result
 
         prepared = selected._ninetoothed_prepare(args, kwargs, public=public)
-        remember(identity, key, selected, prepared)
+        cached_prepared = remember(identity, key, selected, prepared)
 
-        return selected._ninetoothed_invoke_prepared(prepared, args, kwargs)
+        return selected._ninetoothed_invoke_prepared(
+            cached_prepared or prepared,
+            args,
+            kwargs,
+        )
 
     return launch
 

--- a/src/ninetoothed/backends/triton.py
+++ b/src/ninetoothed/backends/triton.py
@@ -111,6 +111,10 @@ class TritonOptimizeSchedule(OptimizeSchedule):
             }
 
         if granularity == "parallel-reduction":
+            reduction = schedule.get("reduction", {})
+
+            if reduction.get("mode") == "row-vector":
+                return {"schedule": {"num_warps": (4, 8, 1), "num_stages": 1}}
             return {"schedule": {"num_warps": 4}}
         return {"schedule": {"num_warps": 4}}
 

--- a/src/ninetoothed/compiler/driver.py
+++ b/src/ninetoothed/compiler/driver.py
@@ -444,6 +444,33 @@ def _tensor_access_modes(program: ssa.Program) -> dict[str, str]:
         for operation in operations
         for result in operation.results
     }
+    block_sources = {}
+
+    for operation in operations:
+        if operation.opcode != "scf.for" or not operation.regions:
+            continue
+
+        block_args = operation.regions[0].args
+
+        if not block_args:
+            continue
+
+        block_sources[block_args[0].name] = operation.operands[:3]
+        yield_operation = next(
+            (
+                nested
+                for nested in reversed(operation.regions[0].operations)
+                if nested.opcode == "scf.yield"
+            ),
+            None,
+        )
+        yielded = yield_operation.operands if yield_operation is not None else ()
+
+        for block_arg, initial, result in zip(
+            block_args[1:], operation.operands[3:], yielded
+        ):
+            block_sources[block_arg.name] = (initial, result)
+
     dependencies: dict[str, frozenset[str]] = {}
 
     def data_dependencies(name, visiting=frozenset()):
@@ -455,6 +482,16 @@ def _tensor_access_modes(program: ssa.Program) -> dict[str, str]:
 
         if name in visiting:
             return frozenset()
+
+        sources = block_sources.get(name)
+
+        if sources is not None:
+            result = frozenset().union(
+                *(data_dependencies(source, visiting | {name}) for source in sources)
+            )
+            dependencies[name] = result
+
+            return result
 
         producer = producers.get(name)
 
@@ -475,26 +512,43 @@ def _tensor_access_modes(program: ssa.Program) -> dict[str, str]:
             )
         )
         dependencies[name] = result
+
         return result
 
     reads = set()
     writes = set()
 
-    for operation in operations:
-        if operation.opcode == "mem.store" and len(operation.operands) >= 2:
-            reads.update(data_dependencies(operation.operands[0]))
+    def visit_effects(effect_operations, control_operands=()):
+        for operation in effect_operations:
+            if operation.opcode == "mem.store" and len(operation.operands) >= 2:
+                reads.update(data_dependencies(operation.operands[0]))
 
-            for index in operation.attrs.get("indices", ()):
-                reads.update(data_dependencies(str(index)))
+                for index in operation.attrs.get("indices", ()):
+                    reads.update(data_dependencies(str(index)))
 
-            writes.update(data_dependencies(operation.operands[1]))
-        elif operation.opcode == "mem.atomic_add" and operation.operands:
-            target = data_dependencies(operation.operands[0])
-            reads.update(target)
-            writes.update(target)
+                writes.update(data_dependencies(operation.operands[1]))
+            elif operation.opcode == "mem.atomic_add" and operation.operands:
+                target = data_dependencies(operation.operands[0])
+                reads.update(target)
+                writes.update(target)
 
-            for operand in operation.operands[1:]:
-                reads.update(data_dependencies(operand))
+                for operand in operation.operands[1:]:
+                    reads.update(data_dependencies(operand))
+
+            if operation.opcode in {"mem.store", "mem.atomic_add"}:
+                for operand in control_operands:
+                    reads.update(data_dependencies(operand))
+
+            control_arity = {"scf.if": 1, "scf.for": 3}.get(operation.opcode, 0)
+            nested_controls = (
+                *control_operands,
+                *operation.operands[:control_arity],
+            )
+
+            for region in operation.regions:
+                visit_effects(region.operations, nested_controls)
+
+    visit_effects(program.blocks[0].operations)
 
     writes.update(value.name for value in program.outputs if value.name in tensor_names)
 

--- a/src/ninetoothed/compiler/driver.py
+++ b/src/ninetoothed/compiler/driver.py
@@ -18,7 +18,7 @@ from ninetoothed.backends.core import (
 )
 from ninetoothed.frontend.layout import tensor_specs
 from ninetoothed.frontend.python import LoweringError, from_application
-from ninetoothed.ir import IndexExpr, Kernel, LaunchABI, LaunchBinding, LaunchPlan
+from ninetoothed.ir import IndexExpr, Kernel, LaunchABI, LaunchBinding, LaunchPlan, ssa
 from ninetoothed.naming import is_meta, remove_prefixes
 
 from .specialization import (
@@ -309,6 +309,7 @@ def _compile_kernel(request: CompileRequest) -> Compilation:
         specs,
         artifact,
         arranged,
+        program=program,
         meta_defaults=scheduled_defaults,
     )
     launch_plan = _launch_plan(launch_abi, artifact, request, arranged)
@@ -343,6 +344,7 @@ def _launch_abi(
     artifact: Artifact,
     arranged,
     *,
+    program: ssa.Program,
     meta_defaults: Mapping[str, int] | None = None,
 ) -> LaunchABI:
     by_name = {spec.name: spec for spec in specs}
@@ -355,37 +357,44 @@ def _launch_abi(
         name: getattr(getattr(tensor, "source", tensor), "value", None)
         for name, tensor in zip(params, arranged)
     }
+    output_names = tuple(artifact.metadata.get("outputs", ()))
+    access_modes = _tensor_access_modes(program)
     bindings = []
 
     for name in (
         *artifact.metadata.get("variables", ()),
-        *artifact.metadata.get("outputs", ()),
+        *output_names,
     ):
         if name in auxiliary_bindings:
             auxiliary = auxiliary_bindings[name]
+            kind = str(auxiliary["kind"])
+            source = str(auxiliary["source"])
             bindings.append(
                 LaunchBinding(
                     name=name,
-                    kind=str(auxiliary["kind"]),
-                    source=str(auxiliary["source"]),
+                    kind=kind,
+                    source=source,
+                    access=_binding_access(kind, source, access_modes, output_names),
                 )
             )
             continue
 
         spec = by_name[name]
+        kind = (
+            "constexpr"
+            if spec.constexpr
+            else "scalar"
+            if spec.ndim == 0
+            else "jagged_values"
+            if spec.jagged_dim is not None
+            else "tensor"
+        )
         bindings.append(
             LaunchBinding(
                 name=name,
-                kind=(
-                    "constexpr"
-                    if spec.constexpr
-                    else "scalar"
-                    if spec.ndim == 0
-                    else "jagged_values"
-                    if spec.jagged_dim is not None
-                    else "tensor"
-                ),
+                kind=kind,
                 source=name,
+                access=_binding_access(kind, name, access_modes, output_names),
             )
         )
 
@@ -406,9 +415,108 @@ def _launch_abi(
     return LaunchABI(
         public_args=tuple(params),
         kernel_args=tuple(bindings),
-        outputs=tuple(artifact.metadata.get("outputs", ())),
+        outputs=output_names,
         shape_params=shape_params,
     )
+
+
+def _binding_access(kind, source, access_modes, output_names):
+    if kind == "jagged_offsets":
+        return "read"
+
+    if kind not in {"tensor", "jagged_values"}:
+        return None
+
+    return access_modes.get(source, "write" if source in output_names else "read")
+
+
+def _tensor_access_modes(program: ssa.Program) -> dict[str, str]:
+    tensor_names = {
+        value.name for value in program.inputs if value.type.kind == "tensor"
+    }
+    operations = tuple(
+        operation
+        for block in program.blocks
+        for operation in _walk_ssa_operations(block.operations)
+    )
+    producers = {
+        result.name: operation
+        for operation in operations
+        for result in operation.results
+    }
+    dependencies: dict[str, frozenset[str]] = {}
+
+    def data_dependencies(name, visiting=frozenset()):
+        if name in tensor_names:
+            return frozenset((name,))
+
+        if name in dependencies:
+            return dependencies[name]
+
+        if name in visiting:
+            return frozenset()
+
+        producer = producers.get(name)
+
+        if producer is None or producer.opcode.startswith(("index.", "shape.")):
+            return frozenset()
+
+        nested_yields = (
+            operand
+            for region in producer.regions
+            for operation in _walk_ssa_operations(region.operations)
+            if operation.opcode == "scf.yield"
+            for operand in operation.operands
+        )
+        result = frozenset().union(
+            *(
+                data_dependencies(operand, visiting | {name})
+                for operand in (*producer.operands, *nested_yields)
+            )
+        )
+        dependencies[name] = result
+        return result
+
+    reads = set()
+    writes = set()
+
+    for operation in operations:
+        if operation.opcode == "mem.store" and len(operation.operands) >= 2:
+            reads.update(data_dependencies(operation.operands[0]))
+
+            for index in operation.attrs.get("indices", ()):
+                reads.update(data_dependencies(str(index)))
+
+            writes.update(data_dependencies(operation.operands[1]))
+        elif operation.opcode == "mem.atomic_add" and operation.operands:
+            target = data_dependencies(operation.operands[0])
+            reads.update(target)
+            writes.update(target)
+
+            for operand in operation.operands[1:]:
+                reads.update(data_dependencies(operand))
+
+    writes.update(value.name for value in program.outputs if value.name in tensor_names)
+
+    return {
+        name: (
+            "read_write"
+            if name in reads and name in writes
+            else "write"
+            if name in writes
+            else "read"
+        )
+        for name in tensor_names
+        if name in reads or name in writes
+    }
+
+
+def _walk_ssa_operations(operations):
+    for operation in operations:
+        yield operation
+
+        for region in operation.regions:
+            yield from _walk_ssa_operations(region.operations)
 
 
 def _launch_plan(

--- a/src/ninetoothed/compiler/driver.py
+++ b/src/ninetoothed/compiler/driver.py
@@ -427,7 +427,10 @@ def _binding_access(kind, source, access_modes, output_names):
     if kind not in {"tensor", "jagged_values"}:
         return None
 
-    return access_modes.get(source, "write" if source in output_names else "read")
+    return access_modes.get(
+        source,
+        "read_write" if source in output_names else "read",
+    )
 
 
 def _tensor_access_modes(program: ssa.Program) -> dict[str, str]:

--- a/src/ninetoothed/compiler/passes.py
+++ b/src/ninetoothed/compiler/passes.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass, field
 from typing import Any, Mapping
 
 from ninetoothed.backends.core import Target, normalize_target
+from ninetoothed.compiler.reductions import analyze_reductions
 from ninetoothed.ir import ssa
 
 HARDWARE_INDEPENDENT = "hardware_independent"
@@ -276,6 +277,7 @@ class AnalyzeEffects(Pass):
         reductions = sum(1 for opcode in opcodes if opcode.startswith("reduce."))
         loops = sum(1 for opcode in opcodes if opcode == "scf.for")
         dot_input_dtypes = _linalg_input_dtypes(program)
+        reduction_analysis = analyze_reductions(program)
 
         return _with_metadata(
             program,
@@ -291,6 +293,7 @@ class AnalyzeEffects(Pass):
                 "has_exp_reduction_dot_pattern": _has_exp_reduction_dot_pattern(
                     opcodes
                 ),
+                **reduction_analysis,
             },
         )
 
@@ -344,7 +347,18 @@ class SelectSchedule(Pass):
             "indexing": "flat-contiguous",
             "parallelism": "program-blocks",
         }
+        reduction = analysis.get("reduction_schedule")
+
+        if "reduction" in options:
+            raise ValueError(
+                "Reduction schedule options are compiler-owned and cannot be "
+                "overridden through `ssa.select_schedule`."
+            )
+
         schedule = _merge_nested(schedule, options)
+
+        if isinstance(reduction, Mapping):
+            schedule["reduction"] = dict(reduction)
 
         return _with_metadata(program, schedule=schedule)
 
@@ -398,6 +412,13 @@ class OptimizeSchedule(Pass):
             _pass_options(context, self.name, "ssa.optimize_schedule")
         )
         optimization_options.pop("candidate", None)
+
+        if "reduction" in dict(optimization_options.get("schedule", {})):
+            raise ValueError(
+                "Reduction schedule options are compiler-owned and cannot be "
+                "overridden by an optimization pass."
+            )
+
         optimization = _merge_nested(
             optimization,
             optimization_options,
@@ -406,6 +427,11 @@ class OptimizeSchedule(Pass):
             schedule,
             dict(optimization.get("schedule", {})),
         )
+        reduction = analysis.get("reduction_schedule")
+
+        if isinstance(reduction, Mapping):
+            optimized_schedule["reduction"] = dict(reduction)
+
         candidate_metadata = tuple(candidate.as_metadata() for candidate in candidates)
 
         return _replace_program(

--- a/src/ninetoothed/compiler/reductions.py
+++ b/src/ninetoothed/compiler/reductions.py
@@ -1,0 +1,518 @@
+"""Backend-neutral reduction-domain analysis for SSA scheduling."""
+
+from collections import defaultdict
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from ninetoothed.ir import ssa
+
+_ELEMENTWISE_USERS = frozenset(
+    {
+        "select.where",
+        "tensor.cast",
+        "tensor.view",
+    }
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class ReductionDomain:
+    """The iteration domain of one fine-grained SSA reduction."""
+
+    result: str
+    operand: str
+    operator: str
+    axis: int
+    input_shape: tuple[str, ...]
+    result_shape: tuple[str, ...]
+    scope: tuple[int, ...]
+    store_shapes: tuple[tuple[str, ...], ...] = ()
+
+    @property
+    def extent(self) -> str:
+        return self.input_shape[self.axis]
+
+    @property
+    def parallel_axes(self) -> tuple[int, ...]:
+        return tuple(axis for axis in range(len(self.input_shape)) if axis != self.axis)
+
+    @property
+    def parallel_shape(self) -> tuple[str, ...]:
+        return tuple(self.input_shape[axis] for axis in self.parallel_axes)
+
+    def as_metadata(self) -> Mapping[str, Any]:
+        return {
+            "result": self.result,
+            "operand": self.operand,
+            "operator": self.operator,
+            "axis": self.axis,
+            "input_shape": self.input_shape,
+            "result_shape": self.result_shape,
+            "scope": self.scope,
+            "store_shapes": self.store_shapes,
+            "extent": self.extent,
+            "parallel_axes": self.parallel_axes,
+            "parallel_shape": self.parallel_shape,
+        }
+
+
+def analyze_reductions(program: ssa.Program) -> Mapping[str, Any]:
+    """Return reduction domains and a conservative shared schedule contract."""
+    value_types = _value_types(program)
+    scoped_operations = tuple(_walk_program(program))
+    users = _users(scoped_operations)
+    definitions = _definitions(scoped_operations)
+    forwarded_values = _forwarded_values(program)
+    domains = []
+    rejections = []
+
+    for operation, scope in scoped_operations:
+        if not operation.opcode.startswith("reduce."):
+            continue
+
+        domain, rejection = _domain(
+            operation,
+            scope,
+            value_types,
+            users,
+            definitions,
+            forwarded_values,
+        )
+        domains.append(domain)
+
+        if rejection is not None:
+            rejections.append({"result": domain.result, "reason": rejection})
+
+    schedule = _schedule_contract(tuple(domains), tuple(rejections))
+
+    return {
+        "reduction_domains": tuple(domain.as_metadata() for domain in domains),
+        "reduction_rejections": tuple(rejections),
+        "reduction_schedule": schedule,
+    }
+
+
+def _domain(operation, scope, value_types, users, definitions, forwarded_values):
+    if operation.opcode not in {"reduce.sum", "reduce.max", "reduce.min"}:
+        raise ValueError(f"Unsupported SSA reduction `{operation.opcode}`.")
+
+    if len(operation.operands) != 1 or len(operation.results) != 1:
+        raise ValueError(
+            f"SSA reduction `{operation.opcode}` requires one operand and one result."
+        )
+
+    operand = operation.operands[0]
+    result = operation.results[0]
+    operand_type = value_types.get(operand)
+
+    if operand_type is None or operand_type.kind != "tensor" or not operand_type.shape:
+        raise ValueError(
+            f"SSA reduction `{operation.opcode}` requires a ranked tensor operand."
+        )
+
+    input_shape = tuple(str(dim) for dim in operand_type.shape)
+    raw_axis = operation.attrs.get("axis")
+    rejection = None
+
+    if raw_axis is None:
+        non_unit_axes = tuple(
+            index for index, extent in enumerate(input_shape) if extent != "1"
+        )
+
+        if len(non_unit_axes) != 1:
+            axis = 0
+            rejection = "full reduction does not have exactly one non-unit axis"
+        else:
+            axis = non_unit_axes[0]
+
+        expected_shape = ()
+    else:
+        if isinstance(raw_axis, bool) or not isinstance(raw_axis, int):
+            raise ValueError("Reduction axis must be a compile-time integer.")
+
+        axis = raw_axis + len(input_shape) if raw_axis < 0 else raw_axis
+
+        if axis < 0 or axis >= len(input_shape):
+            raise ValueError(
+                f"Reduction axis {raw_axis} is outside tensor rank {len(input_shape)}."
+            )
+
+        expected_shape = input_shape[:axis] + input_shape[axis + 1 :]
+
+    result_shape = tuple(str(dim) for dim in result.type.shape)
+    expected_kind = "tensor" if expected_shape else "scalar"
+
+    if result.type.kind != expected_kind or result_shape != expected_shape:
+        raise ValueError(
+            f"Reduction result `{result.name}` has type {result.type.kind}"
+            f"{result_shape}, expected {expected_kind}{expected_shape}."
+        )
+
+    compatible, consumer_reason = _consumer_contract(
+        result.name,
+        users,
+        axis=axis,
+        input_shape=input_shape,
+        result_shape=result_shape,
+        value_types=value_types,
+    )
+    store_shapes = _reachable_store_shapes(
+        result.name,
+        users,
+        value_types,
+        definitions,
+        forwarded_values,
+    )
+
+    if not compatible and rejection is None:
+        rejection = consumer_reason
+
+    if scope and rejection is None:
+        rejection = "nested-region reductions require scalar fallback"
+
+    return (
+        ReductionDomain(
+            result=result.name,
+            operand=operand,
+            operator=operation.opcode.removeprefix("reduce."),
+            axis=axis,
+            input_shape=input_shape,
+            result_shape=result_shape,
+            scope=scope,
+            store_shapes=store_shapes,
+        ),
+        rejection,
+    )
+
+
+def _consumer_contract(
+    result,
+    users,
+    *,
+    axis,
+    input_shape,
+    result_shape,
+    value_types,
+):
+    broadcast_shape = input_shape[:axis] + ("1",) + input_shape[axis + 1 :]
+    allowed_shapes = {(), result_shape, broadcast_shape, input_shape}
+    pending = [(result, _is_right_aligned(axis, input_shape, result_shape))]
+    seen = set()
+
+    while pending:
+        value, broadcast_ready = pending.pop()
+        state = (value, broadcast_ready)
+
+        if state in seen:
+            continue
+
+        seen.add(state)
+
+        for operation in users.get(value, ()):
+            consumer_broadcast_ready = broadcast_ready
+
+            if operation.opcode == "mem.store":
+                stored_type = value_types.get(value)
+                target_type = value_types.get(operation.operands[1])
+
+                if (
+                    stored_type is not None
+                    and target_type is not None
+                    and stored_type.shape != target_type.shape
+                ):
+                    return False, (
+                        "store target does not match the reduction value domain"
+                    )
+
+                continue
+
+            if operation.opcode.startswith("reduce."):
+                continue
+
+            if not _supported_consumer(operation.opcode) or not operation.results:
+                return False, (
+                    f"consumer `{operation.opcode}` is not row-vector compatible"
+                )
+
+            if operation.opcode == "tensor.view":
+                source_type = value_types.get(value)
+                source_shape = (
+                    ()
+                    if source_type is None
+                    else tuple(str(dim) for dim in source_type.shape)
+                )
+
+                view_contract = _broadcast_view_contract(operation, axis, source_shape)
+
+                if view_contract is None:
+                    return False, ("tensor view does not preserve the reduction domain")
+
+                consumer_broadcast_ready |= view_contract
+
+            for consumer_result in operation.results:
+                shape = tuple(str(dim) for dim in consumer_result.type.shape)
+
+                if shape not in allowed_shapes:
+                    return False, "consumer shape is not in the reduction domain"
+
+                if shape == input_shape and not consumer_broadcast_ready:
+                    return False, ("consumer broadcast does not preserve parallel axes")
+
+                pending.append(
+                    (
+                        consumer_result.name,
+                        consumer_broadcast_ready or shape in {(), input_shape},
+                    )
+                )
+
+    return True, None
+
+
+def _reachable_store_shapes(
+    result,
+    users,
+    value_types,
+    definitions,
+    forwarded_values,
+):
+    pending = [result]
+    seen = set()
+    store_shapes = set()
+
+    while pending:
+        value = pending.pop()
+
+        if value in seen:
+            continue
+
+        seen.add(value)
+        pending.extend(forwarded_values.get(value, ()))
+
+        for operation in users.get(value, ()):
+            if operation.opcode in {"mem.store", "mem.atomic_add"}:
+                target_type = _effect_target_type(
+                    operation,
+                    value_types,
+                    definitions,
+                )
+
+                if target_type is not None:
+                    store_shapes.add(tuple(str(dim) for dim in target_type.shape))
+
+                continue
+
+            pending.extend(item.name for item in operation.results)
+
+            for block in operation.regions:
+                store_shapes.update(
+                    _region_store_shapes(block, value_types, definitions)
+                )
+
+    return tuple(sorted(store_shapes))
+
+
+def _region_store_shapes(block, value_types, definitions):
+    store_shapes = set()
+
+    for operation in block.operations:
+        if operation.opcode in {"mem.store", "mem.atomic_add"}:
+            target_type = _effect_target_type(operation, value_types, definitions)
+
+            if target_type is not None:
+                store_shapes.add(tuple(str(dim) for dim in target_type.shape))
+
+        for region in operation.regions:
+            store_shapes.update(_region_store_shapes(region, value_types, definitions))
+
+    return store_shapes
+
+
+def _effect_target_type(operation, value_types, definitions):
+    target_index = 1 if operation.opcode == "mem.store" else 0
+    target = operation.operands[target_index]
+    target_type = value_types.get(target)
+    definition = definitions.get(target)
+
+    if definition is not None and definition.opcode == "mem.data_ptr":
+        target_type = value_types.get(definition.operands[0])
+
+    return target_type
+
+
+def _is_right_aligned(axis, input_shape, result_shape):
+    if not result_shape:
+        return True
+
+    mapped_axes = tuple(range(len(input_shape) - len(result_shape), len(input_shape)))
+    parallel_axes = tuple(index for index in range(len(input_shape)) if index != axis)
+
+    return mapped_axes == parallel_axes
+
+
+def _broadcast_view_contract(operation, axis, source_shape):
+    subscript = str(operation.attrs.get("subscript", "")).strip().strip("()")
+    parts = tuple(part.strip() for part in subscript.split(",") if part.strip())
+
+    if not parts or any(part not in {":", "None"} for part in parts):
+        return None
+
+    new_axes = tuple(index for index, part in enumerate(parts) if part == "None")
+    result_shape = tuple(str(dim) for dim in operation.results[0].type.shape)
+
+    if sum(part != "None" for part in parts) != len(source_shape):
+        return None
+
+    if not new_axes:
+        return False if result_shape == source_shape else None
+
+    compatible = new_axes == (axis,) and result_shape == (
+        source_shape[:axis] + ("1",) + source_shape[axis:]
+    )
+
+    return True if compatible else None
+
+
+def _supported_consumer(opcode):
+    return (
+        opcode in _ELEMENTWISE_USERS
+        or opcode.startswith("arith.")
+        or opcode.startswith("cmp.")
+        or opcode.startswith("math.")
+    )
+
+
+def _schedule_contract(domains, rejections):
+    if not domains:
+        return {"mode": "none"}
+
+    live_domains = tuple(domain for domain in domains if domain.store_shapes)
+
+    if not live_domains:
+        return {"mode": "none"}
+
+    live_results = {domain.result for domain in live_domains}
+    live_rejections = tuple(
+        rejection for rejection in rejections if rejection["result"] in live_results
+    )
+    store_domains = {
+        store_shape for domain in live_domains for store_shape in domain.store_shapes
+    }
+    emittable = len(store_domains) == 1
+
+    if live_rejections:
+        return {
+            "mode": "scalar-fallback",
+            "reason": live_rejections[0]["reason"],
+            "emittable": emittable,
+        }
+
+    keys = {
+        (
+            domain.scope,
+            domain.input_shape,
+            domain.axis,
+            domain.result_shape,
+        )
+        for domain in live_domains
+    }
+
+    if len(keys) != 1:
+        return {
+            "mode": "scalar-fallback",
+            "reason": "reductions do not share one iteration domain",
+            "emittable": emittable,
+        }
+
+    domain = live_domains[0]
+
+    return {
+        "mode": "row-vector",
+        "axis": domain.axis,
+        "value_shape": domain.input_shape,
+        "result_shape": domain.result_shape,
+        "extent": domain.extent,
+        "parallel_axes": domain.parallel_axes,
+        "parallel_shape": domain.parallel_shape,
+        "reductions": tuple(item.result for item in live_domains),
+    }
+
+
+def _value_types(program):
+    result = {value.name: value.type for value in (*program.inputs, *program.outputs)}
+
+    def collect_block(block):
+        result.update({value.name: value.type for value in block.args})
+
+        for operation in block.operations:
+            result.update({value.name: value.type for value in operation.results})
+
+            for region in operation.regions:
+                collect_block(region)
+
+    for block in program.blocks:
+        collect_block(block)
+    return result
+
+
+def _users(scoped_operations):
+    result = defaultdict(list)
+
+    for operation, _ in scoped_operations:
+        for operand in operation.operands:
+            result[operand].append(operation)
+    return result
+
+
+def _definitions(scoped_operations):
+    return {
+        value.name: operation
+        for operation, _ in scoped_operations
+        for value in operation.results
+    }
+
+
+def _forwarded_values(program):
+    result = defaultdict(set)
+
+    def collect_block(block):
+        for operation in block.operations:
+            for region in operation.regions:
+                if region.operations and region.operations[-1].opcode == "scf.yield":
+                    for source, target in zip(
+                        region.operations[-1].operands,
+                        operation.results,
+                    ):
+                        result[source].add(target.name)
+
+                    if operation.opcode == "scf.for":
+                        for source, target in zip(
+                            region.operations[-1].operands,
+                            region.args[1:],
+                        ):
+                            result[source].add(target.name)
+
+                collect_block(region)
+
+    for block in program.blocks:
+        collect_block(block)
+    return result
+
+
+def _walk_program(program):
+    for block in program.blocks:
+        yield from _walk_block(block, ())
+
+
+def _walk_block(block, scope):
+    for operation_index, operation in enumerate(block.operations):
+        yield operation, scope
+
+        for region_index, region in enumerate(operation.regions):
+            yield from _walk_block(
+                region,
+                (*scope, operation_index, region_index),
+            )
+
+
+__all__ = ["ReductionDomain", "analyze_reductions"]

--- a/src/ninetoothed/compiler/runtime.py
+++ b/src/ninetoothed/compiler/runtime.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import sys
 import tempfile
+import weakref
 from dataclasses import dataclass, replace
 from pathlib import Path
 from types import SimpleNamespace
@@ -267,6 +268,17 @@ def _runtime_dtypes(compilation, public) -> dict[str, str]:
     return result
 
 
+def _is_cacheable_runtime_literal(value) -> bool:
+    return (
+        value is None
+        or type(value) in (bool, int, float, complex, str, bytes)
+        or (
+            isinstance(value, tuple)
+            and all(_is_cacheable_runtime_literal(item) for item in value)
+        )
+    )
+
+
 @dataclass(frozen=True)
 class _RuntimeValueContract:
     is_tensor: bool
@@ -284,6 +296,10 @@ class _RuntimeValueContract:
     data_ptr_callable: bool = False
     storage_offset_callable: bool = False
     tensor_state: tuple | None = None
+
+    @property
+    def cacheable(self) -> bool:
+        return self.is_tensor or _is_cacheable_runtime_literal(self.value)
 
     @classmethod
     def from_value(cls, value, *, compare_scalar_tensor=False):
@@ -367,6 +383,12 @@ class _VerifiedRuntimeCall:
     positional: tuple[_RuntimeValueContract, ...]
     keywords: tuple[tuple[str, _RuntimeValueContract], ...]
     two_tensor_state: tuple | None = None
+
+    @property
+    def cacheable(self) -> bool:
+        return all(contract.cacheable for contract in self.positional) and all(
+            contract.cacheable for _name, contract in self.keywords
+        )
 
     @classmethod
     def from_call(cls, abi, args, kwargs):
@@ -496,13 +518,274 @@ class _VerifiedRuntimeCall:
         return True
 
 
+def _jagged_tensor_state(value):
+    try:
+        return (
+            type(value),
+            value.shape,
+            value.stride(),
+            value.dtype,
+            value.device,
+            value.data_ptr(),
+            value.storage_offset(),
+            getattr(value, "_version", None),
+        )
+    except (AttributeError, RuntimeError, TypeError):
+        return None
+
+
+@dataclass(frozen=True)
+class _JaggedOwnerContract:
+    owner: weakref.ReferenceType
+    values_state: tuple
+    offsets_state: tuple
+
+    @classmethod
+    def from_owner(cls, owner):
+        try:
+            reference = weakref.ref(owner)
+            values_state = _jagged_tensor_state(owner.values())
+            offsets_state = _jagged_tensor_state(owner.offsets())
+        except (AttributeError, RuntimeError, TypeError):
+            return None
+
+        if values_state is None or offsets_state is None:
+            return None
+
+        return cls(reference, values_state, offsets_state)
+
+    def matches(self):
+        owner = self.owner()
+
+        if owner is None:
+            return False
+
+        try:
+            state = (
+                _jagged_tensor_state(owner.values()),
+                _jagged_tensor_state(owner.offsets()),
+            )
+        except (AttributeError, RuntimeError, TypeError):
+            return False
+
+        return state == (self.values_state, self.offsets_state)
+
+
+@dataclass(frozen=True)
+class _PreparedBoundValue:
+    value: Any = None
+    tensor: weakref.ReferenceType | None = None
+    owner: weakref.ReferenceType | None = None
+    binding: LaunchBinding | None = None
+    flatten_tensor: bool = False
+
+    @classmethod
+    def from_value(cls, binding, value, public, *, flatten_tensors):
+        if binding.kind.startswith("jagged_"):
+            try:
+                owner = weakref.ref(public[binding.source])
+            except (KeyError, TypeError):
+                return None
+
+            return cls(
+                owner=owner,
+                binding=binding,
+                flatten_tensor=flatten_tensors
+                and binding.kind in {"jagged_values", "jagged_offsets"},
+            )
+
+        is_tensor = hasattr(value, "shape") and hasattr(value, "dtype")
+
+        if binding.kind != "tensor":
+            return cls(value=value) if _is_cacheable_runtime_literal(value) else None
+
+        if not is_tensor:
+            return None
+
+        try:
+            tensor = weakref.ref(value)
+        except TypeError:
+            return None
+
+        return cls(tensor=tensor, flatten_tensor=flatten_tensors)
+
+    def resolve(self, *, flatten_tensor=False):
+        if self.binding is not None:
+            owner = self.owner()
+
+            if owner is None:
+                return None, None
+
+            value = _jagged_binding_value(self.binding, owner)
+        elif self.tensor is not None:
+            value = self.tensor()
+        else:
+            return self.value, None
+
+        if value is None:
+            return None, None
+
+        if (
+            not self.flatten_tensor
+            or not flatten_tensor
+            or not hasattr(value, "as_strided")
+        ):
+            return value, None
+
+        storage_numel = value.untyped_storage().nbytes() // value.element_size()
+        storage_offset = value.storage_offset()
+        flattened = value.as_strided(
+            (storage_numel - storage_offset,),
+            (1,),
+            storage_offset=storage_offset,
+        )
+
+        return flattened, flattened
+
+
+@dataclass(frozen=True)
+class _RuntimeBindingPlan:
+    values: tuple[_PreparedBoundValue, ...]
+    jagged_owners: tuple[_JaggedOwnerContract, ...]
+
+    @classmethod
+    def from_values(cls, bindings, values, public, *, flatten_tensors):
+        planned = tuple(
+            _PreparedBoundValue.from_value(
+                binding,
+                value,
+                public,
+                flatten_tensors=flatten_tensors,
+            )
+            for binding, value in zip(bindings, values)
+        )
+
+        if any(value is None for value in planned):
+            return None
+
+        jagged_owners = []
+        owner_ids = set()
+
+        for value in planned:
+            if value.owner is None:
+                continue
+
+            owner = value.owner()
+
+            if owner is None:
+                return None
+
+            identity = id(owner)
+
+            if identity in owner_ids:
+                continue
+
+            contract = _JaggedOwnerContract.from_owner(owner)
+
+            if contract is None:
+                return None
+
+            owner_ids.add(identity)
+            jagged_owners.append(contract)
+
+        return cls(planned, tuple(jagged_owners))
+
+    @property
+    def owner_refs(self):
+        return tuple(
+            owner
+            for value in self.values
+            for owner in (value.tensor, value.owner)
+            if owner is not None
+        )
+
+    def static_values(self):
+        values = []
+
+        for planned in self.values:
+            if planned.binding is not None:
+                return None
+
+            if planned.tensor is None:
+                values.append(planned.value)
+                continue
+
+            value = planned.tensor()
+
+            if value is None:
+                return None
+
+            values.append(None)
+
+        return tuple(values)
+
+    def call_sources(self, bindings, args, kwargs, public_args):
+        positions = {name: index for index, name in enumerate(public_args[: len(args)])}
+        sources = []
+
+        for binding, planned in zip(bindings, self.values):
+            if planned.tensor is None:
+                sources.append(None)
+            elif binding.source in positions:
+                sources.append(("positional", positions[binding.source]))
+            elif binding.source in kwargs:
+                sources.append(("keyword", binding.source))
+            else:
+                return None
+
+        return tuple(sources)
+
+    def resolve(self, *, flatten_tensors=False):
+        values = []
+        keepalive = []
+
+        for planned in self.values:
+            value, temporary = planned.resolve(flatten_tensor=flatten_tensors)
+
+            if (
+                planned.tensor is not None or planned.owner is not None
+            ) and value is None:
+                return None
+
+            values.append(value)
+
+            if temporary is not None:
+                keepalive.append(temporary)
+
+        return tuple(values), tuple(keepalive)
+
+
 @dataclass(frozen=True)
 class _PreparedRuntimeLaunch:
     guard: _VerifiedRuntimeCall
-    values: tuple
-    keepalive: tuple
+    binding_plan: _RuntimeBindingPlan | None
+    owner_refs: tuple[weakref.ReferenceType, ...] | None
     empty: bool
-    invocation: Callable[[], Any] | None = None
+    invocation_plan: Callable[[tuple, tuple, dict], Any] | None = None
+    cache_token: object | None = None
+
+    @property
+    def cacheable(self) -> bool:
+        return (
+            self.guard.cacheable
+            and self.owner_refs is not None
+            and (self.empty or self.binding_plan is not None)
+        )
+
+    def matches(self, args, kwargs, *, identity_verified=False, call_key=None):
+        if not self.guard.matches(
+            args,
+            kwargs,
+            identity_verified=identity_verified,
+            call_key=call_key,
+        ):
+            return False
+
+        return (
+            self.binding_plan is None
+            or not self.binding_plan.jagged_owners
+            or all(contract.matches() for contract in self.binding_plan.jagged_owners)
+        )
 
 
 _VERIFIED_RUNTIME_CALL_CACHE_SIZE = 8
@@ -525,10 +808,74 @@ def _remember_verified_runtime_call(prepared_calls, identity, prepared):
     prepared_calls[identity] = prepared
 
 
+def _runtime_owner_refs(args, kwargs, binding_plan=None):
+    refs = []
+    identities = set()
+
+    def append(owner, reference=None):
+        identity = id(owner)
+
+        if identity in identities:
+            return True
+
+        try:
+            reference = reference or weakref.ref(owner)
+        except TypeError:
+            return False
+
+        identities.add(identity)
+        refs.append(reference)
+
+        return True
+
+    for value in (*args, *kwargs.values()):
+        if getattr(value, "shape", None) is None or not hasattr(value, "dtype"):
+            continue
+
+        if not append(value):
+            return None
+
+    if binding_plan is not None:
+        for reference in binding_plan.owner_refs:
+            owner = reference()
+
+            if owner is None or not append(owner, reference):
+                return None
+
+    return tuple(refs)
+
+
+def _arm_prepared_runtime_launch(prepared, callback, token):
+    if not prepared.cacheable:
+        return None
+
+    owners = tuple(owner() for owner in prepared.owner_refs)
+
+    if any(owner is None for owner in owners):
+        return None
+
+    return replace(
+        prepared,
+        owner_refs=tuple(weakref.ref(owner, callback) for owner in owners),
+        cache_token=token,
+    )
+
+
 def _verified_runtime_launch(launch):
     active_identity = None
     active = None
     prepared_calls = {}
+
+    def evict(identity, token):
+        nonlocal active, active_identity
+        cached = prepared_calls.get(identity)
+
+        if cached is not None and cached.cache_token is token:
+            prepared_calls.pop(identity, None)
+
+        if active is not None and active.cache_token is token:
+            active = None
+            active_identity = None
 
     def activate(identity, prepared):
         nonlocal active, active_identity
@@ -536,13 +883,26 @@ def _verified_runtime_launch(launch):
         active = prepared
 
     def remember(identity, prepared):
-        _remember_verified_runtime_call(prepared_calls, identity, prepared)
-        activate(identity, prepared)
+        token = object()
+
+        def collected(_reference):
+            evict(identity, token)
+
+        prepared = _arm_prepared_runtime_launch(prepared, collected, token)
+
+        if prepared is not None:
+            _remember_verified_runtime_call(prepared_calls, identity, prepared)
+            activate(identity, prepared)
+
+        return prepared
 
     def verified(*args, **kwargs):
+        active_snapshot = active
+        active_identity_snapshot = active_identity
         call_key = (
-            active.guard.call_key(args, kwargs)
-            if active is not None and active.guard.two_tensor_state is not None
+            active_snapshot.guard.call_key(args, kwargs)
+            if active_snapshot is not None
+            and active_snapshot.guard.two_tensor_state is not None
             else None
         )
         identity = (
@@ -552,20 +912,24 @@ def _verified_runtime_launch(launch):
         )
 
         if (
-            active is not None
-            and identity == active_identity
-            and active.guard.matches(
+            active_snapshot is not None
+            and identity == active_identity_snapshot
+            and active_snapshot.matches(
                 args,
                 kwargs,
                 identity_verified=True,
                 call_key=call_key,
             )
         ):
-            return launch._ninetoothed_invoke_prepared(active, args, kwargs)
+            return launch._ninetoothed_invoke_prepared(
+                active_snapshot,
+                args,
+                kwargs,
+            )
 
         cached = prepared_calls.pop(identity, None)
 
-        if cached is not None and cached.guard.matches(
+        if cached is not None and cached.matches(
             args,
             kwargs,
             identity_verified=True,
@@ -577,14 +941,18 @@ def _verified_runtime_launch(launch):
             return launch._ninetoothed_invoke_prepared(cached, args, kwargs)
 
         prepared = launch._ninetoothed_prepare(args, kwargs)
-        remember(
+        cached_prepared = remember(
             _two_tensor_call_identity(prepared.guard.two_tensor_state)
             if prepared.guard.two_tensor_state is not None
             else identity,
             prepared,
         )
 
-        return launch._ninetoothed_invoke_prepared(prepared, args, kwargs)
+        return launch._ninetoothed_invoke_prepared(
+            cached_prepared or prepared,
+            args,
+            kwargs,
+        )
 
     return verified
 
@@ -609,38 +977,89 @@ def _runtime_wrapper(
         if _empty_launch(abi, public):
             return _PreparedRuntimeLaunch(
                 _VerifiedRuntimeCall.from_call(abi, args, kwargs),
-                (),
-                (),
+                None,
+                _runtime_owner_refs(args, kwargs),
                 True,
             )
 
-        values, keepalive = _bound_values(abi, bound_public, scalar_mode="value")
+        values, _keepalive = _bound_values(abi, bound_public, scalar_mode="value")
         bindings = abi.kernel_args
 
-        if low_level:
-            values, flattened = _flatten_ffi_tensor_args(bindings, values)
-            keepalive.extend(flattened)
+        binding_plan = _RuntimeBindingPlan.from_values(
+            bindings,
+            values,
+            bound_public,
+            flatten_tensors=low_level,
+        )
+        resolved = (
+            binding_plan.resolve(flatten_tensors=low_level)
+            if binding_plan is not None
+            else None
+        )
+        resolved_values = resolved[0] if resolved is not None else ()
+        static_values = (
+            binding_plan.static_values() if binding_plan is not None else None
+        )
+        call_sources = (
+            binding_plan.call_sources(
+                bindings,
+                args,
+                kwargs,
+                abi.public_args,
+            )
+            if binding_plan is not None and static_values is not None
+            else None
+        )
 
-        values = tuple(values)
+        if static_values is not None and call_sources is None:
+            static_values = None
+
+        invocation_plan = (
+            prepare_invocation(resolved_values, static_values, call_sources)
+            if prepare_invocation is not None and resolved is not None
+            else None
+        )
+        owner_refs = _runtime_owner_refs(args, kwargs, binding_plan)
 
         return _PreparedRuntimeLaunch(
             _VerifiedRuntimeCall.from_call(abi, args, kwargs),
-            values,
-            tuple(keepalive),
+            binding_plan,
+            owner_refs,
             False,
-            prepare_invocation(values) if prepare_invocation is not None else None,
+            invocation_plan,
         )
 
     def invoke(prepared, args, kwargs):
         if prepared.empty:
             return _first_output_from_call(abi, args, kwargs)
 
-        if prepared.invocation is not None:
-            result = prepared.invocation()
-        else:
-            result = (
-                function(*prepared.values) if low_level else function(*args, **kwargs)
+        invocation_plan = prepared.invocation_plan
+        static_invocation = invocation_plan is not None and not getattr(
+            invocation_plan,
+            "requires_values",
+            True,
+        )
+        resolved = (
+            ((), ())
+            if static_invocation
+            else (
+                prepared.binding_plan.resolve(flatten_tensors=low_level)
+                if prepared.binding_plan is not None
+                else None
             )
+        )
+
+        if resolved is None:
+            return launch(*args, **kwargs)
+
+        values, keepalive = resolved
+
+        if invocation_plan is not None:
+            result = invocation_plan(values, args, kwargs)
+        else:
+            result = function(*values) if low_level else function(*args, **kwargs)
+
+        del keepalive
 
         if result is not None and not abi.outputs:
             return result

--- a/src/ninetoothed/compiler/runtime.py
+++ b/src/ninetoothed/compiler/runtime.py
@@ -353,10 +353,12 @@ class _RuntimeValueContract:
 
         if current_state != self.tensor_state:
             return False
+
         if self.scalar_value is None:
             return True
 
         item = value.item()
+
         return type(item) is self.scalar_value[0] and item == self.scalar_value[1]
 
 
@@ -440,6 +442,7 @@ class _VerifiedRuntimeCall:
             return None
 
         first, second = args
+
         return (
             expected_name,
             type(scalar),
@@ -570,6 +573,7 @@ def _verified_runtime_launch(launch):
         ):
             prepared_calls[identity] = cached
             activate(identity, cached)
+
             return launch._ninetoothed_invoke_prepared(cached, args, kwargs)
 
         prepared = launch._ninetoothed_prepare(args, kwargs)
@@ -579,6 +583,7 @@ def _verified_runtime_launch(launch):
             else identity,
             prepared,
         )
+
         return launch._ninetoothed_invoke_prepared(prepared, args, kwargs)
 
     return verified
@@ -890,6 +895,7 @@ def _first_output_from_call(abi, args, kwargs):
 
     name = abi.outputs[0]
     index = abi.public_args.index(name)
+
     return args[index] if index < len(args) else kwargs[name]
 
 

--- a/src/ninetoothed/compiler/runtime.py
+++ b/src/ninetoothed/compiler/runtime.py
@@ -7,10 +7,10 @@ import os
 import shutil
 import sys
 import tempfile
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Callable
 
 from ninetoothed.backends.core import BuiltArtifact, Target
 from ninetoothed.compiler.cache import (
@@ -267,32 +267,405 @@ def _runtime_dtypes(compilation, public) -> dict[str, str]:
     return result
 
 
+@dataclass(frozen=True)
+class _RuntimeValueContract:
+    is_tensor: bool
+    identity: int
+    value_type: type
+    value: Any = None
+    shape: tuple | None = None
+    stride: tuple | None = None
+    dtype: Any = None
+    device: Any = None
+    data_ptr: int | None = None
+    storage_offset: int | None = None
+    scalar_value: tuple[type, Any] | None = None
+    stride_callable: bool = False
+    data_ptr_callable: bool = False
+    storage_offset_callable: bool = False
+    tensor_state: tuple | None = None
+
+    @classmethod
+    def from_value(cls, value, *, compare_scalar_tensor=False):
+        shape = getattr(value, "shape", None)
+
+        if shape is None or not hasattr(value, "dtype"):
+            return cls(False, 0, type(value), value=value)
+
+        stride = getattr(value, "stride", None)
+        data_ptr = getattr(value, "data_ptr", None)
+        storage_offset = getattr(value, "storage_offset", None)
+        shape = tuple(shape)
+        stride_callable = callable(stride)
+        data_ptr_callable = callable(data_ptr)
+        storage_offset_callable = callable(storage_offset)
+        stride_value = tuple(stride()) if stride_callable else None
+        device = getattr(value, "device", None)
+        data_ptr_value = data_ptr() if data_ptr_callable else None
+        storage_offset_value = storage_offset() if storage_offset_callable else None
+        scalar_value = None
+
+        if compare_scalar_tensor and not shape:
+            item = value.item()
+            scalar_value = (type(item), item)
+
+        return cls(
+            True,
+            id(value),
+            type(value),
+            shape=shape,
+            stride=stride_value,
+            dtype=value.dtype,
+            device=device,
+            data_ptr=data_ptr_value,
+            storage_offset=storage_offset_value,
+            scalar_value=scalar_value,
+            stride_callable=stride_callable,
+            data_ptr_callable=data_ptr_callable,
+            storage_offset_callable=storage_offset_callable,
+            tensor_state=(
+                shape,
+                stride_value,
+                value.dtype,
+                device,
+                data_ptr_value,
+                storage_offset_value,
+            ),
+        )
+
+    def matches(self, value, *, identity_verified=False) -> bool:
+        if not self.is_tensor:
+            return type(value) is self.value_type and value == self.value
+
+        if not identity_verified and (
+            id(value) != self.identity or type(value) is not self.value_type
+        ):
+            return False
+
+        current_state = (
+            getattr(value, "shape", None),
+            value.stride() if self.stride_callable else None,
+            getattr(value, "dtype", None),
+            getattr(value, "device", None),
+            value.data_ptr() if self.data_ptr_callable else None,
+            value.storage_offset() if self.storage_offset_callable else None,
+        )
+
+        if current_state != self.tensor_state:
+            return False
+        if self.scalar_value is None:
+            return True
+
+        item = value.item()
+        return type(item) is self.scalar_value[0] and item == self.scalar_value[1]
+
+
+@dataclass(frozen=True)
+class _VerifiedRuntimeCall:
+    positional: tuple[_RuntimeValueContract, ...]
+    keywords: tuple[tuple[str, _RuntimeValueContract], ...]
+    two_tensor_state: tuple | None = None
+
+    @classmethod
+    def from_call(cls, abi, args, kwargs):
+        scalar_sources = {
+            binding.source
+            for binding in abi.kernel_args
+            if binding.kind in {"scalar", "constexpr", "meta"}
+        }
+        positional_names = abi.public_args[: len(args)]
+        positional = tuple(
+            _RuntimeValueContract.from_value(
+                value,
+                compare_scalar_tensor=name in scalar_sources,
+            )
+            for name, value in zip(positional_names, args)
+        )
+        keywords = tuple(
+            (
+                name,
+                _RuntimeValueContract.from_value(
+                    value,
+                    compare_scalar_tensor=name in scalar_sources,
+                ),
+            )
+            for name, value in kwargs.items()
+        )
+        two_tensor_state = None
+
+        if (
+            len(positional) == 2
+            and all(
+                contract.is_tensor
+                and contract.stride_callable
+                and contract.data_ptr_callable
+                and contract.storage_offset_callable
+                for contract in positional
+            )
+            and len(keywords) == 1
+            and not keywords[0][1].is_tensor
+        ):
+            scalar = keywords[0][1]
+
+            try:
+                hash(scalar.value)
+            except TypeError:
+                pass
+            else:
+                two_tensor_state = (
+                    keywords[0][0],
+                    scalar.value_type,
+                    scalar.value,
+                    positional[0].identity,
+                    positional[0].value_type,
+                    *positional[0].tensor_state,
+                    positional[1].identity,
+                    positional[1].value_type,
+                    *positional[1].tensor_state,
+                )
+        return cls(positional, keywords, two_tensor_state)
+
+    def call_key(self, args, kwargs):
+        if self.two_tensor_state is None or len(args) != 2 or len(kwargs) != 1:
+            return None
+
+        expected_name = self.keywords[0][0]
+
+        try:
+            scalar = kwargs[expected_name]
+        except KeyError:
+            return None
+
+        if type(scalar) is not self.keywords[0][1].value_type:
+            return None
+
+        first, second = args
+        return (
+            expected_name,
+            type(scalar),
+            scalar,
+            id(first),
+            type(first),
+            first.shape,
+            first.stride(),
+            first.dtype,
+            first.device,
+            first.data_ptr(),
+            first.storage_offset(),
+            id(second),
+            type(second),
+            second.shape,
+            second.stride(),
+            second.dtype,
+            second.device,
+            second.data_ptr(),
+            second.storage_offset(),
+        )
+
+    def matches(
+        self,
+        args,
+        kwargs,
+        *,
+        identity_verified=False,
+        call_key=None,
+    ) -> bool:
+        if len(args) != len(self.positional) or len(kwargs) != len(self.keywords):
+            return False
+
+        if self.two_tensor_state is not None:
+            if call_key is None:
+                call_key = self.call_key(args, kwargs)
+            return call_key == self.two_tensor_state
+
+        for contract, value in zip(self.positional, args):
+            if not contract.matches(value, identity_verified=identity_verified):
+                return False
+
+        for (name, value), (expected_name, contract) in zip(
+            kwargs.items(), self.keywords
+        ):
+            if name != expected_name or not contract.matches(
+                value,
+                identity_verified=identity_verified,
+            ):
+                return False
+        return True
+
+
+@dataclass(frozen=True)
+class _PreparedRuntimeLaunch:
+    guard: _VerifiedRuntimeCall
+    values: tuple
+    keepalive: tuple
+    empty: bool
+    invocation: Callable[[], Any] | None = None
+
+
+_VERIFIED_RUNTIME_CALL_CACHE_SIZE = 8
+
+
+def _runtime_call_identity(args, kwargs):
+    return (len(args), *map(id, args), *map(id, kwargs.values()))
+
+
+def _two_tensor_call_identity(call_key):
+    return (call_key[3], call_key[11], call_key[1], call_key[2])
+
+
+def _remember_verified_runtime_call(prepared_calls, identity, prepared):
+    prepared_calls.pop(identity, None)
+
+    if len(prepared_calls) >= _VERIFIED_RUNTIME_CALL_CACHE_SIZE:
+        prepared_calls.pop(next(iter(prepared_calls)))
+
+    prepared_calls[identity] = prepared
+
+
+def _verified_runtime_launch(launch):
+    active_identity = None
+    active = None
+    prepared_calls = {}
+
+    def activate(identity, prepared):
+        nonlocal active, active_identity
+        active_identity = identity
+        active = prepared
+
+    def remember(identity, prepared):
+        _remember_verified_runtime_call(prepared_calls, identity, prepared)
+        activate(identity, prepared)
+
+    def verified(*args, **kwargs):
+        call_key = (
+            active.guard.call_key(args, kwargs)
+            if active is not None and active.guard.two_tensor_state is not None
+            else None
+        )
+        identity = (
+            _two_tensor_call_identity(call_key)
+            if call_key is not None
+            else _runtime_call_identity(args, kwargs)
+        )
+
+        if (
+            active is not None
+            and identity == active_identity
+            and active.guard.matches(
+                args,
+                kwargs,
+                identity_verified=True,
+                call_key=call_key,
+            )
+        ):
+            return launch._ninetoothed_invoke_prepared(active, args, kwargs)
+
+        cached = prepared_calls.pop(identity, None)
+
+        if cached is not None and cached.guard.matches(
+            args,
+            kwargs,
+            identity_verified=True,
+            call_key=call_key,
+        ):
+            prepared_calls[identity] = cached
+            activate(identity, cached)
+            return launch._ninetoothed_invoke_prepared(cached, args, kwargs)
+
+        prepared = launch._ninetoothed_prepare(args, kwargs)
+        remember(
+            _two_tensor_call_identity(prepared.guard.two_tensor_state)
+            if prepared.guard.two_tensor_state is not None
+            else identity,
+            prepared,
+        )
+        return launch._ninetoothed_invoke_prepared(prepared, args, kwargs)
+
+    return verified
+
+
 def _runtime_wrapper(
     function,
     abi: LaunchABI,
     *,
     low_level: bool = True,
     specs=(),
+    binding_overrides=None,
+    prepare_invocation=None,
 ):
-    def launch(*args, **kwargs):
-        public = _public_values(abi, args, kwargs, specs=specs)
+    overrides = dict(binding_overrides or {})
+
+    def prepare(args, kwargs, *, public=None):
+        if public is None:
+            public = _public_values(abi, args, kwargs, specs=specs)
+
+        bound_public = dict(public) | overrides
 
         if _empty_launch(abi, public):
-            return _first_output(abi, public)
+            return _PreparedRuntimeLaunch(
+                _VerifiedRuntimeCall.from_call(abi, args, kwargs),
+                (),
+                (),
+                True,
+            )
 
-        values, keepalive = _bound_values(abi, public, scalar_mode="value")
+        values, keepalive = _bound_values(abi, bound_public, scalar_mode="value")
         bindings = abi.kernel_args
 
         if low_level:
             values, flattened = _flatten_ffi_tensor_args(bindings, values)
             keepalive.extend(flattened)
 
-        result = function(*values) if low_level else function(*args)
+        values = tuple(values)
+
+        return _PreparedRuntimeLaunch(
+            _VerifiedRuntimeCall.from_call(abi, args, kwargs),
+            values,
+            tuple(keepalive),
+            False,
+            prepare_invocation(values) if prepare_invocation is not None else None,
+        )
+
+    def invoke(prepared, args, kwargs):
+        if prepared.empty:
+            return _first_output_from_call(abi, args, kwargs)
+
+        if prepared.invocation is not None:
+            result = prepared.invocation()
+        else:
+            result = (
+                function(*prepared.values) if low_level else function(*args, **kwargs)
+            )
+
+        if result is not None and not abi.outputs:
+            return result
+        return _first_output_from_call(abi, args, kwargs)
+
+    def launch(*args, **kwargs):
+        public = _public_values(abi, args, kwargs, specs=specs)
+
+        if _empty_launch(abi, public):
+            return _first_output(abi, public)
+
+        values, keepalive = _bound_values(
+            abi,
+            dict(public) | overrides,
+            scalar_mode="value",
+        )
+
+        if low_level:
+            values, flattened = _flatten_ffi_tensor_args(abi.kernel_args, values)
+            keepalive.extend(flattened)
+
+        result = function(*values) if low_level else function(*args, **kwargs)
         del keepalive
 
-        if result is not None:
+        if result is not None and not abi.outputs:
             return result
         return _first_output(abi, public)
+
+    launch._ninetoothed_prepare = prepare
+    launch._ninetoothed_invoke_prepared = invoke
 
     return launch
 
@@ -509,6 +882,15 @@ def _jagged_binding_value(binding: LaunchBinding, value):
 
 def _first_output(abi, public):
     return public[abi.outputs[0]] if abi.outputs else None
+
+
+def _first_output_from_call(abi, args, kwargs):
+    if not abi.outputs:
+        return None
+
+    name = abi.outputs[0]
+    index = abi.public_args.index(name)
+    return args[index] if index < len(args) else kwargs[name]
 
 
 def _empty_launch(abi, public) -> bool:

--- a/src/ninetoothed/compiler/runtime.py
+++ b/src/ninetoothed/compiler/runtime.py
@@ -465,27 +465,30 @@ class _VerifiedRuntimeCall:
 
         first, second = args
 
-        return (
-            expected_name,
-            type(scalar),
-            scalar,
-            id(first),
-            type(first),
-            first.shape,
-            first.stride(),
-            first.dtype,
-            first.device,
-            first.data_ptr(),
-            first.storage_offset(),
-            id(second),
-            type(second),
-            second.shape,
-            second.stride(),
-            second.dtype,
-            second.device,
-            second.data_ptr(),
-            second.storage_offset(),
-        )
+        try:
+            return (
+                expected_name,
+                type(scalar),
+                scalar,
+                id(first),
+                type(first),
+                first.shape,
+                first.stride(),
+                first.dtype,
+                first.device,
+                first.data_ptr(),
+                first.storage_offset(),
+                id(second),
+                type(second),
+                second.shape,
+                second.stride(),
+                second.dtype,
+                second.device,
+                second.data_ptr(),
+                second.storage_offset(),
+            )
+        except (AttributeError, RuntimeError, TypeError):
+            return None
 
     def matches(
         self,

--- a/src/ninetoothed/compiler/runtime.py
+++ b/src/ninetoothed/compiler/runtime.py
@@ -279,7 +279,7 @@ def _is_cacheable_runtime_literal(value) -> bool:
     )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class _RuntimeValueContract:
     is_tensor: bool
     identity: int
@@ -306,7 +306,12 @@ class _RuntimeValueContract:
         shape = getattr(value, "shape", None)
 
         if shape is None or not hasattr(value, "dtype"):
-            return cls(False, 0, type(value), value=value)
+            return cls(
+                is_tensor=False,
+                identity=0,
+                value_type=type(value),
+                value=value,
+            )
 
         stride = getattr(value, "stride", None)
         data_ptr = getattr(value, "data_ptr", None)
@@ -326,9 +331,9 @@ class _RuntimeValueContract:
             scalar_value = (type(item), item)
 
         return cls(
-            True,
-            id(value),
-            type(value),
+            is_tensor=True,
+            identity=id(value),
+            value_type=type(value),
             shape=shape,
             stride=stride_value,
             dtype=value.dtype,
@@ -378,7 +383,7 @@ class _RuntimeValueContract:
         return type(item) is self.scalar_value[0] and item == self.scalar_value[1]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class _VerifiedRuntimeCall:
     positional: tuple[_RuntimeValueContract, ...]
     keywords: tuple[tuple[str, _RuntimeValueContract], ...]
@@ -447,7 +452,11 @@ class _VerifiedRuntimeCall:
                     positional[1].value_type,
                     *positional[1].tensor_state,
                 )
-        return cls(positional, keywords, two_tensor_state)
+        return cls(
+            positional=positional,
+            keywords=keywords,
+            two_tensor_state=two_tensor_state,
+        )
 
     def call_key(self, args, kwargs):
         if self.two_tensor_state is None or len(args) != 2 or len(kwargs) != 1:
@@ -537,7 +546,7 @@ def _jagged_tensor_state(value):
         return None
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class _JaggedOwnerContract:
     owner: weakref.ReferenceType
     values_state: tuple
@@ -555,7 +564,11 @@ class _JaggedOwnerContract:
         if values_state is None or offsets_state is None:
             return None
 
-        return cls(reference, values_state, offsets_state)
+        return cls(
+            owner=reference,
+            values_state=values_state,
+            offsets_state=offsets_state,
+        )
 
     def matches(self):
         owner = self.owner()
@@ -574,7 +587,7 @@ class _JaggedOwnerContract:
         return state == (self.values_state, self.offsets_state)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class _PreparedBoundValue:
     value: Any = None
     tensor: weakref.ReferenceType | None = None
@@ -646,7 +659,7 @@ class _PreparedBoundValue:
         return flattened, flattened
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class _RuntimeBindingPlan:
     values: tuple[_PreparedBoundValue, ...]
     jagged_owners: tuple[_JaggedOwnerContract, ...]
@@ -691,7 +704,7 @@ class _RuntimeBindingPlan:
             owner_ids.add(identity)
             jagged_owners.append(contract)
 
-        return cls(planned, tuple(jagged_owners))
+        return cls(values=planned, jagged_owners=tuple(jagged_owners))
 
     @property
     def owner_refs(self):
@@ -758,7 +771,7 @@ class _RuntimeBindingPlan:
         return tuple(values), tuple(keepalive)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class _PreparedRuntimeLaunch:
     guard: _VerifiedRuntimeCall
     binding_plan: _RuntimeBindingPlan | None
@@ -979,10 +992,10 @@ def _runtime_wrapper(
 
         if _empty_launch(abi, public):
             return _PreparedRuntimeLaunch(
-                _VerifiedRuntimeCall.from_call(abi, args, kwargs),
-                None,
-                _runtime_owner_refs(args, kwargs),
-                True,
+                guard=_VerifiedRuntimeCall.from_call(abi, args, kwargs),
+                binding_plan=None,
+                owner_refs=_runtime_owner_refs(args, kwargs),
+                empty=True,
             )
 
         values, _keepalive = _bound_values(abi, bound_public, scalar_mode="value")
@@ -1025,11 +1038,11 @@ def _runtime_wrapper(
         owner_refs = _runtime_owner_refs(args, kwargs, binding_plan)
 
         return _PreparedRuntimeLaunch(
-            _VerifiedRuntimeCall.from_call(abi, args, kwargs),
-            binding_plan,
-            owner_refs,
-            False,
-            invocation_plan,
+            guard=_VerifiedRuntimeCall.from_call(abi, args, kwargs),
+            binding_plan=binding_plan,
+            owner_refs=owner_refs,
+            empty=False,
+            invocation_plan=invocation_plan,
         )
 
     def invoke(prepared, args, kwargs):

--- a/src/ninetoothed/ir/kernel.py
+++ b/src/ninetoothed/ir/kernel.py
@@ -188,6 +188,11 @@ class LaunchBinding:
     source: str | None = None
     dim: int | None = None
     value: Any = None
+    access: str | None = None
+
+    def __post_init__(self):
+        if self.access not in {None, "read", "write", "read_write"}:
+            raise ValueError(f"Unsupported launch binding access `{self.access}`.")
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/tests/test_aot_auto_tuning.py
+++ b/tests/test_aot_auto_tuning.py
@@ -54,7 +54,7 @@ def test_auto_tuning(size, dtype, device, ninetoothed_dtype, rtol, atol):
     output_dir = CACHE_DIR / "test_auto_tuning"
 
     shutil.rmtree(output_dir, ignore_errors=True)
-    output_dir.mkdir()
+    output_dir.mkdir(parents=True)
 
     configs = (
         ((), {"size": 20260128, "dtype": ninetoothed.float16, "block_size": 256}, {}),

--- a/tests/test_auto_tuner.py
+++ b/tests/test_auto_tuner.py
@@ -84,6 +84,21 @@ def test_auto_tuner_reports_every_failed_candidate(_):
     with pytest.raises(RuntimeError, match="first.*_foo failed.*second.*_bar failed"):
         tuner(1)
 
+    def fail_after_benchmark(*_args, **_kwargs):
+        raise RuntimeError("Winner invocation failed.")
+
+    tuner = AutoTuner(
+        (fail_after_benchmark,),
+        ("winner",),
+        benchmark=lambda *_args: 1.0,
+        cache_namespace=f"winner_failure_{uuid.uuid4().hex}",
+    )
+
+    with pytest.raises(RuntimeError, match="Winner invocation failed"):
+        tuner(1)
+
+    assert tuner._best_func == {}
+
 
 def _foo_delay(*args, **kwargs):
     return 0.001 * (2 * len(args) + len(kwargs))

--- a/tests/test_ssa_first_backend_lowering.py
+++ b/tests/test_ssa_first_backend_lowering.py
@@ -878,7 +878,7 @@ def canonical_math_application(x, y, out):
             ),
         )
         expected = {
-            "triton": ("ssa-unified-triton-emitter", "for v1_i in range(0, cols, 1):"),
+            "triton": ("ssa-unified-triton-emitter", "tl.sum("),
             "cuda": (
                 "ssa-unified-cuda-emitter",
                 "a[(index) * (cols) + (v1_i)] * x[v1_i]",
@@ -891,6 +891,9 @@ def canonical_math_application(x, y, out):
             _assert_ssa_artifact(artifact, route=route)
             assert source_fragment in artifact.primary_source
             assert "reduce.sum" in str(artifact.metadata["ssa"])
+
+            if backend == "triton":
+                assert "for v1_i in range" not in artifact.primary_source
 
     def test_from_source_generates_rowwise_reduction_for_native_backends(self):
         kernel = _ssa_kernel(

--- a/tests/test_triton_reduction_schedule.py
+++ b/tests/test_triton_reduction_schedule.py
@@ -1,0 +1,201 @@
+import pytest
+import torch
+
+import ninetoothed.language as ntl
+from ninetoothed import Symbol, Tensor
+from ninetoothed.compiler import DEFAULT_COMPILER, CompileRequest, make
+from tests.utils import get_available_devices
+
+WIDTH = Symbol("WIDTH", constexpr=True)
+HEIGHT = Symbol("HEIGHT", constexpr=True)
+
+
+def _row_arrangement(x, out, WIDTH=WIDTH):
+    return x.tile((1, WIDTH)), out.tile((1, WIDTH))
+
+
+def _row_reduced_arrangement(x, out, WIDTH=WIDTH):
+    return x.tile((1, WIDTH)), out.tile((1,))
+
+
+def _column_arrangement(x, out, HEIGHT=HEIGHT):
+    return x.tile((HEIGHT, 1)), out.tile((HEIGHT, 1))
+
+
+def _middle_axis_arrangement(x, out):
+    return x.tile((2, 3, 5)), out.tile((2, 5))
+
+
+def _square_arrangement(x, out):
+    return x.tile((4, 4)), out.tile((4, 4))
+
+
+def _separate_reduction_arrangement(x, rows, columns):
+    return x.tile((4, 8)), rows.tile((4,)), columns.tile((8,))
+
+
+def _row_normalize(x, out):
+    maximum = ntl.max(x, axis=1)
+    numerator = ntl.exp(x - maximum[:, None])
+    out = numerator / ntl.sum(numerator, axis=1)[:, None]  # noqa: F841
+
+
+def _row_layernorm(x, out):
+    width = x.shape[1]
+    mean = ntl.sum(x, axis=1) / width
+    mean_square = ntl.sum(x * x, axis=1) / width
+    variance = mean_square - mean * mean
+    out = (x - mean[:, None]) * ntl.rsqrt(variance[:, None] + 1e-5)  # noqa: F841
+
+
+def _row_min(x, out):
+    out = ntl.min(x, axis=1)  # noqa: F841
+
+
+def _column_max_broadcast(x, out):
+    out = x + ntl.max(x, axis=0)[None, :]  # noqa: F841
+
+
+def _middle_axis_sum(x, out):
+    out = ntl.sum(x, axis=1)  # noqa: F841
+
+
+def _incompatible_broadcast(x, out):
+    out = x + ntl.sum(x, axis=1)[None, :]  # noqa: F841
+
+
+def _separate_reduction_outputs(x, rows, columns):
+    rows = ntl.sum(x, axis=1)  # noqa: F841
+    columns = ntl.max(x, axis=0)  # noqa: F841
+
+
+def _request():
+    return CompileRequest(
+        arrangement=_row_arrangement,
+        application=_row_normalize,
+        tensors=(Tensor(2), Tensor(2)),
+        backend="triton",
+        tensor_dtypes={"x": "float32", "out": "float32"},
+    )
+
+
+def test_reduction_domain_selects_triton_row_vector_schedule():
+    compilation = DEFAULT_COMPILER.compile(_request())
+    metadata = compilation.artifact.metadata["ssa_metadata"]
+    domains = metadata["analysis"]["reduction_domains"]
+
+    assert len(domains) == 2
+    assert {domain["operator"] for domain in domains} == {"max", "sum"}
+    assert all(domain["axis"] == 1 for domain in domains)
+    assert all(domain["parallel_shape"] == ("1",) for domain in domains)
+    assert metadata["schedule"]["reduction"]["mode"] == "row-vector"
+    assert tuple(
+        candidate["num_warps"]
+        for candidate in compilation.launch_plan.tuning_candidates
+    ) == (4, 8, 1)
+    assert "tl.max(" in compilation.artifact.primary_source
+    assert "tl.sum(" in compilation.artifact.primary_source
+    assert "for v" not in compilation.artifact.primary_source
+
+    fallback = DEFAULT_COMPILER.compile(
+        CompileRequest(
+            arrangement=_square_arrangement,
+            application=_incompatible_broadcast,
+            tensors=(Tensor(2), Tensor(2)),
+            backend="triton",
+            tensor_dtypes={"x": "float32", "out": "float32"},
+        )
+    )
+    assert (
+        fallback.artifact.metadata["ssa_metadata"]["schedule"]["reduction"]["mode"]
+        == "scalar-fallback"
+    )
+
+    with pytest.raises(ValueError, match="separate kernels"):
+        DEFAULT_COMPILER.compile(
+            CompileRequest(
+                arrangement=_separate_reduction_arrangement,
+                application=_separate_reduction_outputs,
+                tensors=(Tensor(2), Tensor(1), Tensor(1)),
+                backend="triton",
+                tensor_dtypes={
+                    "x": "float32",
+                    "rows": "float32",
+                    "columns": "float32",
+                },
+            )
+        )
+
+
+@pytest.mark.parametrize("device", get_available_devices())
+def test_triton_row_vector_reduction_runtime(device):
+    normalize = make(
+        _row_arrangement,
+        _row_normalize,
+        (Tensor(2), Tensor(2)),
+        backend="triton",
+        max_num_configs=1,
+    )
+    layernorm = make(
+        _row_arrangement,
+        _row_layernorm,
+        (Tensor(2), Tensor(2)),
+        backend="triton",
+        max_num_configs=1,
+    )
+    reduce_min = make(
+        _row_reduced_arrangement,
+        _row_min,
+        (Tensor(2), Tensor(1)),
+        backend="triton",
+        max_num_configs=1,
+    )
+    column_max = make(
+        _column_arrangement,
+        _column_max_broadcast,
+        (Tensor(2), Tensor(2)),
+        backend="triton",
+        max_num_configs=1,
+    )
+    middle_sum = make(
+        _middle_axis_arrangement,
+        _middle_axis_sum,
+        (Tensor(3), Tensor(2)),
+        backend="triton",
+        max_num_configs=1,
+    )
+
+    width = 127
+    base = torch.randn((37, width * 2), device=device)
+    x = base[:, ::2]
+    normalized = torch.empty_like(x)
+    layernorm_output = torch.empty_like(x)
+    minimum = torch.empty((x.shape[0],), device=device)
+
+    normalize(x, normalized, WIDTH=width)
+    layernorm(x, layernorm_output, WIDTH=width)
+    reduce_min(x, minimum, WIDTH=width)
+
+    torch.testing.assert_close(
+        normalized,
+        torch.softmax(x, dim=1),
+        rtol=1e-5,
+        atol=1e-6,
+    )
+    torch.testing.assert_close(
+        layernorm_output,
+        torch.nn.functional.layer_norm(x, (width,)),
+        rtol=2e-4,
+        atol=2e-5,
+    )
+    torch.testing.assert_close(minimum, x.min(dim=1).values)
+
+    x = torch.randn((193, 41), device=device)
+    output = torch.empty_like(x)
+    column_max(x, output, HEIGHT=x.shape[0])
+    torch.testing.assert_close(output, x + x.max(dim=0).values, rtol=1e-5, atol=1e-6)
+
+    x = torch.randn((2, 3, 5), device=device)
+    output = torch.empty((2, 5), device=device)
+    middle_sum(x, output)
+    torch.testing.assert_close(output, x.sum(dim=1))

--- a/tests/test_triton_runtime_auto_tuning.py
+++ b/tests/test_triton_runtime_auto_tuning.py
@@ -88,6 +88,7 @@ class _FakeTuner:
         key = self._make_arg_key(args, kwargs)
         selected = self._funcs[0] if args[0].shape[0] == 4 else self._funcs[1]
         self._best_func[key] = selected
+
         return selected(*args, **kwargs)
 
 
@@ -125,6 +126,7 @@ def _runtime_fixture(*, with_constexpr=False):
         handle,
         compilation,
     )
+
     return launch, tuner, handle, calls
 
 
@@ -152,6 +154,7 @@ def test_triton_single_and_plain_materialization_use_verified_launch(
 
     def raw_launch(*values, **kwargs):
         raw_calls.append((values, kwargs))
+
         return values[0]
 
     class FakeHandle:
@@ -180,6 +183,7 @@ def test_triton_single_and_plain_materialization_use_verified_launch(
     def public(*args, **kwargs):
         nonlocal public_calls
         public_calls += 1
+
         return original_public(*args, **kwargs)
 
     monkeypatch.setattr(runtime, "Handle", FakeHandle)
@@ -228,6 +232,7 @@ def _verified_runtime_fixture(*, with_constexpr=False, outputs=()):
         lambda *values: calls.append(values),
         abi,
     )
+
     return runtime._verified_runtime_launch(wrapped), calls
 
 
@@ -238,6 +243,7 @@ def test_verified_runtime_launch_rebinds_zero_dimensional_value(monkeypatch):
     def bound(*args, **kwargs):
         nonlocal binding_calls
         binding_calls += 1
+
         return original_bound(*args, **kwargs)
 
     monkeypatch.setattr(runtime, "_bound_values", bound)
@@ -261,6 +267,7 @@ def test_verified_runtime_launch_keeps_eight_recent_identities(monkeypatch):
     def bound(*args, **kwargs):
         nonlocal binding_calls
         binding_calls += 1
+
         return original_bound(*args, **kwargs)
 
     monkeypatch.setattr(runtime, "_bound_values", bound)
@@ -297,8 +304,10 @@ def test_verified_runtime_launch_preserves_argument_errors():
 
     with pytest.raises(TypeError, match="passed twice"):
         launch(value, 2, scale=2)
+
     with pytest.raises(TypeError, match="Missing kernel arguments"):
         launch(value)
+
     with pytest.raises(TypeError, match="Unknown kernel arguments"):
         launch(value, 2, unknown=True)
 
@@ -366,6 +375,7 @@ def test_triton_prepared_invocation_caches_grid_without_launching(monkeypatch):
 
             def launch(*args, **kwargs):
                 kernel_calls.append((args, kwargs))
+
                 return object()
 
             return launch
@@ -375,13 +385,15 @@ def test_triton_prepared_invocation_caches_grid_without_launching(monkeypatch):
 
     def generated_launch(value, size, _ninetoothed_num_warps=4):
         if size <= 0:
-            raise ValueError("size must be positive")
+            raise ValueError("Size must be positive.")
+
         _prepared_test_kernel[(size,)](
             value,
             size,
             BLOCK=1,
             num_warps=_ninetoothed_num_warps,
         )
+
         return value
 
     function = functools.partial(generated_launch, _ninetoothed_num_warps=8)
@@ -413,11 +425,13 @@ def test_triton_direct_winner_reuses_verified_binding_and_restores_aba(monkeypat
     def public(*args, **kwargs):
         nonlocal public_calls
         public_calls += 1
+
         return original_public(*args, **kwargs)
 
     def bound(*args, **kwargs):
         nonlocal binding_calls
         binding_calls += 1
+
         return original_bound(*args, **kwargs)
 
     monkeypatch.setattr(runtime, "_public_values", public)
@@ -514,8 +528,10 @@ def test_triton_direct_winner_validates_constexpr_and_argument_errors():
 
     with pytest.raises(TypeError, match="passed twice"):
         launch(tensor, 2, scale=2)
+
     with pytest.raises(TypeError, match="Missing kernel arguments"):
         launch(tensor)
+
     with pytest.raises(TypeError, match="Unknown kernel arguments"):
         launch(tensor, 2, unknown=True)
 

--- a/tests/test_triton_runtime_auto_tuning.py
+++ b/tests/test_triton_runtime_auto_tuning.py
@@ -76,6 +76,9 @@ class _FakeTensor:
     def data_ptr(self):
         return self._data_ptr
 
+    def element_size(self):
+        return 4
+
     def storage_offset(self):
         return self._storage_offset
 
@@ -585,7 +588,9 @@ def test_triton_alias_selection_does_not_pollute_non_alias_tuning():
         public_args=("value", "output"),
         kernel_args=(
             LaunchBinding(name="value", kind="tensor", source="value"),
-            LaunchBinding(name="output", kind="tensor", source="output"),
+            LaunchBinding(
+                name="output", kind="tensor", source="output", access="write"
+            ),
         ),
         outputs=("output",),
     )
@@ -610,13 +615,23 @@ def test_triton_alias_selection_does_not_pollute_non_alias_tuning():
         handle,
         SimpleNamespace(launch_abi=abi, kernel=SimpleNamespace(tensors=())),
     )
+    first_value = _FakeTensor((4,))
+    first_output = _FakeTensor((4,))
+
+    assert launch(first_value, output=first_output) is first_output
+    assert tuner.calls == 1
+    assert [name for name, _ in calls] == ["first", "second", "second"]
+    assert tuner._best_func["shared-key"] is candidates[1]
+    assert handle._selected_tuning_candidate == {"id": "second"}
+
+    calls.clear()
     aliased = _FakeTensor((4,))
 
     assert launch(aliased, output=aliased) is aliased
-    assert tuner.calls == 0
+    assert tuner.calls == 1
     assert [name for name, _ in calls] == ["first"]
     assert handle._selected_tuning_candidate == {"id": "first"}
-    assert tuner._best_func == {}
+    assert tuner._best_func["shared-key"] is candidates[1]
 
     calls.clear()
     value = _FakeTensor((4,))
@@ -624,9 +639,100 @@ def test_triton_alias_selection_does_not_pollute_non_alias_tuning():
 
     assert launch(value, output=output) is output
     assert tuner.calls == 1
-    assert [name for name, _ in calls] == ["first", "second", "second"]
-    assert tuner._best_func["shared-key"] is candidates[1]
+    assert [name for name, _ in calls] == ["second"]
     assert handle._selected_tuning_candidate == {"id": "second"}
+
+
+@pytest.mark.parametrize("kind", ("scalar", "constexpr"))
+def test_triton_tensor_scalar_alias_uses_alias_safe_selection(kind):
+    abi = LaunchABI(
+        public_args=("scale", "output"),
+        kernel_args=(
+            LaunchBinding(name="scale", kind=kind, source="scale"),
+            LaunchBinding(
+                name="output",
+                kind="tensor",
+                source="output",
+                access="write",
+            ),
+        ),
+        outputs=("output",),
+    )
+    calls = []
+
+    def candidate(name):
+        return runtime._runtime_wrapper(
+            lambda *_values: calls.append(name),
+            abi,
+        )
+
+    candidates = (candidate("first"), candidate("second"))
+    tuner = _FakeTuner(candidates, lambda args, kwargs: "shared-key")
+    handle = SimpleNamespace(_selected_tuning_candidate=None)
+    launch = triton_materializer._tuned_runtime_launch(
+        tuner,
+        dict(zip(candidates, ({"id": "first"}, {"id": "second"}))),
+        handle,
+        SimpleNamespace(launch_abi=abi, kernel=SimpleNamespace(tensors=())),
+    )
+    output = torch.zeros(4)
+
+    assert launch(output[0], output) is output
+    assert calls == ["first"]
+    assert tuner.calls == 0
+
+
+def test_triton_alias_signature_uses_absolute_spans_and_fails_closed():
+    abi = LaunchABI(
+        public_args=("value", "output"),
+        kernel_args=(
+            LaunchBinding(name="value", kind="tensor", source="value", access="read"),
+            LaunchBinding(
+                name="output",
+                kind="tensor",
+                source="output",
+                access="write",
+            ),
+        ),
+        outputs=("output",),
+    )
+    output = _FakeTensor((4,), data_ptr=1024)
+
+    overlapping = _FakeTensor((4,), data_ptr=1032)
+    assert triton_materializer._runtime_alias_signature(
+        abi, {"value": overlapping, "output": output}
+    )
+
+    unknown = SimpleNamespace(
+        shape=(4,),
+        stride=lambda: (1,),
+        data_ptr=lambda: 2048,
+        device="cuda:0",
+    )
+    assert triton_materializer._runtime_alias_signature(
+        abi, {"value": unknown, "output": output}
+    )
+
+    legacy_output_abi = LaunchABI(
+        public_args=("output",),
+        kernel_args=(LaunchBinding(name="output", kind="tensor", source="output"),),
+        outputs=("output",),
+    )
+    assert triton_materializer._runtime_alias_signature(
+        legacy_output_abi, {"output": output}
+    )
+
+    mixed_access_abi = LaunchABI(
+        public_args=("output",),
+        kernel_args=(
+            LaunchBinding(name="read", kind="tensor", source="output", access="read"),
+            LaunchBinding(name="write", kind="tensor", source="output", access="write"),
+        ),
+        outputs=("output",),
+    )
+    assert triton_materializer._runtime_alias_signature(
+        mixed_access_abi, {"output": output}
+    )
 
 
 def test_triton_read_write_binding_uses_alias_safe_selection():
@@ -755,12 +861,14 @@ def test_triton_alias_selection_uses_jagged_binding_access():
     assert handle._selected_tuning_candidate == {"id": "second"}
 
 
-def test_triton_alias_selection_skips_failed_candidate():
+def test_triton_alias_selection_handles_candidate_failures_safely():
     abi = LaunchABI(
         public_args=("value", "output"),
         kernel_args=(
             LaunchBinding(name="value", kind="tensor", source="value"),
-            LaunchBinding(name="output", kind="tensor", source="output"),
+            LaunchBinding(
+                name="output", kind="tensor", source="output", access="write"
+            ),
         ),
         outputs=("output",),
     )
@@ -786,11 +894,51 @@ def test_triton_alias_selection_skips_failed_candidate():
     )
     value = _FakeTensor((4,))
 
-    assert launch(value, output=value) is value
-    assert calls == ["first", "second"]
+    with pytest.raises(RuntimeError, match="Candidate unavailable"):
+        launch(value, output=value)
+
+    assert calls == ["first"]
     assert tuner.calls == 0
     assert tuner._best_func == {}
-    assert handle._selected_tuning_candidate == {"id": "second"}
+    assert handle._selected_tuning_candidate is None
+
+    calls.clear()
+    candidates = (candidate("first"), candidate("second"))
+
+    def fail_prepare(*_args, **_kwargs):
+        raise RuntimeError("Candidate did not prepare.")
+
+    candidates[0]._ninetoothed_prepare = fail_prepare
+    tuner = _FakeTuner(candidates, lambda args, kwargs: "shared-key")
+    launch = triton_materializer._tuned_runtime_launch(
+        tuner,
+        dict(zip(candidates, ({"id": "first"}, {"id": "second"}))),
+        handle,
+        SimpleNamespace(launch_abi=abi, kernel=SimpleNamespace(tensors=())),
+    )
+
+    assert launch(value, output=value) is value
+    assert calls == ["first"]
+    assert handle._selected_tuning_candidate == {"id": "first"}
+
+    calls.clear()
+    candidates = (candidate("first"), candidate("second"))
+    candidates[0]._ninetoothed_prepare = fail_prepare
+    tuner = _FakeTuner(
+        candidates,
+        lambda args, kwargs: "shared-key",
+        selected_index=0,
+    )
+    launch = triton_materializer._tuned_runtime_launch(
+        tuner,
+        dict(zip(candidates, ({"id": "first"}, {"id": "second"}))),
+        handle,
+        SimpleNamespace(launch_abi=abi, kernel=SimpleNamespace(tensors=())),
+    )
+
+    assert launch(_FakeTensor((4,)), output=_FakeTensor((4,))) is not None
+    assert calls == ["first", "second", "first"]
+    assert handle._selected_tuning_candidate == {"id": "first"}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_triton_runtime_auto_tuning.py
+++ b/tests/test_triton_runtime_auto_tuning.py
@@ -72,10 +72,11 @@ def _contiguous_stride(shape):
 
 
 class _FakeTuner:
-    def __init__(self, candidates, key_function):
+    def __init__(self, candidates, key_function, *, selected_index=None):
         self._funcs = tuple(candidates)
         self._best_func = {}
         self._key_function = key_function
+        self._selected_index = selected_index
         self.calls = 0
 
     def _make_arg_key(self, args, kwargs):
@@ -88,7 +89,13 @@ class _FakeTuner:
             candidate(*args, **kwargs)
 
         key = self._make_arg_key(args, kwargs)
-        selected = self._funcs[0] if args[0].shape[0] == 4 else self._funcs[1]
+        selected = (
+            self._funcs[self._selected_index]
+            if self._selected_index is not None
+            else self._funcs[0]
+            if args[0].shape[0] == 4
+            else self._funcs[1]
+        )
         self._best_func[key] = selected
 
         return selected(*args, **kwargs)
@@ -518,7 +525,7 @@ def test_triton_direct_winner_reuses_verified_binding_and_restores_aba(monkeypat
     assert binding_calls == 0
 
 
-def test_triton_aliasing_output_uses_one_statically_ranked_candidate():
+def test_triton_alias_selection_does_not_pollute_non_alias_tuning():
     abi = LaunchABI(
         public_args=("value", "output"),
         kernel_args=(
@@ -536,7 +543,59 @@ def test_triton_aliasing_output_uses_one_statically_ranked_candidate():
         )
 
     candidates = (candidate("first"), candidate("second"))
-    tuner = _FakeTuner(candidates, lambda args, kwargs: "alias-key")
+    tuner = _FakeTuner(
+        candidates,
+        lambda args, kwargs: "shared-key",
+        selected_index=1,
+    )
+    handle = SimpleNamespace(_selected_tuning_candidate=None)
+    launch = triton_materializer._tuned_runtime_launch(
+        tuner,
+        dict(zip(candidates, ({"id": "first"}, {"id": "second"}))),
+        handle,
+        SimpleNamespace(launch_abi=abi, kernel=SimpleNamespace(tensors=())),
+    )
+    aliased = _FakeTensor((4,))
+
+    assert launch(aliased, output=aliased) is aliased
+    assert tuner.calls == 0
+    assert [name for name, _ in calls] == ["first"]
+    assert handle._selected_tuning_candidate == {"id": "first"}
+    assert tuner._best_func == {}
+
+    calls.clear()
+    value = _FakeTensor((4,))
+    output = _FakeTensor((4,))
+
+    assert launch(value, output=output) is output
+    assert tuner.calls == 1
+    assert [name for name, _ in calls] == ["first", "second", "second"]
+    assert tuner._best_func["shared-key"] is candidates[1]
+    assert handle._selected_tuning_candidate == {"id": "second"}
+
+
+def test_triton_alias_selection_skips_failed_candidate():
+    abi = LaunchABI(
+        public_args=("value", "output"),
+        kernel_args=(
+            LaunchBinding(name="value", kind="tensor", source="value"),
+            LaunchBinding(name="output", kind="tensor", source="output"),
+        ),
+        outputs=("output",),
+    )
+    calls = []
+
+    def candidate(name, *, fails=False):
+        def invoke(*_values):
+            calls.append(name)
+
+            if fails:
+                raise RuntimeError("Candidate unavailable.")
+
+        return runtime._runtime_wrapper(invoke, abi)
+
+    candidates = (candidate("first", fails=True), candidate("second"))
+    tuner = _FakeTuner(candidates, lambda args, kwargs: "shared-key")
     handle = SimpleNamespace(_selected_tuning_candidate=None)
     launch = triton_materializer._tuned_runtime_launch(
         tuner,
@@ -547,9 +606,10 @@ def test_triton_aliasing_output_uses_one_statically_ranked_candidate():
     value = _FakeTensor((4,))
 
     assert launch(value, output=value) is value
+    assert calls == ["first", "second"]
     assert tuner.calls == 0
-    assert [name for name, _ in calls] == ["first"]
-    assert handle._selected_tuning_candidate == {"id": "first"}
+    assert tuner._best_func == {}
+    assert handle._selected_tuning_candidate == {"id": "second"}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_triton_runtime_auto_tuning.py
+++ b/tests/test_triton_runtime_auto_tuning.py
@@ -1,6 +1,8 @@
 import functools
+import gc
 import inspect
 import uuid
+import weakref
 from types import SimpleNamespace
 
 import pytest
@@ -330,7 +332,51 @@ def test_verified_runtime_four_buffer_call_has_no_cached_output_field():
     prepared = inspect.getclosurevars(launch).nonlocals["active"]
     assert not hasattr(prepared, "output")
     assert not hasattr(prepared, "result")
-    assert all(contract.value is None for contract in prepared.guard.positional)
+
+
+def test_verified_runtime_cache_does_not_retain_tensor_or_flattened_view():
+    abi = LaunchABI(
+        public_args=("value",),
+        kernel_args=(LaunchBinding(name="value", kind="tensor", source="value"),),
+    )
+    view_refs = []
+    invoked_refs = []
+
+    def prepare_invocation(values, _static_values, _call_sources):
+        view_refs.append(weakref.ref(values[0]))
+
+        def invoke(current_values, _args, _kwargs):
+            invoked_refs.append(weakref.ref(current_values[0]))
+
+        return invoke
+
+    wrapped = runtime._runtime_wrapper(
+        lambda _value: None,
+        abi,
+        prepare_invocation=prepare_invocation,
+    )
+    launch = runtime._verified_runtime_launch(wrapped)
+    value = torch.arange(8)
+    value_ref = weakref.ref(value)
+
+    launch(value)
+    launch(value)
+    gc.collect()
+
+    nonlocals = inspect.getclosurevars(launch).nonlocals
+    assert len(nonlocals["prepared_calls"]) == 1
+    assert len(view_refs) == 1
+    assert all(reference() is None for reference in view_refs)
+    assert len(invoked_refs) == 2
+    assert all(reference() is None for reference in invoked_refs)
+    assert torch.equal(value, torch.arange(8))
+
+    del value
+    gc.collect()
+
+    assert value_ref() is None
+    assert nonlocals["prepared_calls"] == {}
+    assert inspect.getclosurevars(launch).nonlocals["active"] is None
 
 
 def test_verified_runtime_uses_prepared_low_level_invocation():
@@ -342,11 +388,11 @@ def test_verified_runtime_uses_prepared_low_level_invocation():
     invoked_values = []
     raw_calls = []
 
-    def prepare_invocation(values):
+    def prepare_invocation(values, _static_values, _call_sources):
         prepared_values.append(values)
 
-        def invoke():
-            invoked_values.append(values)
+        def invoke(current_values, _args, _kwargs):
+            invoked_values.append(current_values)
 
         return invoke
 
@@ -405,12 +451,28 @@ def test_triton_prepared_invocation_caches_grid_without_launching(monkeypatch):
     assert bound_grids == [(4,)]
     assert kernel_calls == []
 
-    assert invocation() is None
-    assert invocation() is None
+    assert invocation(("pointer", 4), (), {}) is None
+    assert invocation(("pointer", 4), (), {}) is None
     assert kernel_calls == [
         (("pointer", 4), {"BLOCK": 1, "num_warps": 8}),
         (("pointer", 4), {"BLOCK": 1, "num_warps": 8}),
     ]
+
+    value = _FakeTensor((4,))
+    value_ref = weakref.ref(value)
+    unowned_invocation = prepare(
+        (value, 4),
+        (None, 4),
+        (("positional", 0), None),
+    )
+    assert unowned_invocation((), (value,), {}) is None
+    kernel_calls.clear()
+    del value
+    gc.collect()
+
+    assert unowned_invocation is not None
+    assert not unowned_invocation.requires_values
+    assert value_ref() is None
 
     with pytest.raises(ValueError, match="positive"):
         prepare(("pointer", 0))
@@ -665,6 +727,48 @@ def test_triton_tuple_configurations_are_benchmarked_and_cached(device, monkeypa
 
     handle(input, other, output)
     assert len(benchmarked) == 2
+
+
+@pytest.mark.parametrize("device", get_available_devices())
+def test_triton_prepared_cache_releases_gpu_tensor_storage(device):
+    handle = ninetoothed.make(
+        _arrangement,
+        _application,
+        tuple(Tensor(shape=(1 << 20,), dtype=ninetoothed.float32) for _ in range(3)),
+        backend="triton",
+        kernel_name=f"runtime_weak_cache_{uuid.uuid4().hex}",
+    )
+    warm_input = torch.randn(1 << 20, device=device)
+    warm_other = torch.randn_like(warm_input)
+    warm_output = torch.empty_like(warm_input)
+    handle(warm_input, warm_other, warm_output)
+    torch.cuda.synchronize(device)
+    del warm_input, warm_other, warm_output
+    gc.collect()
+    baseline = torch.cuda.memory_allocated(device)
+
+    input = torch.randn(1 << 20, device=device)
+    other = torch.randn_like(input)
+    output = torch.empty_like(input)
+    references = tuple(weakref.ref(value) for value in (input, other, output))
+    handle(input, other, output)
+    torch.cuda.synchronize(device)
+    allocated = torch.cuda.memory_allocated(device)
+    del input, other, output
+    gc.collect()
+    torch.cuda.synchronize(device)
+
+    assert allocated > baseline
+    assert all(reference() is None for reference in references)
+    assert torch.cuda.memory_allocated(device) <= baseline
+
+    replacement_input = torch.randn(1 << 20, device=device)
+    replacement_other = torch.randn_like(replacement_input)
+    replacement_output = torch.empty_like(replacement_input)
+    handle(replacement_input, replacement_other, replacement_output)
+    torch.cuda.synchronize(device)
+
+    assert torch.allclose(replacement_output, replacement_input + replacement_other)
 
 
 def test_auto_tuner_validates_arguments_before_benchmark(tmp_path, monkeypatch):

--- a/tests/test_triton_runtime_auto_tuning.py
+++ b/tests/test_triton_runtime_auto_tuning.py
@@ -1,12 +1,20 @@
+import functools
+import inspect
 import uuid
+from types import SimpleNamespace
 
 import pytest
 import torch
 
 import ninetoothed
 import ninetoothed.auto_tuner as auto_tuner
+import ninetoothed.backends.materializers.triton as triton_materializer
+import ninetoothed.compiler.runtime as runtime
 from ninetoothed import Tensor
+from ninetoothed.ir import LaunchABI, LaunchBinding
 from tests.utils import get_available_devices
+
+_prepared_test_kernel = None
 
 
 def _arrangement(input, other, output):
@@ -15,6 +23,595 @@ def _arrangement(input, other, output):
 
 def _application(input, other, output):
     output = input + other  # noqa: F841
+
+
+class _FakeTensor:
+    def __init__(
+        self,
+        shape,
+        *,
+        stride=None,
+        dtype="float32",
+        device="cuda:0",
+        data_ptr=None,
+    ):
+        self.shape = tuple(shape)
+        self._stride = tuple(stride or _contiguous_stride(shape))
+        self.dtype = dtype
+        self.device = device
+        self._data_ptr = id(self) if data_ptr is None else data_ptr
+        self._storage_offset = 0
+
+    def stride(self):
+        return self._stride
+
+    def data_ptr(self):
+        return self._data_ptr
+
+    def storage_offset(self):
+        return self._storage_offset
+
+    def numel(self):
+        result = 1
+
+        for size in self.shape:
+            result *= size
+        return result
+
+
+def _contiguous_stride(shape):
+    result = []
+    stride = 1
+
+    for size in reversed(shape):
+        result.append(stride)
+        stride *= size
+    return tuple(reversed(result))
+
+
+class _FakeTuner:
+    def __init__(self, candidates, key_function):
+        self._funcs = tuple(candidates)
+        self._best_func = {}
+        self._key_function = key_function
+        self.calls = 0
+
+    def _make_arg_key(self, args, kwargs):
+        return self._key_function(args, kwargs)
+
+    def __call__(self, *args, **kwargs):
+        self.calls += 1
+
+        for candidate in self._funcs:
+            candidate(*args, **kwargs)
+
+        key = self._make_arg_key(args, kwargs)
+        selected = self._funcs[0] if args[0].shape[0] == 4 else self._funcs[1]
+        self._best_func[key] = selected
+        return selected(*args, **kwargs)
+
+
+def _runtime_fixture(*, with_constexpr=False):
+    public_args = ("value", "scale") if with_constexpr else ("value",)
+    bindings = [LaunchBinding(name="value", kind="tensor", source="value")]
+
+    if with_constexpr:
+        bindings.append(LaunchBinding(name="scale", kind="constexpr", source="scale"))
+
+    abi = LaunchABI(public_args=public_args, kernel_args=tuple(bindings))
+    calls = []
+
+    def candidate(name):
+        return runtime._runtime_wrapper(
+            lambda *values: calls.append((name, values)) or values[0],
+            abi,
+        )
+
+    candidates = (candidate("first"), candidate("second"))
+    compilation = SimpleNamespace(
+        launch_abi=abi,
+        kernel=SimpleNamespace(tensors=()),
+    )
+    tuner = _FakeTuner(
+        candidates,
+        lambda args, kwargs: triton_materializer._triton_specialization_key(
+            compilation, args, kwargs
+        ),
+    )
+    handle = SimpleNamespace(_selected_tuning_candidate=None)
+    launch = triton_materializer._tuned_runtime_launch(
+        tuner,
+        dict(zip(candidates, ({"id": "first"}, {"id": "second"}))),
+        handle,
+        compilation,
+    )
+    return launch, tuner, handle, calls
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    (
+        None,
+        {
+            "id": "single",
+            "num_warps": 4,
+            "num_stages": 1,
+            "meta_parameters": {},
+        },
+    ),
+    ids=("plain", "single-candidate"),
+)
+def test_triton_single_and_plain_materialization_use_verified_launch(
+    candidate, tmp_path, monkeypatch
+):
+    abi = LaunchABI(
+        public_args=("value",),
+        kernel_args=(LaunchBinding(name="value", kind="tensor", source="value"),),
+    )
+    raw_calls = []
+
+    def raw_launch(*values, **kwargs):
+        raw_calls.append((values, kwargs))
+        return values[0]
+
+    class FakeHandle:
+        def __init__(self, compilation, kernel, launch, source):
+            del compilation, kernel, source
+            self._launch = launch
+
+        def __call__(self, *args, **kwargs):
+            return self._launch(*args, **kwargs)
+
+    compilation = SimpleNamespace(
+        artifact=SimpleNamespace(
+            kernel_name="verified_runtime",
+            primary_source="",
+            entrypoint="launch",
+        ),
+        launch_abi=abi,
+        launch_plan=SimpleNamespace(
+            tuning_candidates=() if candidate is None else (candidate,)
+        ),
+        kernel=SimpleNamespace(tensors=()),
+    )
+    public_calls = 0
+    original_public = runtime._public_values
+
+    def public(*args, **kwargs):
+        nonlocal public_calls
+        public_calls += 1
+        return original_public(*args, **kwargs)
+
+    monkeypatch.setattr(runtime, "Handle", FakeHandle)
+    monkeypatch.setattr(runtime, "_public_values", public)
+    monkeypatch.setattr(triton_materializer, "_ensure_c_compiler", lambda: None)
+    monkeypatch.setattr(
+        triton_materializer,
+        "compilation_cache_key",
+        lambda compilation: "verified-runtime",
+    )
+    monkeypatch.setattr(
+        triton_materializer,
+        "write_source",
+        lambda *args, **kwargs: tmp_path / "verified_runtime.py",
+    )
+    monkeypatch.setattr(
+        runtime,
+        "import_python_module",
+        lambda source: SimpleNamespace(launch=raw_launch),
+    )
+    monkeypatch.setattr(triton_materializer, "TRITON_CACHE_DIR", tmp_path / "cache")
+    handle = triton_materializer._materialize(compilation)
+    value = _FakeTensor((4,))
+
+    assert handle(value) is value
+    assert handle(value) is value
+    assert len(raw_calls) == 2
+    assert public_calls == 1
+    assert len(inspect.getclosurevars(handle._launch).nonlocals["prepared_calls"]) == 1
+
+
+def _verified_runtime_fixture(*, with_constexpr=False, outputs=()):
+    public_args = ("value", "scale") if with_constexpr else ("value",)
+    bindings = [LaunchBinding(name="value", kind="tensor", source="value")]
+
+    if with_constexpr:
+        bindings.append(LaunchBinding(name="scale", kind="constexpr", source="scale"))
+
+    abi = LaunchABI(
+        public_args=public_args,
+        kernel_args=tuple(bindings),
+        outputs=outputs,
+    )
+    calls = []
+    wrapped = runtime._runtime_wrapper(
+        lambda *values: calls.append(values),
+        abi,
+    )
+    return runtime._verified_runtime_launch(wrapped), calls
+
+
+def test_verified_runtime_launch_rebinds_zero_dimensional_value(monkeypatch):
+    binding_calls = 0
+    original_bound = runtime._bound_values
+
+    def bound(*args, **kwargs):
+        nonlocal binding_calls
+        binding_calls += 1
+        return original_bound(*args, **kwargs)
+
+    monkeypatch.setattr(runtime, "_bound_values", bound)
+    launch, calls = _verified_runtime_fixture(with_constexpr=True)
+    value = _FakeTensor((4,))
+    scale = torch.tensor(2)
+
+    launch(value, scale)
+    launch(value, scale)
+    scale.fill_(3)
+    launch(value, scale)
+
+    assert [values[-1] for values in calls] == [2, 2, 3]
+    assert binding_calls == 2
+
+
+def test_verified_runtime_launch_keeps_eight_recent_identities(monkeypatch):
+    binding_calls = 0
+    original_bound = runtime._bound_values
+
+    def bound(*args, **kwargs):
+        nonlocal binding_calls
+        binding_calls += 1
+        return original_bound(*args, **kwargs)
+
+    monkeypatch.setattr(runtime, "_bound_values", bound)
+    launch, _ = _verified_runtime_fixture()
+    values = [_FakeTensor((size,)) for size in range(1, 18)]
+
+    for value in values:
+        launch(value)
+
+    nonlocals = inspect.getclosurevars(launch).nonlocals
+    assert len(nonlocals["prepared_calls"]) == 8
+    assert binding_calls == 17
+
+    launch(values[0])
+    assert binding_calls == 18
+
+
+def test_verified_runtime_launch_handles_zero_without_calling_kernel():
+    launch, calls = _verified_runtime_fixture()
+    nonempty = _FakeTensor((4,))
+    empty = _FakeTensor((0,))
+
+    assert launch(nonempty) is None
+    assert launch(empty) is None
+    assert launch(nonempty) is None
+    assert calls == [(nonempty,), (nonempty,)]
+
+
+def test_verified_runtime_launch_preserves_argument_errors():
+    launch, _ = _verified_runtime_fixture(with_constexpr=True)
+    value = _FakeTensor((4,))
+
+    launch(value, 2)
+
+    with pytest.raises(TypeError, match="passed twice"):
+        launch(value, 2, scale=2)
+    with pytest.raises(TypeError, match="Missing kernel arguments"):
+        launch(value)
+    with pytest.raises(TypeError, match="Unknown kernel arguments"):
+        launch(value, 2, unknown=True)
+
+
+def test_verified_runtime_four_buffer_call_has_no_cached_output_field():
+    names = ("first", "second", "third", "output")
+    abi = LaunchABI(
+        public_args=names,
+        kernel_args=tuple(
+            LaunchBinding(name=name, kind="tensor", source=name) for name in names
+        ),
+        outputs=("output",),
+    )
+    wrapped = runtime._runtime_wrapper(lambda *values: None, abi)
+    launch = runtime._verified_runtime_launch(wrapped)
+    buffers = tuple(_FakeTensor((4,)) for _ in names)
+
+    assert launch(*buffers) is buffers[-1]
+    assert launch(*buffers) is buffers[-1]
+    prepared = inspect.getclosurevars(launch).nonlocals["active"]
+    assert not hasattr(prepared, "output")
+    assert not hasattr(prepared, "result")
+    assert all(contract.value is None for contract in prepared.guard.positional)
+
+
+def test_verified_runtime_uses_prepared_low_level_invocation():
+    abi = LaunchABI(
+        public_args=("value",),
+        kernel_args=(LaunchBinding(name="value", kind="tensor", source="value"),),
+    )
+    prepared_values = []
+    invoked_values = []
+    raw_calls = []
+
+    def prepare_invocation(values):
+        prepared_values.append(values)
+
+        def invoke():
+            invoked_values.append(values)
+
+        return invoke
+
+    wrapped = runtime._runtime_wrapper(
+        lambda *values: raw_calls.append(values),
+        abi,
+        prepare_invocation=prepare_invocation,
+    )
+    launch = runtime._verified_runtime_launch(wrapped)
+    value = _FakeTensor((4,))
+
+    assert launch(value) is None
+    assert launch(value) is None
+    assert prepared_values == [(value,)]
+    assert invoked_values == [(value,), (value,)]
+    assert raw_calls == []
+
+
+def test_triton_prepared_invocation_caches_grid_without_launching(monkeypatch):
+    bound_grids = []
+    kernel_calls = []
+
+    class FakeKernel:
+        def __getitem__(self, grid):
+            bound_grids.append(grid)
+
+            def launch(*args, **kwargs):
+                kernel_calls.append((args, kwargs))
+                return object()
+
+            return launch
+
+    kernel = FakeKernel()
+    monkeypatch.setitem(globals(), "_prepared_test_kernel", kernel)
+
+    def generated_launch(value, size, _ninetoothed_num_warps=4):
+        if size <= 0:
+            raise ValueError("size must be positive")
+        _prepared_test_kernel[(size,)](
+            value,
+            size,
+            BLOCK=1,
+            num_warps=_ninetoothed_num_warps,
+        )
+        return value
+
+    function = functools.partial(generated_launch, _ninetoothed_num_warps=8)
+    prepare = triton_materializer._triton_prepare_invocation(function, kernel)
+
+    assert prepare is not None
+    assert bound_grids == []
+    invocation = prepare(("pointer", 4))
+    assert bound_grids == [(4,)]
+    assert kernel_calls == []
+
+    assert invocation() is None
+    assert invocation() is None
+    assert kernel_calls == [
+        (("pointer", 4), {"BLOCK": 1, "num_warps": 8}),
+        (("pointer", 4), {"BLOCK": 1, "num_warps": 8}),
+    ]
+
+    with pytest.raises(ValueError, match="positive"):
+        prepare(("pointer", 0))
+
+
+def test_triton_direct_winner_reuses_verified_binding_and_restores_aba(monkeypatch):
+    public_calls = 0
+    binding_calls = 0
+    original_public = runtime._public_values
+    original_bound = runtime._bound_values
+
+    def public(*args, **kwargs):
+        nonlocal public_calls
+        public_calls += 1
+        return original_public(*args, **kwargs)
+
+    def bound(*args, **kwargs):
+        nonlocal binding_calls
+        binding_calls += 1
+        return original_bound(*args, **kwargs)
+
+    monkeypatch.setattr(runtime, "_public_values", public)
+    monkeypatch.setattr(runtime, "_bound_values", bound)
+    launch, tuner, handle, calls = _runtime_fixture()
+    first = _FakeTensor((4,))
+    second = _FakeTensor((8,), stride=(2,))
+
+    assert launch(first) is first
+    assert handle._selected_tuning_candidate == {"id": "first"}
+    assert launch(second) is second
+    assert handle._selected_tuning_candidate == {"id": "second"}
+    assert tuner.calls == 2
+    public_calls = binding_calls = 0
+    calls.clear()
+
+    assert launch(first) is first
+    assert handle._selected_tuning_candidate == {"id": "first"}
+    assert calls == [("first", (first,))]
+    assert tuner.calls == 2
+    assert public_calls == 0
+    assert binding_calls == 0
+
+
+def test_triton_aliasing_output_uses_one_statically_ranked_candidate():
+    abi = LaunchABI(
+        public_args=("value", "output"),
+        kernel_args=(
+            LaunchBinding(name="value", kind="tensor", source="value"),
+            LaunchBinding(name="output", kind="tensor", source="output"),
+        ),
+        outputs=("output",),
+    )
+    calls = []
+
+    def candidate(name):
+        return runtime._runtime_wrapper(
+            lambda *values: calls.append((name, values)) or object(),
+            abi,
+        )
+
+    candidates = (candidate("first"), candidate("second"))
+    tuner = _FakeTuner(candidates, lambda args, kwargs: "alias-key")
+    handle = SimpleNamespace(_selected_tuning_candidate=None)
+    launch = triton_materializer._tuned_runtime_launch(
+        tuner,
+        dict(zip(candidates, ({"id": "first"}, {"id": "second"}))),
+        handle,
+        SimpleNamespace(launch_abi=abi, kernel=SimpleNamespace(tensors=())),
+    )
+    value = _FakeTensor((4,))
+
+    assert launch(value, output=value) is value
+    assert tuner.calls == 0
+    assert [name for name, _ in calls] == ["first"]
+    assert handle._selected_tuning_candidate == {"id": "first"}
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected_tuner_calls"),
+    (
+        ("shape", (4, 1), 2),
+        ("_stride", (2,), 2),
+        ("dtype", "float16", 2),
+        ("device", "cuda:1", 2),
+        ("_data_ptr", 1, 1),
+        ("_storage_offset", 1, 1),
+    ),
+)
+def test_prepared_launch_rebinds_after_tensor_contract_change(
+    field, value, expected_tuner_calls
+):
+    launch, tuner, _, _ = _runtime_fixture()
+    tensor = _FakeTensor((4,))
+
+    assert launch(tensor) is tensor
+    assert tuner.calls == 1
+    setattr(tensor, field, value)
+    assert launch(tensor) is tensor
+    assert tuner.calls == expected_tuner_calls
+
+
+def test_triton_direct_winner_validates_constexpr_and_argument_errors():
+    launch, tuner, _, _ = _runtime_fixture(with_constexpr=True)
+    tensor = _FakeTensor((4,))
+
+    assert launch(tensor, 2) is tensor
+    assert launch(tensor, 2) is tensor
+    assert tuner.calls == 1
+    assert launch(tensor, 3) is tensor
+    assert tuner.calls == 2
+    assert launch(tensor, 2) is tensor
+    assert tuner.calls == 2
+
+    with pytest.raises(TypeError, match="passed twice"):
+        launch(tensor, 2, scale=2)
+    with pytest.raises(TypeError, match="Missing kernel arguments"):
+        launch(tensor)
+    with pytest.raises(TypeError, match="Unknown kernel arguments"):
+        launch(tensor, 2, unknown=True)
+
+
+def test_zero_dimensional_constexpr_mutation_rebinds_current_value():
+    launch, tuner, _, calls = _runtime_fixture(with_constexpr=True)
+    tensor = _FakeTensor((4,))
+    scale = torch.tensor(2)
+
+    assert launch(tensor, scale) is tensor
+    calls.clear()
+    assert launch(tensor, scale) is tensor
+    assert calls == [("first", (tensor, 2))]
+
+    scale.fill_(3)
+    calls.clear()
+    assert launch(tensor, scale) is tensor
+    assert [values[-1] for _, values in calls] == [3, 3, 3]
+    assert tuner.calls == 2
+
+    abi = LaunchABI(
+        public_args=("value", "scale"),
+        kernel_args=(
+            LaunchBinding(name="value", kind="tensor", source="value"),
+            LaunchBinding(name="scale", kind="constexpr", source="scale"),
+        ),
+    )
+    compilation = SimpleNamespace(launch_abi=abi)
+    scale.fill_(2)
+    first_key = triton_materializer._triton_specialization_key(
+        compilation, (tensor, scale), {}
+    )
+    scale.fill_(3)
+    second_key = triton_materializer._triton_specialization_key(
+        compilation, (tensor, scale), {}
+    )
+    assert first_key != second_key
+
+
+def test_triton_winner_proofs_share_the_bounded_prepared_lru():
+    launch, tuner, _, _ = _runtime_fixture()
+
+    for size in range(1, 18):
+        tensor = _FakeTensor((size,))
+        assert launch(tensor) is tensor
+
+    nonlocals = inspect.getclosurevars(launch).nonlocals
+    assert "selected_by_key" not in nonlocals
+    assert len(nonlocals["prepared_calls"]) == 8
+    assert tuner.calls == 17
+
+    first = _FakeTensor((1,))
+    assert launch(first) is first
+    assert tuner.calls == 18
+
+
+def test_prepared_launch_resolves_output_from_the_current_call():
+    abi = LaunchABI(
+        public_args=("value", "output"),
+        kernel_args=(
+            LaunchBinding(name="value", kind="tensor", source="value"),
+            LaunchBinding(name="output", kind="tensor", source="output"),
+        ),
+        outputs=("output",),
+    )
+    internal_result = object()
+    wrapped = runtime._runtime_wrapper(
+        lambda value, output: internal_result,
+        abi,
+    )
+    value = _FakeTensor((4,))
+    output = _FakeTensor((4,))
+    prepared = wrapped._ninetoothed_prepare((value, output), {})
+
+    assert wrapped(value, output) is output
+    assert not hasattr(prepared, "output")
+    assert not hasattr(prepared, "args")
+    assert not hasattr(prepared, "kwargs")
+    assert prepared.guard.positional[1].identity == id(output)
+    assert prepared.guard.positional[1].value is None
+    assert wrapped._ninetoothed_invoke_prepared(prepared, (value, output), {}) is output
+
+
+def test_triton_zero_size_does_not_disturb_nonempty_prepared_call():
+    launch, tuner, _, calls = _runtime_fixture()
+    nonempty = _FakeTensor((4,))
+    empty = _FakeTensor((0,))
+
+    assert launch(nonempty) is nonempty
+    assert tuner.calls == 1
+    calls.clear()
+    assert launch(empty) is None
+    assert calls == []
+    assert tuner.calls == 1
+    assert launch(nonempty) is nonempty
+    assert tuner.calls == 1
 
 
 @pytest.mark.parametrize("device", get_available_devices())

--- a/tests/test_triton_runtime_auto_tuning.py
+++ b/tests/test_triton_runtime_auto_tuning.py
@@ -13,6 +13,7 @@ import ninetoothed.auto_tuner as auto_tuner
 import ninetoothed.backends.materializers.triton as triton_materializer
 import ninetoothed.compiler.runtime as runtime
 from ninetoothed import Tensor
+from ninetoothed.compiler import DEFAULT_COMPILER, CompileRequest
 from ninetoothed.ir import LaunchABI, LaunchBinding
 from tests.utils import get_available_devices
 
@@ -25,6 +26,14 @@ def _arrangement(input, other, output):
 
 def _application(input, other, output):
     output = input + other  # noqa: F841
+
+
+def _inplace_arrangement(output):
+    return (output.tile((64,)),)
+
+
+def _inplace_application(output):
+    output = output + 1  # noqa: F841
 
 
 class _FakeTensor:
@@ -603,15 +612,72 @@ def test_triton_alias_selection_does_not_pollute_non_alias_tuning():
     assert handle._selected_tuning_candidate == {"id": "second"}
 
 
-def test_triton_alias_selection_uses_jagged_physical_bindings():
+def test_triton_read_write_binding_uses_alias_safe_selection():
+    compilation = DEFAULT_COMPILER.compile(
+        CompileRequest(
+            arrangement=_inplace_arrangement,
+            application=_inplace_application,
+            tensors=(Tensor(1),),
+            backend="triton",
+            num_warps=(4, 8),
+        )
+    )
+    abi = compilation.launch_abi
+    binding = next(binding for binding in abi.kernel_args if binding.kind == "tensor")
+    calls = []
+
+    def candidate(name):
+        def increment(value, *_metadata):
+            calls.append(name)
+            return value.add_(1)
+
+        return runtime._runtime_wrapper(increment, abi)
+
+    candidates = (candidate("first"), candidate("second"))
+    tuner = _FakeTuner(candidates, lambda args, kwargs: "shared-key")
+    handle = SimpleNamespace(_selected_tuning_candidate=None)
+    launch = triton_materializer._tuned_runtime_launch(
+        tuner,
+        dict(zip(candidates, ({"id": "first"}, {"id": "second"}))),
+        handle,
+        SimpleNamespace(launch_abi=abi, kernel=SimpleNamespace(tensors=())),
+    )
+    output = torch.zeros(4)
+
+    assert binding.access == "read_write"
+    assert launch(output) is output
+    assert torch.equal(output, torch.ones(4))
+    assert calls == ["first"]
+    assert tuner.calls == 0
+
+
+def test_triton_alias_selection_uses_jagged_binding_access():
     abi = LaunchABI(
         public_args=("value", "output"),
         kernel_args=(
-            LaunchBinding(name="value_values", kind="jagged_values", source="value"),
-            LaunchBinding(name="value_offsets", kind="jagged_offsets", source="value"),
-            LaunchBinding(name="output_values", kind="jagged_values", source="output"),
             LaunchBinding(
-                name="output_offsets", kind="jagged_offsets", source="output"
+                name="value_values",
+                kind="jagged_values",
+                source="value",
+                access="read",
+            ),
+            LaunchBinding(
+                name="value_offsets",
+                kind="jagged_offsets",
+                source="value",
+                access="read",
+            ),
+            LaunchBinding(
+                name="output_values",
+                kind="jagged_values",
+                source="output",
+                access="write",
+            ),
+            LaunchBinding(
+                name="output_offsets",
+                kind="jagged_offsets",
+                source="output",
+                access="read",
             ),
         ),
         outputs=("output",),
@@ -641,6 +707,16 @@ def test_triton_alias_selection_uses_jagged_physical_bindings():
     assert tuner.calls == 0
     assert [name for name, _ in calls] == ["first"]
     assert handle._selected_tuning_candidate == {"id": "first"}
+
+    calls.clear()
+    offsets = torch.tensor((0, 4, 8))
+    value = torch.nested.nested_tensor_from_jagged(torch.arange(8.0), offsets)
+    output = torch.nested.nested_tensor_from_jagged(torch.empty(8), offsets)
+
+    assert launch(value, output=output) is output
+    assert tuner.calls == 1
+    assert [name for name, _ in calls] == ["first", "second", "second"]
+    assert handle._selected_tuning_candidate == {"id": "second"}
 
 
 def test_triton_alias_selection_skips_failed_candidate():

--- a/tests/test_triton_runtime_auto_tuning.py
+++ b/tests/test_triton_runtime_auto_tuning.py
@@ -28,12 +28,29 @@ def _application(input, other, output):
     output = input + other  # noqa: F841
 
 
-def _inplace_arrangement(output):
-    return (output.tile((64,)),)
+def _control_dependent_inplace_arrangement(output):
+    return (output.tile((1,)),)
 
 
-def _inplace_application(output):
-    output = output + 1  # noqa: F841
+def _loop_carried_arrangement(input, output):
+    return (input.tile((1,)), output.tile((1,)))
+
+
+def _control_dependent_inplace_application(output):
+    if output[0] > 1:
+        output[0] = 0
+    elif output[0] > 0:
+        output[0] = 2
+    else:
+        output[0] = 1
+
+
+def _loop_carried_application(input, output):
+    value = input
+
+    for _ in range(2):
+        output = value  # noqa: F841
+        value = value + 1
 
 
 class _FakeTensor:
@@ -615,8 +632,8 @@ def test_triton_alias_selection_does_not_pollute_non_alias_tuning():
 def test_triton_read_write_binding_uses_alias_safe_selection():
     compilation = DEFAULT_COMPILER.compile(
         CompileRequest(
-            arrangement=_inplace_arrangement,
-            application=_inplace_application,
+            arrangement=_control_dependent_inplace_arrangement,
+            application=_control_dependent_inplace_application,
             tensors=(Tensor(1),),
             backend="triton",
             num_warps=(4, 8),
@@ -629,6 +646,7 @@ def test_triton_read_write_binding_uses_alias_safe_selection():
     def candidate(name):
         def increment(value, *_metadata):
             calls.append(name)
+
             return value.add_(1)
 
         return runtime._runtime_wrapper(increment, abi)
@@ -649,6 +667,24 @@ def test_triton_read_write_binding_uses_alias_safe_selection():
     assert torch.equal(output, torch.ones(4))
     assert calls == ["first"]
     assert tuner.calls == 0
+
+
+def test_triton_loop_carried_binding_access_preserves_input_dependency():
+    compilation = DEFAULT_COMPILER.compile(
+        CompileRequest(
+            arrangement=_loop_carried_arrangement,
+            application=_loop_carried_application,
+            tensors=(Tensor(1), Tensor(1)),
+            backend="triton",
+        )
+    )
+    access = {
+        binding.source: binding.access
+        for binding in compilation.launch_abi.kernel_args
+        if binding.kind == "tensor"
+    }
+
+    assert access == {"input": "read", "output": "write"}
 
 
 def test_triton_alias_selection_uses_jagged_binding_access():

--- a/tests/test_triton_runtime_auto_tuning.py
+++ b/tests/test_triton_runtime_auto_tuning.py
@@ -321,6 +321,35 @@ def test_verified_runtime_launch_preserves_argument_errors():
         launch(value, 2, unknown=True)
 
 
+def test_verified_runtime_fast_key_defers_invalid_tensor_to_validation():
+    abi = LaunchABI(
+        public_args=("first", "second", "scale"),
+        kernel_args=(
+            LaunchBinding(name="first", kind="tensor", source="first"),
+            LaunchBinding(name="second", kind="tensor", source="second"),
+            LaunchBinding(name="scale", kind="scalar", source="scale"),
+        ),
+    )
+    specs = tuple(
+        SimpleNamespace(
+            name=name,
+            ndim=1,
+            dtype=None,
+            attrs={"source_ndim": 1},
+        )
+        for name in ("first", "second")
+    )
+    wrapped = runtime._runtime_wrapper(lambda *_values: None, abi, specs=specs)
+    launch = runtime._verified_runtime_launch(wrapped)
+    first = _FakeTensor((4,))
+    second = _FakeTensor((4,))
+
+    launch(first, second, scale=1)
+
+    with pytest.raises(TypeError, match="`first` must be a tensor"):
+        launch(None, second, scale=1)
+
+
 def test_verified_runtime_four_buffer_call_has_no_cached_output_field():
     names = ("first", "second", "third", "output")
     abi = LaunchABI(
@@ -572,6 +601,46 @@ def test_triton_alias_selection_does_not_pollute_non_alias_tuning():
     assert [name for name, _ in calls] == ["first", "second", "second"]
     assert tuner._best_func["shared-key"] is candidates[1]
     assert handle._selected_tuning_candidate == {"id": "second"}
+
+
+def test_triton_alias_selection_uses_jagged_physical_bindings():
+    abi = LaunchABI(
+        public_args=("value", "output"),
+        kernel_args=(
+            LaunchBinding(name="value_values", kind="jagged_values", source="value"),
+            LaunchBinding(name="value_offsets", kind="jagged_offsets", source="value"),
+            LaunchBinding(name="output_values", kind="jagged_values", source="output"),
+            LaunchBinding(
+                name="output_offsets", kind="jagged_offsets", source="output"
+            ),
+        ),
+        outputs=("output",),
+    )
+    calls = []
+
+    def candidate(name):
+        return runtime._runtime_wrapper(
+            lambda *values: calls.append((name, values)),
+            abi,
+        )
+
+    candidates = (candidate("first"), candidate("second"))
+    tuner = _FakeTuner(candidates, lambda args, kwargs: "shared-key")
+    handle = SimpleNamespace(_selected_tuning_candidate=None)
+    launch = triton_materializer._tuned_runtime_launch(
+        tuner,
+        dict(zip(candidates, ({"id": "first"}, {"id": "second"}))),
+        handle,
+        SimpleNamespace(launch_abi=abi, kernel=SimpleNamespace(tensors=())),
+    )
+    values = torch.arange(8.0)
+    value = torch.nested.nested_tensor_from_jagged(values, torch.tensor((0, 4, 8)))
+    output = torch.nested.nested_tensor_from_jagged(values, torch.tensor((0, 2, 8)))
+
+    assert launch(value, output=output) is output
+    assert tuner.calls == 0
+    assert [name for name, _ in calls] == ["first"]
+    assert handle._selected_tuning_candidate == {"id": "first"}
 
 
 def test_triton_alias_selection_skips_failed_candidate():


### PR DESCRIPTION
## 背景

当前 SSA 编译链路对 reduction 的调度主要依赖启发式判断，缺少对归约域、并行域和结果使用关系的结构化分析。这带来两个问题：

1. Triton 可能使用 block mask 访问 scalar pointer，导致生成代码无法编译。
2. Softmax、LayerNorm 等包含归约与广播的数据流无法稳定生成高效的 row-vector kernel，性能明显低于旧版生成路径。

本 PR 从 SSA 类型、归约轴和 use-def 链中提取通用的 Reduction Domain，并据此完成调度。

## 主要修改

### 通用 Reduction Domain

新增不可变的 `ReductionDomain`，用于描述：

- reduction operand、result 和 `sum/max/min` 类型；
- 规范化后的 reduction axis；
- 输入、结果及 parallel domain shape；
- reduction extent；
- 同域 reduction 及其广播 consumer；
- row-vector 调度的合法性和拒绝原因。

分析同时覆盖：

- 正轴与负轴归一化；
- 多个同域 reduction；
- reduction 到算术、数学、条件、广播和 store 的数据流；
- `scf.if`、`scf.for`、`scf.yield` 和 loop-carried value；
- `mem.store` 与 `mem.atomic_add` 等 effect sink；
- 不同输出域、未知布局和不兼容 consumer 的 fail-closed 处理。

### Triton Row-Vector 调度

当 Reduction Domain 满足约束时，Triton 使用 row-vector 调度：

- 一个 Triton program 对应一个 parallel domain 实例；
- `tl.arange()` 覆盖 reduction axis；
- block pointer、value 和 predicate 保持相同向量域；
- 使用 `tl.sum`、`tl.max` 或 `tl.min` 完成归约；
- reduced output 使用 scalar store；
- 广播后的完整 shape output 使用 vector store；
- 支持任意单轴归约，包括 axis 0、末轴和 rank >= 3 的中间轴。

不满足条件时进入明确的 scalar fallback，无法保证语义时直接报错，不生成可疑代码。

### 调优接入

复用现有 `LaunchPlan` 和 AutoTuner，不引入第二套调优系统：

- 默认 `num_warps` 候选为 `4、8、1`；
- `num_stages=1`；
- 用户显式配置仍具有最高优先级；
- `max_num_configs=1` 使用安全的 4-warps 配置；
- winner 继续由现有运行时 benchmark 和缓存机制管理。

### 后端隔离

Row-vector value semantics 仅由 Triton 后端消费。CUDA 和 TileLang 保持原有 lowering 行为，后续 PR 再做更新。


## 正确性覆盖

新增测试集中覆盖以下高价值场景：

- Reduction Domain 的 axis、shape 和同域多归约分析；
- `sum/max/min` 生成；
- Softmax 和 LayerNorm 形式的通用 SSA 数据流；
- axis 0、末轴及 rank-3 中间轴归约；
- 非二次幂 reduction extent；
- 动态 shape、stride 和非连续输入；
- 不兼容广播及不同输出域的 fail-closed；
- tuning candidate 传播和显式配置优先级。

没有为每个内部 helper 增加独立测试，测试主要保持在 IR 契约、生成源码和公共执行路径三个层次。

## 测试结果

三个后端分别执行完整并行测试：

| 默认后端 | 结果 |
|---|---:|
| Triton | 385 passed, 2 skipped |
| CUDA | 385 passed, 2 skipped |
| TileLang | 385 passed, 2 skipped |

两个 skip 均为已有的多 GPU 测试，当前测试服务器只有一张 GPU：

- AOT multi-device test
- Triton multi-context reload test


## 性能结果

测试平台为 NVIDIA L20。基准为历史 master：

`c9ebd4950a185beed8d4c1db9ff4a1fd133934ae`

覆盖：

- Softmax：`4096 × {128, 256, 512, 1024, 2048, 4096}`
- LayerNorm：`4096 × {128, 256, 512, 1024, 2048, 4096}`
- Held-out width：`127、781、1127、4097`

共 12 个主性能点和 8 个 held-out 点，全部数值正确。

下表中的比值为：

`本 PR 延迟 / 历史 master 延迟`

因此小于 1 表示本 PR 更快。

| 指标 | 结果 |
|---|---:|
| 12 个主性能点延迟比几何平均 | 0.9659× |
| 相对历史 master 的整体提升 | 约 3.4% |
| 最差单点延迟比 | 1.0029× |
| 最差单点回归 | 约 0.29% |


所有主测试点均不超过历史 master 10%，整体性能优于历史 master。

## 改动范围


本 PR 只完成通用 Reduction Domain 和 Triton row-vector 物化。CUDA、TileLang 的并行归约物化与后端专属性能优化将通过后续独立 PR 完成。