### PR TITLE
Add generic reduction domains and Triton row-vector scheduling

### DIFF
--- a/src/ninetoothed/backends/__init__.py
+++ b/src/ninetoothed/backends/__init__.py
@@ -75,6 +75,7 @@ def _prepare_kernel_for_backend(kernel: Kernel, target: Target) -> Kernel:
             backend=target,
             compiler_options=kernel.compiler_options,
             kernel_metadata=kernel.metadata,
+            tensors=kernel.tensors,
             pass_pipeline=kernel.compiler_options.get("ssa_pass_pipeline"),
             pass_options=kernel.compiler_options.get("ssa_pass_options"),
         )

--- a/src/ninetoothed/backends/emitters/base.py
+++ b/src/ninetoothed/backends/emitters/base.py
@@ -45,6 +45,7 @@ class EmitterTarget(ABC):
     vector_value_semantics: bool = False
     tir_value_semantics: bool = False
     native_block_matmul: bool = False
+    max_vector_numel: int | None = None
 
     def symbol(self, name: str) -> str:
         return f"v{name[1:]}" if name.startswith("%") else name

--- a/src/ninetoothed/backends/emitters/context.py
+++ b/src/ninetoothed/backends/emitters/context.py
@@ -65,6 +65,7 @@ class EmitContext:
     native_block_program: bool = False
     layout_contiguous: bool = False
     vector_program: bool = False
+    reduction_lane: str | None = None
 
     def child(
         self,
@@ -104,6 +105,7 @@ class EmitContext:
             "native_block_program": self.native_block_program,
             "layout_contiguous": self.layout_contiguous,
             "vector_program": self.vector_program,
+            "reduction_lane": self.reduction_lane,
         }
         data.update(kwargs)
 

--- a/src/ninetoothed/backends/emitters/context.py
+++ b/src/ninetoothed/backends/emitters/context.py
@@ -66,6 +66,7 @@ class EmitContext:
     layout_contiguous: bool = False
     vector_program: bool = False
     reduction_lane: str | None = None
+    scheduled_reductions: frozenset[str] = frozenset()
 
     def child(
         self,
@@ -106,6 +107,7 @@ class EmitContext:
             "layout_contiguous": self.layout_contiguous,
             "vector_program": self.vector_program,
             "reduction_lane": self.reduction_lane,
+            "scheduled_reductions": self.scheduled_reductions,
         }
         data.update(kwargs)
 

--- a/src/ninetoothed/backends/emitters/ssa.py
+++ b/src/ninetoothed/backends/emitters/ssa.py
@@ -170,6 +170,7 @@ def emit(kernel: Kernel, target: EmitterTarget) -> Artifact:
             "scalar": render_context.scalar_program,
             "vector": render_context.vector_program,
         },
+        "vector_numel_limit": target.max_vector_numel,
     }
 
     return Artifact(
@@ -187,7 +188,10 @@ def emit(kernel: Kernel, target: EmitterTarget) -> Artifact:
     )
 
 
-def _row_reduction_schedule(program: ssa.Program) -> Mapping[str, Any] | None:
+def _row_reduction_schedule(
+    program: ssa.Program,
+    target: _Target,
+) -> Mapping[str, Any] | None:
     schedule = program.metadata.get("schedule", {})
 
     if not isinstance(schedule, Mapping):
@@ -207,7 +211,25 @@ def _row_reduction_schedule(program: ssa.Program) -> Mapping[str, Any] | None:
 
     if reduction.get("mode") != "row-vector":
         return None
+
+    extent = _static_integer(reduction.get("extent"))
+    limit = target.max_vector_numel
+
+    if limit is not None and extent is not None and extent > limit:
+        block = 1 << (extent - 1).bit_length()
+        raise ValueError(
+            f"{target.backend.value} row-vector reduction extent {extent} "
+            f"requires BLOCK={block}, exceeding the backend tensor numel "
+            f"limit {limit}; hierarchical reduction is not implemented."
+        )
     return reduction
+
+
+def _static_integer(value) -> int | None:
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return None
 
 
 def _render_source(
@@ -218,7 +240,7 @@ def _render_source(
 ) -> tuple[str, ModuleRenderContext]:
     program = kernel.ssa
     assert program is not None
-    reduction_schedule = _row_reduction_schedule(program)
+    reduction_schedule = _row_reduction_schedule(program, target)
     block = program.blocks[0] if program.blocks else ssa.Block()
     tensor_infos = {tensor.name: _tensor_info(tensor) for tensor in kernel.tensors}
     auxiliary_bindings = _auxiliary_pointer_bindings(kernel.tensors)
@@ -376,7 +398,9 @@ def _render_source(
 
         coordinate_exprs = tuple(coordinate_exprs)
         total = _target_index_expr(target, str(reduction_schedule["extent"]))
-        outer_program_shape = outer_axes if split_outer_inner else ()
+        outer_program_shape = tuple(
+            str(axis) for axis in reduction_schedule.get("program_shape", ())
+        )
         grid_total = _target_index_expr(
             target,
             _product((*outer_program_shape, *parallel_shape)),

--- a/src/ninetoothed/backends/emitters/ssa.py
+++ b/src/ninetoothed/backends/emitters/ssa.py
@@ -783,11 +783,15 @@ def _nested_local_suffix(ctx: _EmitContext, label: str) -> str:
 
 
 def _coords_use_reduction_lane(coords: tuple[str, ...], ctx: _EmitContext) -> bool:
-    return bool(
+    return (
         ctx.vector_program
         and ctx.reduction_lane is not None
-        and ctx.reduction_lane in coords
+        and any(ctx.reduction_lane in _expression_symbols(coord) for coord in coords)
     )
+
+
+def _expression_symbols(expression: str) -> set[str]:
+    return set(re.findall(r"\b[A-Za-z_][A-Za-z0-9_]*\b", expression))
 
 
 def _mask_for_coords(coords: tuple[str, ...], ctx: _EmitContext) -> str | None:
@@ -1773,9 +1777,16 @@ def _load_tensor_at(
         ),
     )
     source_index = _materialize_index_expr(source_index, ctx)
+    base_mask = _load_base_mask(source_index, ctx)
+
+    if ctx.vector_program:
+        base_mask = _mask_for_coords(coords, ctx)
+    elif extract_indices:
+        base_mask = None
+
     mask = _combined_mask(
         ctx.target,
-        _load_base_mask(source_index, ctx),
+        base_mask,
         info,
         view_index,
         ctx=ctx,
@@ -2622,7 +2633,7 @@ def _load_base_mask(source_index: str, ctx: _EmitContext) -> str | None:
 
 
 def _index_expr_is_vector(source_index: str, ctx: _EmitContext) -> bool:
-    symbols = set(re.findall(r"\b[A-Za-z_][A-Za-z0-9_]*\b", source_index))
+    symbols = _expression_symbols(source_index)
 
     return bool(
         ctx.target.index_name in symbols
@@ -2663,7 +2674,6 @@ def _source_bounds_mask(
     base_mask: str | None,
 ) -> str | None:
     checks = []
-    base_mask = _mask_for_coords(indices, ctx)
 
     if base_mask:
         checks.append(base_mask)

--- a/src/ninetoothed/backends/emitters/ssa.py
+++ b/src/ninetoothed/backends/emitters/ssa.py
@@ -1339,6 +1339,9 @@ def _emit_element(name: str, coords: tuple[str, ...], ctx: _EmitContext) -> str:
     if ctx.bindings and name in ctx.bindings and not coords:
         return ctx.bindings[name]
 
+    if name in ctx.memo and coords == _current_coords(_value_axes(name, ctx), ctx):
+        return ctx.memo[name]
+
     if not name.startswith("%"):
         if name not in ctx.tensor_infos:
             return name

--- a/src/ninetoothed/backends/emitters/ssa.py
+++ b/src/ninetoothed/backends/emitters/ssa.py
@@ -187,6 +187,29 @@ def emit(kernel: Kernel, target: EmitterTarget) -> Artifact:
     )
 
 
+def _row_reduction_schedule(program: ssa.Program) -> Mapping[str, Any] | None:
+    schedule = program.metadata.get("schedule", {})
+
+    if not isinstance(schedule, Mapping):
+        return None
+
+    reduction = schedule.get("reduction", {})
+
+    if not isinstance(reduction, Mapping):
+        return None
+
+    if reduction.get("mode") == "scalar-fallback" and not reduction.get(
+        "emittable", True
+    ):
+        raise ValueError(
+            "Reduction outputs with different domains require separate kernels."
+        )
+
+    if reduction.get("mode") != "row-vector":
+        return None
+    return reduction
+
+
 def _render_source(
     kernel: Kernel,
     target: _Target,
@@ -195,6 +218,7 @@ def _render_source(
 ) -> tuple[str, ModuleRenderContext]:
     program = kernel.ssa
     assert program is not None
+    reduction_schedule = _row_reduction_schedule(program)
     block = program.blocks[0] if program.blocks else ssa.Block()
     tensor_infos = {tensor.name: _tensor_info(tensor) for tensor in kernel.tensors}
     auxiliary_bindings = _auxiliary_pointer_bindings(kernel.tensors)
@@ -271,6 +295,11 @@ def _render_source(
     else:
         value_axes = store_value_axes
 
+    if target.vector_value_semantics and reduction_schedule is not None:
+        value_axes = tuple(
+            str(axis) for axis in reduction_schedule.get("value_shape", ())
+        )
+
     output_attrs = output_info.attrs or {} if output_info is not None else {}
     split_outer_inner = bool(
         value_axes
@@ -291,10 +320,8 @@ def _render_source(
     )
     vector_reduction_program = bool(
         target.vector_value_semantics
-        and split_outer_inner
+        and reduction_schedule is not None
         and not vector_block_program
-        and sum(str(axis).strip("() ") != "1" for axis in value_axes) <= 1
-        and any(op.opcode.startswith("reduce.") for op in walked_ops)
     )
     native_block_program = bool(
         target.native_block_matmul
@@ -318,10 +345,52 @@ def _render_source(
         inner_index_expr = "0"
     elif vector_reduction_program:
         axes = value_axes
-        total = _target_index_expr(target, _product(value_axes))
-        grid_total = _target_index_expr(target, _product(outer_axes))
-        outer_index_expr = target.program_id(0)
-        inner_index_expr = "offsets"
+        reduction_axis = int(reduction_schedule["axis"])
+        parallel_shape = tuple(
+            str(axis) for axis in reduction_schedule.get("parallel_shape", ())
+        )
+        parallel_total = _product(parallel_shape)
+        program_index = target.program_id(0)
+        parallel_index = (
+            "0"
+            if _is_one_expr(parallel_total)
+            else _target_index_expr(target, f"({program_index}) % ({parallel_total})")
+        )
+        coordinate_exprs = []
+        parallel_dim = 0
+
+        for dim in range(len(value_axes)):
+            if dim == reduction_axis:
+                coordinate_exprs.append("offsets")
+                continue
+
+            coordinate_exprs.append(
+                _axis_offset_expr(
+                    parallel_shape,
+                    parallel_dim,
+                    parallel_index,
+                    target,
+                )
+            )
+            parallel_dim += 1
+
+        coordinate_exprs = tuple(coordinate_exprs)
+        total = _target_index_expr(target, str(reduction_schedule["extent"]))
+        outer_program_shape = outer_axes if split_outer_inner else ()
+        grid_total = _target_index_expr(
+            target,
+            _product((*outer_program_shape, *parallel_shape)),
+        )
+        outer_index_expr = (
+            "0"
+            if not outer_program_shape
+            else program_index
+            if _is_one_expr(parallel_total)
+            else _target_index_expr(
+                target, f"floor(({program_index})/({parallel_total}))"
+            )
+        )
+        inner_index_expr = _linearized_index(coordinate_exprs, value_axes)
     elif native_block_program:
         axes = value_axes
         total = _target_index_expr(target, _product(value_axes))
@@ -367,6 +436,8 @@ def _render_source(
         block_program=vector_block_program,
         native_block_program=native_block_program,
         vector_program=vector_reduction_program,
+        coordinate_exprs=(coordinate_exprs if vector_reduction_program else ()),
+        reduction_schedule=(reduction_schedule if vector_reduction_program else None),
     )
     body = _with_contiguous_1d_fast_path(
         kernel,
@@ -443,6 +514,9 @@ def _with_contiguous_1d_fast_path(
     vector_program: bool,
 ) -> str:
     logical_infos = tuple(tensor_infos[tensor.name] for tensor in kernel.tensors)
+
+    if vector_program:
+        return generic_body
 
     if not logical_infos or any(
         info.ndim != 1
@@ -560,10 +634,11 @@ def _render_body(
     native_block_program: bool = False,
     layout_contiguous: bool = False,
     vector_program: bool = False,
+    coordinate_exprs: tuple[str, ...] = (),
+    reduction_schedule: Mapping[str, Any] | None = None,
 ) -> str:
     output = outputs[0] if outputs else "out"
     lines: list[str] = []
-    coordinate_exprs: tuple[str, ...] = ()
     enable_index_cse = (
         not target.vector_value_semantics and outer_index_expr != inner_index_expr
     )
@@ -641,6 +716,7 @@ def _render_body(
         native_block_program=native_block_program,
         layout_contiguous=layout_contiguous,
         vector_program=vector_program,
+        reduction_lane="offsets" if reduction_schedule is not None else None,
     )
 
     for op in operations:
@@ -680,6 +756,24 @@ def _nested_local_suffix(ctx: _EmitContext, label: str) -> str:
     suffix = f"_{clean}_body"
 
     return f"{ctx.local_suffix}{suffix}" if ctx.local_suffix else suffix
+
+
+def _coords_use_reduction_lane(coords: tuple[str, ...], ctx: _EmitContext) -> bool:
+    return bool(
+        ctx.vector_program
+        and ctx.reduction_lane is not None
+        and ctx.reduction_lane in coords
+    )
+
+
+def _mask_for_coords(coords: tuple[str, ...], ctx: _EmitContext) -> str | None:
+    if not ctx.vector_program:
+        return ctx.mask_expr
+    return ctx.mask_expr if _coords_use_reduction_lane(coords, ctx) else None
+
+
+def _mask_for_axes(axes: tuple[str, ...], ctx: _EmitContext) -> str | None:
+    return _mask_for_coords(_current_coords(axes, ctx), ctx)
 
 
 def _emit_operation(op: ssa.Operation, ctx: _EmitContext) -> None:
@@ -753,7 +847,7 @@ def _emit_operation(op: ssa.Operation, ctx: _EmitContext) -> None:
         else:
             mask = _store_mask(
                 ctx.target,
-                ctx.mask_expr,
+                _mask_for_axes(_value_axes(tensor, ctx), ctx),
                 info,
                 view_index,
                 ctx=ctx,
@@ -804,6 +898,27 @@ def _emit_value(name: str, ctx: _EmitContext) -> str:
     local = _local_symbol(name, ctx)
 
     if op.opcode.startswith("reduce."):
+        if ctx.vector_program:
+            operator = op.opcode[len("reduce.") :]
+            operand_axes = _value_axes(op.operands[0], ctx)
+            operand = _emit_element(
+                op.operands[0], _current_coords(operand_axes, ctx), ctx
+            )
+            result_type = ssa.Type(
+                kind="scalar",
+                dtype=op.results[0].type.dtype if op.results else "float32",
+            )
+            identity = _reduction_identity(operator, result_type, ctx.target)
+
+            if ctx.mask_expr is not None:
+                operand = ctx.target.where(ctx.mask_expr, operand, identity)
+
+            expr = ctx.target.vector_reduce(operator, operand, 0)
+            ctx.lines.append(ctx.target.local_decl(result_type, local, expr))
+            ctx.memo[name] = local
+
+            return local
+
         if ctx.block_program:
             operator = op.opcode[len("reduce.") :]
             operand = _emit_value(op.operands[0], ctx)
@@ -1306,7 +1421,7 @@ def _emit_element(name: str, coords: tuple[str, ...], ctx: _EmitContext) -> str:
         )
 
     if op.opcode.startswith("reduce."):
-        if ctx.block_program:
+        if ctx.block_program or ctx.vector_program:
             return _emit_value(name, ctx)
         return _emit_reduce_element(op, coords, ctx)
 
@@ -1401,11 +1516,18 @@ def _emit_pointer_load(pointer: str, coords: tuple[str, ...], ctx: _EmitContext)
     address = _pointer_address(pointer, coords, ctx)
 
     if address is None:
+        if ctx.vector_program:
+            raise ValueError(
+                "Row-vector reductions require a decomposable pointer address."
+            )
+
         return ctx.target.call("load", (_emit_element(pointer, coords, ctx),))
 
     base, offset = address
 
-    return ctx.target.load(base, offset)
+    mask = _mask_for_coords(coords, ctx) if ctx.vector_program else None
+
+    return ctx.target.load(base, offset, mask=mask)
 
 
 def _pointer_address(
@@ -1446,21 +1568,19 @@ def _pointer_address(
 
 
 def _reduction_identity(operator: str, type_: ssa.Type, target: _Target) -> str:
-    if operator == "sum":
-        return "0.0"
-
     dtype = _normalize_dtype(type_.dtype or "float32")
+
+    if operator == "sum":
+        return target.literal(0.0 if "float" in dtype else 0)
 
     if dtype == "bool":
         return target.literal(operator == "min")
 
+    if dtype in {"float8_e5m2", "float16", "bfloat16", "float32", "float64"}:
+        return target.literal(float("-inf") if operator == "max" else float("inf"))
+
     limits: Mapping[str, tuple[int | float, int | float]] = {
         "float8_e4m3fn": (-448.0, 448.0),
-        "float8_e5m2": (-57344.0, 57344.0),
-        "float16": (-65504.0, 65504.0),
-        "bfloat16": (-3.3895313892515355e38, 3.3895313892515355e38),
-        "float32": (-3.4028234663852886e38, 3.4028234663852886e38),
-        "float64": (-1.7976931348623157e308, 1.7976931348623157e308),
         "int8": (-128, 127),
         "uint8": (0, 255),
         "int16": (-32768, 32767),
@@ -1779,6 +1899,11 @@ def _current_coords(axes: tuple[str, ...], ctx: _EmitContext) -> tuple[str, ...]
             _axis_offset_expr(output_axes, dim, ctx.inner_index_expr, ctx.target)
             for dim in range(len(output_axes))
         )
+        vector_reduction_axis = (
+            output_coords.index(ctx.reduction_lane)
+            if ctx.vector_program and ctx.reduction_lane in output_coords
+            else None
+        )
         coords: tuple[str, ...] | None = None
 
         if len(axes) == len(output_axes):
@@ -1786,6 +1911,18 @@ def _current_coords(axes: tuple[str, ...], ctx: _EmitContext) -> tuple[str, ...]
                 "0" if axis == "1" else output_coords[index]
                 for index, axis in enumerate(axes)
             )
+        elif vector_reduction_axis is not None and len(axes) == len(output_axes) - 1:
+            parallel_dims = tuple(
+                index
+                for index in range(len(output_axes))
+                if index != vector_reduction_axis
+            )
+
+            if axes == tuple(output_axes[index] for index in parallel_dims):
+                coords = tuple(
+                    "0" if axis == "1" else output_coords[parallel_dim]
+                    for axis, parallel_dim in zip(axes, parallel_dims)
+                )
         elif len(axes) < len(output_axes):
             if _axes_compatible_prefix(axes, output_axes):
                 coords = tuple(
@@ -2502,6 +2639,7 @@ def _source_bounds_mask(
     base_mask: str | None,
 ) -> str | None:
     checks = []
+    base_mask = _mask_for_coords(indices, ctx)
 
     if base_mask:
         checks.append(base_mask)
@@ -3004,6 +3142,12 @@ def _store_index(op: ssa.Operation, ctx: _EmitContext) -> str:
         rendered = tuple(_emit_index_value(str(index), ctx) for index in indices)
 
         return _linearized_index(rendered, _value_axes(op.operands[1], ctx))
+
+    if ctx.vector_program:
+        axes = _value_axes(op.operands[1], ctx)
+        coords = _current_coords(axes, ctx)
+
+        return _linearized_index(coords, axes) if coords else "0"
 
     if ctx.block_program and ctx.coordinate_exprs:
         return _linearized_index(ctx.coordinate_exprs, ctx.output_axes)

--- a/src/ninetoothed/backends/emitters/ssa.py
+++ b/src/ninetoothed/backends/emitters/ssa.py
@@ -741,6 +741,9 @@ def _render_body(
         layout_contiguous=layout_contiguous,
         vector_program=vector_program,
         reduction_lane="offsets" if reduction_schedule is not None else None,
+        scheduled_reductions=frozenset(
+            str(result) for result in (reduction_schedule or {}).get("reductions", ())
+        ),
     )
 
     for op in operations:
@@ -871,7 +874,11 @@ def _emit_operation(op: ssa.Operation, ctx: _EmitContext) -> None:
         store_index = _materialize_index_expr(store_index, ctx)
 
         if op.attrs.get("source"):
-            mask = _source_bounds_mask(info, rendered, base_mask=ctx.mask_expr)
+            mask = _source_bounds_mask(
+                info,
+                rendered,
+                base_mask=_mask_for_coords(rendered, ctx),
+            )
         else:
             mask = _store_mask(
                 ctx.target,
@@ -926,7 +933,15 @@ def _emit_value(name: str, ctx: _EmitContext) -> str:
     local = _local_symbol(name, ctx)
 
     if op.opcode.startswith("reduce."):
-        if ctx.vector_program:
+        operand_type = ctx.value_types.get(op.operands[0]) if op.operands else None
+
+        if operand_type is not None and operand_type.kind == "scalar":
+            operand = _emit_value(op.operands[0], ctx)
+            ctx.memo[name] = operand
+
+            return operand
+
+        if ctx.vector_program and name in ctx.scheduled_reductions:
             operator = op.opcode[len("reduce.") :]
             operand_axes = _value_axes(op.operands[0], ctx)
             operand = _emit_element(
@@ -2122,7 +2137,10 @@ def _emit_reduce(local: str, op: ssa.Operation, ctx: _EmitContext) -> str:
     operand_axes = _value_axes(op.operands[0], ctx) if op.operands else ctx.output_axes
     normalized_axis = None
 
-    if ctx.target.vector_value_semantics and (ctx.vector_program or ctx.block_program):
+    if ctx.target.vector_value_semantics and (
+        (ctx.vector_program and op.results[0].name in ctx.scheduled_reductions)
+        or ctx.block_program
+    ):
         operand = _emit_value(op.operands[0], ctx)
         expr = ctx.target.vector_reduce(operator, operand, 0)
         ctx.lines.append(ctx.target.local_decl(op.results[0].type, local, expr))

--- a/src/ninetoothed/backends/emitters/ssa.py
+++ b/src/ninetoothed/backends/emitters/ssa.py
@@ -218,7 +218,7 @@ def _row_reduction_schedule(
     if limit is not None and extent is not None and extent > limit:
         block = 1 << (extent - 1).bit_length()
         raise ValueError(
-            f"{target.backend.value} row-vector reduction extent {extent} "
+            f"Row-vector reduction for {target.backend.value} extent {extent} "
             f"requires BLOCK={block}, exceeding the backend tensor numel "
             f"limit {limit}; hierarchical reduction is not implemented."
         )

--- a/src/ninetoothed/backends/emitters/triton.py
+++ b/src/ninetoothed/backends/emitters/triton.py
@@ -18,6 +18,7 @@ class TritonTarget(EmitterTarget):
     suffix: str = "triton.py"
     source_route: str = "ssa-unified-triton-emitter"
     vector_value_semantics: bool = True
+    max_vector_numel: int | None = 1 << 20
 
     def program_id(self, axis: int = 0) -> str:
         return f"tl.program_id({axis})"

--- a/src/ninetoothed/backends/materializers/triton.py
+++ b/src/ninetoothed/backends/materializers/triton.py
@@ -790,7 +790,7 @@ def _runtime_vector_validator(compilation):
         if limit is not None and extent > limit:
             block = 1 << (extent - 1).bit_length()
             raise ValueError(
-                f"triton row-vector reduction extent {extent} requires "
+                f"Triton row-vector reduction extent {extent} requires "
                 f"BLOCK={block}, exceeding the backend tensor numel limit "
                 f"{limit}; hierarchical reduction is not implemented."
             )
@@ -1209,7 +1209,7 @@ def _compile_block(compilation) -> int:
 
         if limit is not None and block > limit:
             raise ValueError(
-                f"triton row-vector reduction extent {total} requires "
+                f"Triton row-vector reduction extent {total} requires "
                 f"BLOCK={block}, exceeding the backend tensor numel limit "
                 f"{limit}; hierarchical reduction is not implemented."
             )
@@ -1231,6 +1231,7 @@ def _constant_reduction_extent(compilation, reduction) -> int:
         import sympy
 
         value = sympy.sympify(expression)
+
         if value.free_symbols:
             raise ValueError
         return int(value)

--- a/src/ninetoothed/backends/materializers/triton.py
+++ b/src/ninetoothed/backends/materializers/triton.py
@@ -119,8 +119,9 @@ def _materialize(compilation):
     launch = getattr(module, artifact.entrypoint)
     kernel = getattr(module, f"{artifact.kernel_name}_kernel", None)
     candidates = tuple(compilation.launch_plan.tuning_candidates)
+    validate_bindings = _runtime_vector_validator(compilation)
     candidate_launches = tuple(
-        _candidate_launch(compilation, launch, kernel, candidate)
+        _candidate_launch(compilation, launch, kernel, candidate, validate_bindings)
         for candidate in candidates
     )
     tuner = None
@@ -137,7 +138,7 @@ def _materialize(compilation):
             candidate_launches,
             tuple((cache_key, candidate["id"]) for candidate in candidates),
             cache_namespace=f"jit_{cache_key}",
-            validator=_runtime_validator(compilation),
+            validator=_runtime_validator(compilation, validate_bindings),
         )
         wrapped = tuner
     elif candidate_launches:
@@ -149,6 +150,7 @@ def _materialize(compilation):
                 compilation.launch_abi,
                 specs=compilation.kernel.tensors,
                 prepare_invocation=_triton_prepare_invocation(launch, kernel),
+                validate_bindings=validate_bindings,
             )
         )
 
@@ -168,7 +170,7 @@ def _materialize(compilation):
     return handle
 
 
-def _candidate_launch(compilation, launch, kernel, candidate):
+def _candidate_launch(compilation, launch, kernel, candidate, validate_bindings):
     from ninetoothed.compiler.runtime import _runtime_wrapper
 
     bindings = {binding.name: binding for binding in compilation.launch_abi.kernel_args}
@@ -188,6 +190,7 @@ def _candidate_launch(compilation, launch, kernel, candidate):
         specs=compilation.kernel.tensors,
         binding_overrides=meta_values,
         prepare_invocation=_triton_prepare_invocation(function, kernel),
+        validate_bindings=validate_bindings,
     )
 
 
@@ -699,16 +702,116 @@ def _triton_specialization_key(compilation, args, kwargs):
     return f"{base}, specialization={tuple(scalar_values)!r}"
 
 
-def _runtime_validator(compilation):
+def _runtime_validator(compilation, validate_bindings):
     from ninetoothed.compiler.runtime import _public_values
 
     def validate(args, kwargs):
-        _public_values(
+        public = _public_values(
             compilation.launch_abi,
             args,
             kwargs,
             specs=compilation.kernel.tensors,
         )
+
+        if validate_bindings is not None:
+            validate_bindings(public)
+
+    return validate
+
+
+def _runtime_vector_validator(compilation):
+    metadata = getattr(compilation.artifact, "metadata", {})
+    limit = metadata.get("vector_numel_limit")
+    schedule = metadata.get("ssa_schedule", {})
+    reduction = schedule.get("reduction", {})
+
+    if reduction.get("mode") != "row-vector":
+        return None
+
+    import sympy
+
+    extent_expression = sympy.sympify(str(reduction["extent"]))
+    program_constraints = tuple(
+        (
+            tuple(sympy.sympify(str(value)) for value in actual),
+            tuple(sympy.sympify(str(value)) for value in expected),
+        )
+        for actual, expected in reduction.get("program_constraints", ())
+    )
+    expressions = (
+        extent_expression,
+        *(
+            expression
+            for constraint in program_constraints
+            for shape in constraint
+            for expression in shape
+        ),
+    )
+    bindings = {binding.name: binding for binding in compilation.launch_abi.kernel_args}
+
+    try:
+        symbols = tuple(
+            (symbol, bindings[str(symbol)])
+            for symbol in sorted(
+                set().union(*(expression.free_symbols for expression in expressions)),
+                key=str,
+            )
+        )
+    except KeyError as exc:
+        raise ValueError(
+            f"Triton reduction extent references unknown symbol `{exc.args[0]}`."
+        ) from exc
+
+    from ninetoothed.compiler.runtime import _binding_value
+
+    last_values = None
+
+    def validate(public):
+        nonlocal last_values
+        values = tuple(_binding_value(binding, public) for _symbol, binding in symbols)
+
+        if values == last_values:
+            return
+
+        substitutions = {
+            symbol: value for (symbol, _binding), value in zip(symbols, values)
+        }
+
+        def resolve(expression):
+            resolved = expression.subs(substitutions)
+
+            if resolved.free_symbols:
+                names = ", ".join(sorted(map(str, resolved.free_symbols)))
+                raise ValueError(f"Unresolved Triton row-vector symbols: {names}.")
+            return int(resolved)
+
+        extent = resolve(extent_expression)
+
+        if limit is not None and extent > limit:
+            block = 1 << (extent - 1).bit_length()
+            raise ValueError(
+                f"triton row-vector reduction extent {extent} requires "
+                f"BLOCK={block}, exceeding the backend tensor numel limit "
+                f"{limit}; hierarchical reduction is not implemented."
+            )
+
+        for actual, expected in program_constraints:
+            actual_total = 1
+            expected_total = 1
+
+            for expression in actual:
+                actual_total *= resolve(expression)
+
+            for expression in expected:
+                expected_total *= resolve(expression)
+
+            if actual_total != expected_total:
+                raise ValueError(
+                    "Triton row-vector reduction operand and output program "
+                    "domains do not match; separate kernels are required."
+                )
+
+        last_values = values
 
     return validate
 
@@ -1088,15 +1191,54 @@ def _triton_scalar_dtype(dtype) -> str:
 
 def _compile_block(compilation) -> int:
     mode = dict(compilation.artifact.metadata.get("program_mode", {}))
+    reduction = dict(
+        compilation.artifact.metadata.get("ssa_schedule", {}).get("reduction", {})
+    )
 
     if mode.get("block") or mode.get("scalar"):
         return 1
 
     if mode.get("vector"):
-        total = _constant_grid_total(compilation)
+        total = (
+            _constant_reduction_extent(compilation, reduction)
+            if reduction.get("mode") == "row-vector"
+            else _constant_grid_total(compilation)
+        )
+        block = 1 << max(0, (total - 1).bit_length())
+        limit = compilation.artifact.metadata.get("vector_numel_limit")
 
-        return 1 << max(0, (total - 1).bit_length())
+        if limit is not None and block > limit:
+            raise ValueError(
+                f"triton row-vector reduction extent {total} requires "
+                f"BLOCK={block}, exceeding the backend tensor numel limit "
+                f"{limit}; hierarchical reduction is not implemented."
+            )
+        return block
     return 256
+
+
+def _constant_reduction_extent(compilation, reduction) -> int:
+    expression = replace_symbols(
+        str(reduction["extent"]),
+        {
+            binding.name: str(binding.value)
+            for binding in compilation.launch_abi.kernel_args
+            if binding.kind in {"meta", "constexpr"} and binding.value is not None
+        },
+    )
+
+    try:
+        import sympy
+
+        value = sympy.sympify(expression)
+        if value.free_symbols:
+            raise ValueError
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "Triton AOT row-vector reductions require a statically "
+            "specialized reduction extent."
+        ) from exc
 
 
 def _constant_grid_total(compilation) -> int:

--- a/src/ninetoothed/backends/triton.py
+++ b/src/ninetoothed/backends/triton.py
@@ -111,6 +111,10 @@ class TritonOptimizeSchedule(OptimizeSchedule):
             }
 
         if granularity == "parallel-reduction":
+            reduction = schedule.get("reduction", {})
+
+            if reduction.get("mode") == "row-vector":
+                return {"schedule": {"num_warps": (4, 8, 1), "num_stages": 1}}
             return {"schedule": {"num_warps": 4}}
         return {"schedule": {"num_warps": 4}}
 

--- a/src/ninetoothed/compiler/passes.py
+++ b/src/ninetoothed/compiler/passes.py
@@ -44,6 +44,7 @@ class Context:
     backend: Target
     compiler_options: Mapping[str, Any]
     kernel_metadata: Mapping[str, Any]
+    tensors: tuple[Any, ...] = ()
     pass_options: Mapping[str, Mapping[str, Any]] = field(default_factory=dict)
     pipeline_spec: PipelineSpec | None = None
 
@@ -277,7 +278,7 @@ class AnalyzeEffects(Pass):
         reductions = sum(1 for opcode in opcodes if opcode.startswith("reduce."))
         loops = sum(1 for opcode in opcodes if opcode == "scf.for")
         dot_input_dtypes = _linalg_input_dtypes(program)
-        reduction_analysis = analyze_reductions(program)
+        reduction_analysis = analyze_reductions(program, context.tensors)
 
         return _with_metadata(
             program,
@@ -574,6 +575,7 @@ def lower_for_target(
     backend: Target | str | None,
     compiler_options: Mapping[str, Any] | None = None,
     kernel_metadata: Mapping[str, Any] | None = None,
+    tensors: tuple[Any, ...] = (),
     pass_pipeline: Pipeline
     | PipelineSpec
     | Sequence[str]
@@ -598,6 +600,7 @@ def lower_for_target(
             backend=backend_name,
             compiler_options=compiler_options,
             kernel_metadata=kernel_metadata,
+            tensors=tensors,
             pass_options=explicit_pass_options,
         )
 
@@ -641,6 +644,7 @@ def lower_for_target(
         backend=backend_name,
         compiler_options=compiler_options,
         kernel_metadata=kernel_metadata,
+        tensors=tensors,
         pass_options=merged_pass_options,
         pipeline_spec=spec,
     )

--- a/src/ninetoothed/compiler/passes.py
+++ b/src/ninetoothed/compiler/passes.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass, field
 from typing import Any, Mapping
 
 from ninetoothed.backends.core import Target, normalize_target
+from ninetoothed.compiler.reductions import analyze_reductions
 from ninetoothed.ir import ssa
 
 HARDWARE_INDEPENDENT = "hardware_independent"
@@ -276,6 +277,7 @@ class AnalyzeEffects(Pass):
         reductions = sum(1 for opcode in opcodes if opcode.startswith("reduce."))
         loops = sum(1 for opcode in opcodes if opcode == "scf.for")
         dot_input_dtypes = _linalg_input_dtypes(program)
+        reduction_analysis = analyze_reductions(program)
 
         return _with_metadata(
             program,
@@ -291,6 +293,7 @@ class AnalyzeEffects(Pass):
                 "has_exp_reduction_dot_pattern": _has_exp_reduction_dot_pattern(
                     opcodes
                 ),
+                **reduction_analysis,
             },
         )
 
@@ -344,7 +347,18 @@ class SelectSchedule(Pass):
             "indexing": "flat-contiguous",
             "parallelism": "program-blocks",
         }
+        reduction = analysis.get("reduction_schedule")
+
+        if "reduction" in options:
+            raise ValueError(
+                "Reduction schedule options are compiler-owned and cannot be "
+                "overridden through `ssa.select_schedule`."
+            )
+
         schedule = _merge_nested(schedule, options)
+
+        if isinstance(reduction, Mapping):
+            schedule["reduction"] = dict(reduction)
 
         return _with_metadata(program, schedule=schedule)
 
@@ -398,6 +412,13 @@ class OptimizeSchedule(Pass):
             _pass_options(context, self.name, "ssa.optimize_schedule")
         )
         optimization_options.pop("candidate", None)
+
+        if "reduction" in dict(optimization_options.get("schedule", {})):
+            raise ValueError(
+                "Reduction schedule options are compiler-owned and cannot be "
+                "overridden by an optimization pass."
+            )
+
         optimization = _merge_nested(
             optimization,
             optimization_options,
@@ -406,6 +427,11 @@ class OptimizeSchedule(Pass):
             schedule,
             dict(optimization.get("schedule", {})),
         )
+        reduction = analysis.get("reduction_schedule")
+
+        if isinstance(reduction, Mapping):
+            optimized_schedule["reduction"] = dict(reduction)
+
         candidate_metadata = tuple(candidate.as_metadata() for candidate in candidates)
 
         return _replace_program(

--- a/src/ninetoothed/compiler/reductions.py
+++ b/src/ninetoothed/compiler/reductions.py
@@ -78,6 +78,13 @@ def analyze_reductions(program: ssa.Program, tensors=()) -> Mapping[str, Any]:
         if not operation.opcode.startswith("reduce."):
             continue
 
+        if operation.operands:
+            operand_type = value_types.get(operation.operands[0])
+
+            if operand_type is not None and operand_type.kind == "scalar":
+                _validate_scalar_fallback(operation)
+                continue
+
         domain, rejection = _domain(
             operation,
             scope,
@@ -99,6 +106,25 @@ def analyze_reductions(program: ssa.Program, tensors=()) -> Mapping[str, Any]:
         "reduction_rejections": tuple(rejections),
         "reduction_schedule": schedule,
     }
+
+
+def _validate_scalar_fallback(operation):
+    if len(operation.operands) != 1 or len(operation.results) != 1:
+        raise ValueError(
+            f"SSA reduction `{operation.opcode}` requires one operand and one result."
+        )
+
+    axis = operation.attrs.get("axis")
+
+    if isinstance(axis, bool) or axis not in {None, -1, 0}:
+        raise ValueError("Scalar fallback reduction axis must be omitted, -1, or 0.")
+
+    result = operation.results[0]
+
+    if result.type.kind != "scalar" or result.type.shape:
+        raise ValueError(
+            f"Scalar fallback reduction result `{result.name}` must be scalar."
+        )
 
 
 def _domain(

--- a/src/ninetoothed/compiler/reductions.py
+++ b/src/ninetoothed/compiler/reductions.py
@@ -1,0 +1,518 @@
+"""Backend-neutral reduction-domain analysis for SSA scheduling."""
+
+from collections import defaultdict
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from ninetoothed.ir import ssa
+
+_ELEMENTWISE_USERS = frozenset(
+    {
+        "select.where",
+        "tensor.cast",
+        "tensor.view",
+    }
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class ReductionDomain:
+    """The iteration domain of one fine-grained SSA reduction."""
+
+    result: str
+    operand: str
+    operator: str
+    axis: int
+    input_shape: tuple[str, ...]
+    result_shape: tuple[str, ...]
+    scope: tuple[int, ...]
+    store_shapes: tuple[tuple[str, ...], ...] = ()
+
+    @property
+    def extent(self) -> str:
+        return self.input_shape[self.axis]
+
+    @property
+    def parallel_axes(self) -> tuple[int, ...]:
+        return tuple(axis for axis in range(len(self.input_shape)) if axis != self.axis)
+
+    @property
+    def parallel_shape(self) -> tuple[str, ...]:
+        return tuple(self.input_shape[axis] for axis in self.parallel_axes)
+
+    def as_metadata(self) -> Mapping[str, Any]:
+        return {
+            "result": self.result,
+            "operand": self.operand,
+            "operator": self.operator,
+            "axis": self.axis,
+            "input_shape": self.input_shape,
+            "result_shape": self.result_shape,
+            "scope": self.scope,
+            "store_shapes": self.store_shapes,
+            "extent": self.extent,
+            "parallel_axes": self.parallel_axes,
+            "parallel_shape": self.parallel_shape,
+        }
+
+
+def analyze_reductions(program: ssa.Program) -> Mapping[str, Any]:
+    """Return reduction domains and a conservative shared schedule contract."""
+    value_types = _value_types(program)
+    scoped_operations = tuple(_walk_program(program))
+    users = _users(scoped_operations)
+    definitions = _definitions(scoped_operations)
+    forwarded_values = _forwarded_values(program)
+    domains = []
+    rejections = []
+
+    for operation, scope in scoped_operations:
+        if not operation.opcode.startswith("reduce."):
+            continue
+
+        domain, rejection = _domain(
+            operation,
+            scope,
+            value_types,
+            users,
+            definitions,
+            forwarded_values,
+        )
+        domains.append(domain)
+
+        if rejection is not None:
+            rejections.append({"result": domain.result, "reason": rejection})
+
+    schedule = _schedule_contract(tuple(domains), tuple(rejections))
+
+    return {
+        "reduction_domains": tuple(domain.as_metadata() for domain in domains),
+        "reduction_rejections": tuple(rejections),
+        "reduction_schedule": schedule,
+    }
+
+
+def _domain(operation, scope, value_types, users, definitions, forwarded_values):
+    if operation.opcode not in {"reduce.sum", "reduce.max", "reduce.min"}:
+        raise ValueError(f"Unsupported SSA reduction `{operation.opcode}`.")
+
+    if len(operation.operands) != 1 or len(operation.results) != 1:
+        raise ValueError(
+            f"SSA reduction `{operation.opcode}` requires one operand and one result."
+        )
+
+    operand = operation.operands[0]
+    result = operation.results[0]
+    operand_type = value_types.get(operand)
+
+    if operand_type is None or operand_type.kind != "tensor" or not operand_type.shape:
+        raise ValueError(
+            f"SSA reduction `{operation.opcode}` requires a ranked tensor operand."
+        )
+
+    input_shape = tuple(str(dim) for dim in operand_type.shape)
+    raw_axis = operation.attrs.get("axis")
+    rejection = None
+
+    if raw_axis is None:
+        non_unit_axes = tuple(
+            index for index, extent in enumerate(input_shape) if extent != "1"
+        )
+
+        if len(non_unit_axes) != 1:
+            axis = 0
+            rejection = "full reduction does not have exactly one non-unit axis"
+        else:
+            axis = non_unit_axes[0]
+
+        expected_shape = ()
+    else:
+        if isinstance(raw_axis, bool) or not isinstance(raw_axis, int):
+            raise ValueError("Reduction axis must be a compile-time integer.")
+
+        axis = raw_axis + len(input_shape) if raw_axis < 0 else raw_axis
+
+        if axis < 0 or axis >= len(input_shape):
+            raise ValueError(
+                f"Reduction axis {raw_axis} is outside tensor rank {len(input_shape)}."
+            )
+
+        expected_shape = input_shape[:axis] + input_shape[axis + 1 :]
+
+    result_shape = tuple(str(dim) for dim in result.type.shape)
+    expected_kind = "tensor" if expected_shape else "scalar"
+
+    if result.type.kind != expected_kind or result_shape != expected_shape:
+        raise ValueError(
+            f"Reduction result `{result.name}` has type {result.type.kind}"
+            f"{result_shape}, expected {expected_kind}{expected_shape}."
+        )
+
+    compatible, consumer_reason = _consumer_contract(
+        result.name,
+        users,
+        axis=axis,
+        input_shape=input_shape,
+        result_shape=result_shape,
+        value_types=value_types,
+    )
+    store_shapes = _reachable_store_shapes(
+        result.name,
+        users,
+        value_types,
+        definitions,
+        forwarded_values,
+    )
+
+    if not compatible and rejection is None:
+        rejection = consumer_reason
+
+    if scope and rejection is None:
+        rejection = "nested-region reductions require scalar fallback"
+
+    return (
+        ReductionDomain(
+            result=result.name,
+            operand=operand,
+            operator=operation.opcode.removeprefix("reduce."),
+            axis=axis,
+            input_shape=input_shape,
+            result_shape=result_shape,
+            scope=scope,
+            store_shapes=store_shapes,
+        ),
+        rejection,
+    )
+
+
+def _consumer_contract(
+    result,
+    users,
+    *,
+    axis,
+    input_shape,
+    result_shape,
+    value_types,
+):
+    broadcast_shape = input_shape[:axis] + ("1",) + input_shape[axis + 1 :]
+    allowed_shapes = {(), result_shape, broadcast_shape, input_shape}
+    pending = [(result, _is_right_aligned(axis, input_shape, result_shape))]
+    seen = set()
+
+    while pending:
+        value, broadcast_ready = pending.pop()
+        state = (value, broadcast_ready)
+
+        if state in seen:
+            continue
+
+        seen.add(state)
+
+        for operation in users.get(value, ()):
+            consumer_broadcast_ready = broadcast_ready
+
+            if operation.opcode == "mem.store":
+                stored_type = value_types.get(value)
+                target_type = value_types.get(operation.operands[1])
+
+                if (
+                    stored_type is not None
+                    and target_type is not None
+                    and stored_type.shape != target_type.shape
+                ):
+                    return False, (
+                        "store target does not match the reduction value domain"
+                    )
+
+                continue
+
+            if operation.opcode.startswith("reduce."):
+                continue
+
+            if not _supported_consumer(operation.opcode) or not operation.results:
+                return False, (
+                    f"consumer `{operation.opcode}` is not row-vector compatible"
+                )
+
+            if operation.opcode == "tensor.view":
+                source_type = value_types.get(value)
+                source_shape = (
+                    ()
+                    if source_type is None
+                    else tuple(str(dim) for dim in source_type.shape)
+                )
+
+                view_contract = _broadcast_view_contract(operation, axis, source_shape)
+
+                if view_contract is None:
+                    return False, ("tensor view does not preserve the reduction domain")
+
+                consumer_broadcast_ready |= view_contract
+
+            for consumer_result in operation.results:
+                shape = tuple(str(dim) for dim in consumer_result.type.shape)
+
+                if shape not in allowed_shapes:
+                    return False, "consumer shape is not in the reduction domain"
+
+                if shape == input_shape and not consumer_broadcast_ready:
+                    return False, ("consumer broadcast does not preserve parallel axes")
+
+                pending.append(
+                    (
+                        consumer_result.name,
+                        consumer_broadcast_ready or shape in {(), input_shape},
+                    )
+                )
+
+    return True, None
+
+
+def _reachable_store_shapes(
+    result,
+    users,
+    value_types,
+    definitions,
+    forwarded_values,
+):
+    pending = [result]
+    seen = set()
+    store_shapes = set()
+
+    while pending:
+        value = pending.pop()
+
+        if value in seen:
+            continue
+
+        seen.add(value)
+        pending.extend(forwarded_values.get(value, ()))
+
+        for operation in users.get(value, ()):
+            if operation.opcode in {"mem.store", "mem.atomic_add"}:
+                target_type = _effect_target_type(
+                    operation,
+                    value_types,
+                    definitions,
+                )
+
+                if target_type is not None:
+                    store_shapes.add(tuple(str(dim) for dim in target_type.shape))
+
+                continue
+
+            pending.extend(item.name for item in operation.results)
+
+            for block in operation.regions:
+                store_shapes.update(
+                    _region_store_shapes(block, value_types, definitions)
+                )
+
+    return tuple(sorted(store_shapes))
+
+
+def _region_store_shapes(block, value_types, definitions):
+    store_shapes = set()
+
+    for operation in block.operations:
+        if operation.opcode in {"mem.store", "mem.atomic_add"}:
+            target_type = _effect_target_type(operation, value_types, definitions)
+
+            if target_type is not None:
+                store_shapes.add(tuple(str(dim) for dim in target_type.shape))
+
+        for region in operation.regions:
+            store_shapes.update(_region_store_shapes(region, value_types, definitions))
+
+    return store_shapes
+
+
+def _effect_target_type(operation, value_types, definitions):
+    target_index = 1 if operation.opcode == "mem.store" else 0
+    target = operation.operands[target_index]
+    target_type = value_types.get(target)
+    definition = definitions.get(target)
+
+    if definition is not None and definition.opcode == "mem.data_ptr":
+        target_type = value_types.get(definition.operands[0])
+
+    return target_type
+
+
+def _is_right_aligned(axis, input_shape, result_shape):
+    if not result_shape:
+        return True
+
+    mapped_axes = tuple(range(len(input_shape) - len(result_shape), len(input_shape)))
+    parallel_axes = tuple(index for index in range(len(input_shape)) if index != axis)
+
+    return mapped_axes == parallel_axes
+
+
+def _broadcast_view_contract(operation, axis, source_shape):
+    subscript = str(operation.attrs.get("subscript", "")).strip().strip("()")
+    parts = tuple(part.strip() for part in subscript.split(",") if part.strip())
+
+    if not parts or any(part not in {":", "None"} for part in parts):
+        return None
+
+    new_axes = tuple(index for index, part in enumerate(parts) if part == "None")
+    result_shape = tuple(str(dim) for dim in operation.results[0].type.shape)
+
+    if sum(part != "None" for part in parts) != len(source_shape):
+        return None
+
+    if not new_axes:
+        return False if result_shape == source_shape else None
+
+    compatible = new_axes == (axis,) and result_shape == (
+        source_shape[:axis] + ("1",) + source_shape[axis:]
+    )
+
+    return True if compatible else None
+
+
+def _supported_consumer(opcode):
+    return (
+        opcode in _ELEMENTWISE_USERS
+        or opcode.startswith("arith.")
+        or opcode.startswith("cmp.")
+        or opcode.startswith("math.")
+    )
+
+
+def _schedule_contract(domains, rejections):
+    if not domains:
+        return {"mode": "none"}
+
+    live_domains = tuple(domain for domain in domains if domain.store_shapes)
+
+    if not live_domains:
+        return {"mode": "none"}
+
+    live_results = {domain.result for domain in live_domains}
+    live_rejections = tuple(
+        rejection for rejection in rejections if rejection["result"] in live_results
+    )
+    store_domains = {
+        store_shape for domain in live_domains for store_shape in domain.store_shapes
+    }
+    emittable = len(store_domains) == 1
+
+    if live_rejections:
+        return {
+            "mode": "scalar-fallback",
+            "reason": live_rejections[0]["reason"],
+            "emittable": emittable,
+        }
+
+    keys = {
+        (
+            domain.scope,
+            domain.input_shape,
+            domain.axis,
+            domain.result_shape,
+        )
+        for domain in live_domains
+    }
+
+    if len(keys) != 1:
+        return {
+            "mode": "scalar-fallback",
+            "reason": "reductions do not share one iteration domain",
+            "emittable": emittable,
+        }
+
+    domain = live_domains[0]
+
+    return {
+        "mode": "row-vector",
+        "axis": domain.axis,
+        "value_shape": domain.input_shape,
+        "result_shape": domain.result_shape,
+        "extent": domain.extent,
+        "parallel_axes": domain.parallel_axes,
+        "parallel_shape": domain.parallel_shape,
+        "reductions": tuple(item.result for item in live_domains),
+    }
+
+
+def _value_types(program):
+    result = {value.name: value.type for value in (*program.inputs, *program.outputs)}
+
+    def collect_block(block):
+        result.update({value.name: value.type for value in block.args})
+
+        for operation in block.operations:
+            result.update({value.name: value.type for value in operation.results})
+
+            for region in operation.regions:
+                collect_block(region)
+
+    for block in program.blocks:
+        collect_block(block)
+    return result
+
+
+def _users(scoped_operations):
+    result = defaultdict(list)
+
+    for operation, _ in scoped_operations:
+        for operand in operation.operands:
+            result[operand].append(operation)
+    return result
+
+
+def _definitions(scoped_operations):
+    return {
+        value.name: operation
+        for operation, _ in scoped_operations
+        for value in operation.results
+    }
+
+
+def _forwarded_values(program):
+    result = defaultdict(set)
+
+    def collect_block(block):
+        for operation in block.operations:
+            for region in operation.regions:
+                if region.operations and region.operations[-1].opcode == "scf.yield":
+                    for source, target in zip(
+                        region.operations[-1].operands,
+                        operation.results,
+                    ):
+                        result[source].add(target.name)
+
+                    if operation.opcode == "scf.for":
+                        for source, target in zip(
+                            region.operations[-1].operands,
+                            region.args[1:],
+                        ):
+                            result[source].add(target.name)
+
+                collect_block(region)
+
+    for block in program.blocks:
+        collect_block(block)
+    return result
+
+
+def _walk_program(program):
+    for block in program.blocks:
+        yield from _walk_block(block, ())
+
+
+def _walk_block(block, scope):
+    for operation_index, operation in enumerate(block.operations):
+        yield operation, scope
+
+        for region_index, region in enumerate(operation.regions):
+            yield from _walk_block(
+                region,
+                (*scope, operation_index, region_index),
+            )
+
+
+__all__ = ["ReductionDomain", "analyze_reductions"]

--- a/src/ninetoothed/compiler/reductions.py
+++ b/src/ninetoothed/compiler/reductions.py
@@ -28,6 +28,9 @@ class ReductionDomain:
     result_shape: tuple[str, ...]
     scope: tuple[int, ...]
     store_shapes: tuple[tuple[str, ...], ...] = ()
+    program_shapes: tuple[tuple[str, ...], ...] = ()
+    program_constraints: tuple[tuple[tuple[str, ...], tuple[str, ...]], ...] = ()
+    program_compatible: bool = True
 
     @property
     def extent(self) -> str:
@@ -51,19 +54,23 @@ class ReductionDomain:
             "result_shape": self.result_shape,
             "scope": self.scope,
             "store_shapes": self.store_shapes,
+            "program_shapes": self.program_shapes,
+            "program_constraints": self.program_constraints,
+            "program_compatible": self.program_compatible,
             "extent": self.extent,
             "parallel_axes": self.parallel_axes,
             "parallel_shape": self.parallel_shape,
         }
 
 
-def analyze_reductions(program: ssa.Program) -> Mapping[str, Any]:
+def analyze_reductions(program: ssa.Program, tensors=()) -> Mapping[str, Any]:
     """Return reduction domains and a conservative shared schedule contract."""
     value_types = _value_types(program)
     scoped_operations = tuple(_walk_program(program))
     users = _users(scoped_operations)
     definitions = _definitions(scoped_operations)
     forwarded_values = _forwarded_values(program)
+    tensor_specs = {tensor.name: tensor for tensor in tensors}
     domains = []
     rejections = []
 
@@ -78,6 +85,7 @@ def analyze_reductions(program: ssa.Program) -> Mapping[str, Any]:
             users,
             definitions,
             forwarded_values,
+            tensor_specs,
         )
         domains.append(domain)
 
@@ -93,7 +101,15 @@ def analyze_reductions(program: ssa.Program) -> Mapping[str, Any]:
     }
 
 
-def _domain(operation, scope, value_types, users, definitions, forwarded_values):
+def _domain(
+    operation,
+    scope,
+    value_types,
+    users,
+    definitions,
+    forwarded_values,
+    tensor_specs,
+):
     if operation.opcode not in {"reduce.sum", "reduce.max", "reduce.min"}:
         raise ValueError(f"Unsupported SSA reduction `{operation.opcode}`.")
 
@@ -157,16 +173,34 @@ def _domain(operation, scope, value_types, users, definitions, forwarded_values)
         result_shape=result_shape,
         value_types=value_types,
     )
-    store_shapes = _reachable_store_shapes(
+    stores = _reachable_stores(
         result.name,
         users,
         value_types,
         definitions,
         forwarded_values,
     )
+    store_shapes = tuple(sorted({shape for _target, shape in stores}))
+    (
+        program_shapes,
+        program_constraints,
+        program_compatible,
+        program_reason,
+    ) = _program_contract(
+        operand,
+        definitions,
+        stores,
+        tensor_specs,
+    )
 
     if not compatible and rejection is None:
         rejection = consumer_reason
+
+    if program_reason is not None and rejection is None:
+        rejection = program_reason
+
+    if len(program_shapes) > 1 and rejection is None:
+        rejection = "reduction stores do not share one outer program domain"
 
     if scope and rejection is None:
         rejection = "nested-region reductions require scalar fallback"
@@ -181,6 +215,9 @@ def _domain(operation, scope, value_types, users, definitions, forwarded_values)
             result_shape=result_shape,
             scope=scope,
             store_shapes=store_shapes,
+            program_shapes=program_shapes,
+            program_constraints=program_constraints,
+            program_compatible=program_compatible,
         ),
         rejection,
     )
@@ -269,7 +306,7 @@ def _consumer_contract(
     return True, None
 
 
-def _reachable_store_shapes(
+def _reachable_stores(
     result,
     users,
     value_types,
@@ -278,7 +315,7 @@ def _reachable_store_shapes(
 ):
     pending = [result]
     seen = set()
-    store_shapes = set()
+    stores = set()
 
     while pending:
         value = pending.pop()
@@ -291,53 +328,185 @@ def _reachable_store_shapes(
 
         for operation in users.get(value, ()):
             if operation.opcode in {"mem.store", "mem.atomic_add"}:
-                target_type = _effect_target_type(
+                target, target_type = _effect_target(
                     operation,
                     value_types,
                     definitions,
                 )
 
-                if target_type is not None:
-                    store_shapes.add(tuple(str(dim) for dim in target_type.shape))
+                if target is not None and target_type is not None:
+                    stores.add((target, tuple(str(dim) for dim in target_type.shape)))
 
                 continue
 
             pending.extend(item.name for item in operation.results)
 
             for block in operation.regions:
-                store_shapes.update(
-                    _region_store_shapes(block, value_types, definitions)
-                )
+                stores.update(_region_stores(block, value_types, definitions))
 
-    return tuple(sorted(store_shapes))
+    return tuple(sorted(stores))
 
 
-def _region_store_shapes(block, value_types, definitions):
-    store_shapes = set()
+def _region_stores(block, value_types, definitions):
+    stores = set()
 
     for operation in block.operations:
         if operation.opcode in {"mem.store", "mem.atomic_add"}:
-            target_type = _effect_target_type(operation, value_types, definitions)
+            target, target_type = _effect_target(operation, value_types, definitions)
 
-            if target_type is not None:
-                store_shapes.add(tuple(str(dim) for dim in target_type.shape))
+            if target is not None and target_type is not None:
+                stores.add((target, tuple(str(dim) for dim in target_type.shape)))
 
         for region in operation.regions:
-            store_shapes.update(_region_store_shapes(region, value_types, definitions))
+            stores.update(_region_stores(region, value_types, definitions))
 
-    return store_shapes
+    return stores
 
 
-def _effect_target_type(operation, value_types, definitions):
+def _effect_target(operation, value_types, definitions):
     target_index = 1 if operation.opcode == "mem.store" else 0
     target = operation.operands[target_index]
     target_type = value_types.get(target)
     definition = definitions.get(target)
 
     if definition is not None and definition.opcode == "mem.data_ptr":
-        target_type = value_types.get(definition.operands[0])
+        target = definition.operands[0]
+        target_type = value_types.get(target)
 
-    return target_type
+    return target, target_type
+
+
+def _program_contract(
+    operand,
+    definitions,
+    stores,
+    tensor_specs,
+):
+    producer_targets = _producer_targets(operand, definitions, tensor_specs)
+    producer_specs = tuple(tensor_specs[target] for target in producer_targets)
+    store_specs = tuple(tensor_specs.get(target) for target, _shape in stores)
+    legacy_global_domain = (
+        producer_specs
+        and all(tensor.layout is None for tensor in producer_specs)
+        and store_specs
+        and all(tensor is not None and tensor.layout is None for tensor in store_specs)
+    )
+
+    if legacy_global_domain:
+        return ((),), (((), ()),), True, None
+
+    if not producer_specs or any(tensor.layout is None for tensor in producer_specs):
+        return (
+            (),
+            (),
+            True,
+            "reduction operand has no structured Layout IR program domain",
+        )
+
+    producer_shapes = tuple(
+        sorted(
+            {
+                tuple(expression.render() for expression in tensor.layout.view_shape)
+                for tensor in producer_specs
+            }
+        )
+    )
+    shapes = set()
+    constraints = []
+    compatible = True
+    reason = None
+
+    for target, _store_shape in stores:
+        tensor = tensor_specs.get(target)
+
+        if tensor is None or tensor.layout is None:
+            return (
+                (),
+                (),
+                True,
+                "store target has no structured Layout IR program domain",
+            )
+
+        store_program_shape = tuple(
+            expression.render() for expression in tensor.layout.view_shape
+        )
+
+        shapes.add(store_program_shape)
+
+        for producer_shape in producer_shapes:
+            constraints.append((store_program_shape, producer_shape))
+            actual_static = _static_product(store_program_shape)
+            expected_static = _static_product(producer_shape)
+
+            if (
+                actual_static is not None
+                and expected_static is not None
+                and actual_static != expected_static
+            ):
+                compatible = False
+                reason = "reduction operand and store program domains do not match"
+
+    if len(shapes) > 1:
+        compatible = False
+        reason = "reduction stores do not share one outer program domain"
+
+    return (
+        tuple(sorted(shapes)),
+        tuple(sorted(constraints)),
+        compatible,
+        reason,
+    )
+
+
+def _producer_targets(value, definitions, tensor_specs):
+    pending = [value]
+    seen = set()
+    targets = set()
+
+    while pending:
+        current = pending.pop()
+
+        if current in seen:
+            continue
+
+        seen.add(current)
+        tensor = tensor_specs.get(current)
+
+        if tensor is not None:
+            if tensor.ndim > 0 and not tensor.constexpr:
+                targets.add(current)
+            continue
+
+        operation = definitions.get(current)
+
+        if operation is not None:
+            pending.extend(operation.operands)
+
+    return tuple(sorted(targets))
+
+
+def _static_product(shape):
+    values = tuple(_static_integer_expression(expression) for expression in shape)
+
+    if any(value is None for value in values):
+        return None
+
+    result = 1
+
+    for value in values:
+        result *= value
+    return result
+
+
+def _static_integer_expression(expression):
+    try:
+        import sympy
+
+        value = sympy.sympify(expression)
+
+        return None if value.free_symbols else int(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _is_right_aligned(axis, input_shape, result_shape):
@@ -398,7 +567,16 @@ def _schedule_contract(domains, rejections):
     store_domains = {
         store_shape for domain in live_domains for store_shape in domain.store_shapes
     }
-    emittable = len(store_domains) == 1
+    program_domains = {
+        program_shape
+        for domain in live_domains
+        for program_shape in domain.program_shapes
+    }
+    emittable = (
+        len(store_domains) == 1
+        and len(program_domains) <= 1
+        and all(domain.program_compatible for domain in live_domains)
+    )
 
     if live_rejections:
         return {
@@ -413,6 +591,8 @@ def _schedule_contract(domains, rejections):
             domain.input_shape,
             domain.axis,
             domain.result_shape,
+            domain.program_shapes,
+            domain.program_constraints,
         )
         for domain in live_domains
     }
@@ -434,6 +614,8 @@ def _schedule_contract(domains, rejections):
         "extent": domain.extent,
         "parallel_axes": domain.parallel_axes,
         "parallel_shape": domain.parallel_shape,
+        "program_shape": domain.program_shapes[0],
+        "program_constraints": domain.program_constraints,
         "reductions": tuple(item.result for item in live_domains),
     }
 

--- a/src/ninetoothed/compiler/reductions.py
+++ b/src/ninetoothed/compiler/reductions.py
@@ -14,6 +14,7 @@ _ELEMENTWISE_USERS = frozenset(
         "tensor.view",
     }
 )
+_SUPPORTED_REDUCTIONS = frozenset({"reduce.sum", "reduce.max", "reduce.min"})
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -78,6 +79,9 @@ def analyze_reductions(program: ssa.Program, tensors=()) -> Mapping[str, Any]:
         if not operation.opcode.startswith("reduce."):
             continue
 
+        if operation.opcode not in _SUPPORTED_REDUCTIONS:
+            raise ValueError(f"Unsupported SSA reduction `{operation.opcode}`.")
+
         if operation.operands:
             operand_type = value_types.get(operation.operands[0])
 
@@ -136,9 +140,6 @@ def _domain(
     forwarded_values,
     tensor_specs,
 ):
-    if operation.opcode not in {"reduce.sum", "reduce.max", "reduce.min"}:
-        raise ValueError(f"Unsupported SSA reduction `{operation.opcode}`.")
-
     if len(operation.operands) != 1 or len(operation.results) != 1:
         raise ValueError(
             f"SSA reduction `{operation.opcode}` requires one operand and one result."

--- a/src/ninetoothed/compiler/reductions.py
+++ b/src/ninetoothed/compiler/reductions.py
@@ -475,6 +475,7 @@ def _producer_targets(value, definitions, tensor_specs):
         if tensor is not None:
             if tensor.ndim > 0 and not tensor.constexpr:
                 targets.add(current)
+
             continue
 
         operation = definitions.get(current)

--- a/src/ninetoothed/compiler/runtime.py
+++ b/src/ninetoothed/compiler/runtime.py
@@ -1192,16 +1192,19 @@ def _validate_tensor_contract(spec, value, expected_device):
             f"expected {source_ndim}."
         )
 
-    try:
-        expected_shape = tuple(int(dim) for dim in spec.attrs["source_shape"])
-    except (KeyError, TypeError, ValueError):
-        expected_shape = None
+    for axis, (actual, expected) in enumerate(
+        zip(shape, spec.attrs.get("source_shape", ()), strict=False)
+    ):
+        try:
+            expected = int(expected)
+        except (TypeError, ValueError):
+            continue
 
-    if expected_shape is not None and tuple(shape) != expected_shape:
-        raise TypeError(
-            f"Kernel argument `{spec.name}` has shape {tuple(shape)}; "
-            f"expected {expected_shape}."
-        )
+        if actual != expected:
+            raise TypeError(
+                f"Kernel argument `{spec.name}` has shape {tuple(shape)}; "
+                f"expected dimension {axis} to be {expected}."
+            )
 
     device = getattr(value, "device", None)
 

--- a/src/ninetoothed/compiler/runtime.py
+++ b/src/ninetoothed/compiler/runtime.py
@@ -981,6 +981,7 @@ def _runtime_wrapper(
     specs=(),
     binding_overrides=None,
     prepare_invocation=None,
+    validate_bindings=None,
 ):
     overrides = dict(binding_overrides or {})
 
@@ -997,6 +998,9 @@ def _runtime_wrapper(
                 owner_refs=_runtime_owner_refs(args, kwargs),
                 empty=True,
             )
+
+        if validate_bindings is not None:
+            validate_bindings(bound_public)
 
         values, _keepalive = _bound_values(abi, bound_public, scalar_mode="value")
         bindings = abi.kernel_args
@@ -1087,9 +1091,14 @@ def _runtime_wrapper(
         if _empty_launch(abi, public):
             return _first_output(abi, public)
 
+        bound_public = dict(public) | overrides
+
+        if validate_bindings is not None:
+            validate_bindings(bound_public)
+
         values, keepalive = _bound_values(
             abi,
-            dict(public) | overrides,
+            bound_public,
             scalar_mode="value",
         )
 
@@ -1181,6 +1190,17 @@ def _validate_tensor_contract(spec, value, expected_device):
         raise TypeError(
             f"Kernel argument `{spec.name}` has rank {len(shape)}; "
             f"expected {source_ndim}."
+        )
+
+    try:
+        expected_shape = tuple(int(dim) for dim in spec.attrs["source_shape"])
+    except (KeyError, TypeError, ValueError):
+        expected_shape = None
+
+    if expected_shape is not None and tuple(shape) != expected_shape:
+        raise TypeError(
+            f"Kernel argument `{spec.name}` has shape {tuple(shape)}; "
+            f"expected {expected_shape}."
         )
 
     device = getattr(value, "device", None)

--- a/tests/test_compiler_cache_runtime.py
+++ b/tests/test_compiler_cache_runtime.py
@@ -79,6 +79,24 @@ def test_runtime_binding_validates_tensor_contract(value, message):
         )
 
 
+def test_runtime_binding_validates_static_dimensions_of_dynamic_shape():
+    spec = TensorSpec(
+        name="x",
+        ndim=2,
+        shape=("rows", "127"),
+        dtype="float32",
+        attrs={"source_ndim": 2, "source_shape": ("rows", "127")},
+    )
+
+    with pytest.raises(TypeError, match="expected dimension 1 to be 127"):
+        _public_values(
+            LaunchABI(public_args=("x",)),
+            (_Tensor((3, 64)),),
+            {},
+            specs=(spec,),
+        )
+
+
 def test_runtime_wrappers_skip_empty_launches():
     abi = LaunchABI(public_args=("out",), outputs=("out",))
     output = SimpleNamespace(numel=lambda: 0)

--- a/tests/test_ssa_first_backend_lowering.py
+++ b/tests/test_ssa_first_backend_lowering.py
@@ -1122,7 +1122,7 @@ def scalarized_index_application(x, indices, y):
             ),
         )
         expected = {
-            "triton": ("ssa-unified-triton-emitter", "for v1_i in range(0, cols, 1):"),
+            "triton": ("ssa-unified-triton-emitter", "tl.sum("),
             "cuda": (
                 "ssa-unified-cuda-emitter",
                 "a[(index) * (cols) + (v1_i)] * x[v1_i]",
@@ -1135,6 +1135,9 @@ def scalarized_index_application(x, indices, y):
             _assert_ssa_artifact(artifact, route=route)
             assert source_fragment in artifact.primary_source
             assert "reduce.sum" in str(artifact.metadata["ssa"])
+
+            if backend == "triton":
+                assert "for v1_i in range" not in artifact.primary_source
 
     def test_from_source_generates_rowwise_reduction_for_native_backends(self):
         kernel = _ssa_kernel(

--- a/tests/test_triton_reduction_schedule.py
+++ b/tests/test_triton_reduction_schedule.py
@@ -109,6 +109,16 @@ def _too_wide_sum(x, out):
     out = ntl.sum(x, axis=1)  # noqa: F841
 
 
+def _mixed_tensor_scalar_reductions(x, out):
+    row = ntl.sum(x, axis=1)
+    scalar = ntl.sum(x[0, 0], axis=0)
+    out = row + scalar  # noqa: F841
+
+
+def _source_store_sum(x, out):
+    out.source[out.offsets(0)] = ntl.sum(x, axis=1)
+
+
 def _request():
     return CompileRequest(
         arrangement=_row_arrangement,
@@ -138,6 +148,33 @@ def test_reduction_domain_selects_triton_row_vector_schedule():
     assert "tl.max(" in compilation.artifact.primary_source
     assert "tl.sum(" in compilation.artifact.primary_source
     assert "for v" not in compilation.artifact.primary_source
+
+    mixed = DEFAULT_COMPILER.compile(
+        CompileRequest(
+            arrangement=_row_reduced_arrangement,
+            application=_mixed_tensor_scalar_reductions,
+            tensors=(Tensor(2), Tensor(1)),
+            backend="triton",
+            max_num_configs=1,
+        )
+    )
+    assert mixed.artifact.primary_source.count("tl.sum(") == 1
+
+    source_store = DEFAULT_COMPILER.compile(
+        CompileRequest(
+            arrangement=_row_reduced_arrangement,
+            application=_source_store_sum,
+            tensors=(Tensor(2), Tensor(1)),
+            backend="triton",
+            max_num_configs=1,
+        )
+    )
+    store = next(
+        line
+        for line in source_store.artifact.primary_source.splitlines()
+        if "tl.store(out +" in line
+    )
+    assert "offsets" not in store
 
     fallback = DEFAULT_COMPILER.compile(
         CompileRequest(
@@ -317,3 +354,25 @@ def test_triton_row_vector_reduction_runtime(device, tmp_path):
     for launch in (aot_reduce_min, load_built_artifact(aot_reduce_min._built_artifact)):
         with pytest.raises(TypeError, match="has shape .* expected"):
             launch(resized_x, resized_output)
+
+
+@pytest.mark.parametrize("device", get_available_devices())
+def test_row_vector_only_vectorizes_scheduled_reductions_and_masks_source_store(
+    device,
+):
+    x = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device=device)
+
+    for application, expected in (
+        (_mixed_tensor_scalar_reductions, torch.tensor([7.0, 19.0], device=device)),
+        (_source_store_sum, torch.tensor([6.0, 15.0], device=device)),
+    ):
+        kernel = make(
+            _row_reduced_arrangement,
+            application,
+            (Tensor(2), Tensor(1)),
+            backend="triton",
+            max_num_configs=1,
+        )
+        output = torch.empty(2, device=device)
+        kernel(x, output, WIDTH=3)
+        torch.testing.assert_close(output, expected)

--- a/tests/test_triton_reduction_schedule.py
+++ b/tests/test_triton_reduction_schedule.py
@@ -9,6 +9,8 @@ from ninetoothed.compiler import (
     load_built_artifact,
     make,
 )
+from ninetoothed.compiler.reductions import analyze_reductions
+from ninetoothed.ir import ssa
 from tests.utils import get_available_devices
 
 WIDTH = Symbol("WIDTH", constexpr=True)
@@ -230,6 +232,30 @@ def test_reduction_domain_selects_triton_row_vector_schedule():
             )
         )
 
+    scalar = ssa.Type(kind="scalar", dtype="float32")
+    operand = ssa.Value(name="x", type=scalar)
+    result = ssa.Value(name="result", type=scalar)
+    unsupported = ssa.Program(
+        kind="unsupported-reduction",
+        inputs=(operand,),
+        outputs=(result,),
+        blocks=(
+            ssa.Block(
+                operations=(
+                    ssa.Operation(
+                        opcode="reduce.product",
+                        operands=(operand.name,),
+                        results=(result,),
+                        attrs={"axis": 0},
+                    ),
+                )
+            ),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="Unsupported SSA reduction `reduce.product`"):
+        analyze_reductions(unsupported)
+
 
 @pytest.mark.parametrize("device", get_available_devices())
 def test_triton_row_vector_reduction_runtime(device, tmp_path):
@@ -354,6 +380,38 @@ def test_triton_row_vector_reduction_runtime(device, tmp_path):
     for launch in (aot_reduce_min, load_built_artifact(aot_reduce_min._built_artifact)):
         with pytest.raises(TypeError, match="has shape .* expected"):
             launch(resized_x, resized_output)
+
+    dynamic_tensors = (
+        Tensor(shape=(None, 127), dtype=float32),
+        Tensor(shape=(None,), dtype=float32),
+    )
+    dynamic_jit = make(
+        _fixed_row_reduced_arrangement,
+        _row_min,
+        dynamic_tensors,
+        backend="triton",
+        max_num_configs=1,
+    )
+    dynamic_aot = make(
+        _fixed_row_reduced_arrangement,
+        _row_min,
+        dynamic_tensors,
+        backend="triton",
+        caller=device,
+        kernel_name="dynamic_row_min_reduction_aot",
+        output_dir=tmp_path,
+        max_num_configs=1,
+    )
+    invalid_x = torch.randn((37, 64), device=device)
+    invalid_output = torch.empty((37,), device=device)
+
+    for launch in (
+        dynamic_jit,
+        dynamic_aot,
+        load_built_artifact(dynamic_aot._built_artifact),
+    ):
+        with pytest.raises(TypeError, match="expected dimension 1 to be 127"):
+            launch(invalid_x, invalid_output)
 
 
 @pytest.mark.parametrize("device", get_available_devices())

--- a/tests/test_triton_reduction_schedule.py
+++ b/tests/test_triton_reduction_schedule.py
@@ -1,0 +1,201 @@
+import pytest
+import torch
+
+import ninetoothed.language as ntl
+from ninetoothed import Symbol, Tensor
+from ninetoothed.compiler import DEFAULT_COMPILER, CompileRequest, make
+from tests.utils import get_available_devices
+
+WIDTH = Symbol("WIDTH", constexpr=True)
+HEIGHT = Symbol("HEIGHT", constexpr=True)
+
+
+def _row_arrangement(x, out, WIDTH=WIDTH):
+    return x.tile((1, WIDTH)), out.tile((1, WIDTH))
+
+
+def _row_reduced_arrangement(x, out, WIDTH=WIDTH):
+    return x.tile((1, WIDTH)), out.tile((1,))
+
+
+def _column_arrangement(x, out, HEIGHT=HEIGHT):
+    return x.tile((HEIGHT, 1)), out.tile((HEIGHT, 1))
+
+
+def _middle_axis_arrangement(x, out):
+    return x.tile((2, 3, 5)), out.tile((2, 5))
+
+
+def _square_arrangement(x, out):
+    return x.tile((4, 4)), out.tile((4, 4))
+
+
+def _separate_reduction_arrangement(x, rows, columns):
+    return x.tile((4, 8)), rows.tile((4,)), columns.tile((8,))
+
+
+def _row_normalize(x, out):
+    maximum = ntl.max(x, axis=1)
+    numerator = ntl.exp(x - maximum[:, None])
+    out = numerator / ntl.sum(numerator, axis=1)[:, None]  # noqa: F841
+
+
+def _row_layernorm(x, out):
+    width = x.shape[1]
+    mean = ntl.sum(x, axis=1) / width
+    mean_square = ntl.sum(x * x, axis=1) / width
+    variance = mean_square - mean * mean
+    out = (x - mean[:, None]) * ntl.rsqrt(variance[:, None] + 1e-5)  # noqa: F841
+
+
+def _row_min(x, out):
+    out = ntl.min(x, axis=1)  # noqa: F841
+
+
+def _column_max_broadcast(x, out):
+    out = x + ntl.max(x, axis=0)[None, :]  # noqa: F841
+
+
+def _middle_axis_sum(x, out):
+    out = ntl.sum(x, axis=1)  # noqa: F841
+
+
+def _incompatible_broadcast(x, out):
+    out = x + ntl.sum(x, axis=1)[None, :]  # noqa: F841
+
+
+def _separate_reduction_outputs(x, rows, columns):
+    rows = ntl.sum(x, axis=1)  # noqa: F841
+    columns = ntl.max(x, axis=0)  # noqa: F841
+
+
+def _request():
+    return CompileRequest(
+        arrangement=_row_arrangement,
+        application=_row_normalize,
+        tensors=(Tensor(2), Tensor(2)),
+        backend="triton",
+        tensor_dtypes={"x": "float32", "out": "float32"},
+    )
+
+
+def test_reduction_domain_selects_triton_row_vector_schedule():
+    compilation = DEFAULT_COMPILER.compile(_request())
+    metadata = compilation.artifact.metadata["ssa_metadata"]
+    domains = metadata["analysis"]["reduction_domains"]
+
+    assert len(domains) == 2
+    assert {domain["operator"] for domain in domains} == {"max", "sum"}
+    assert all(domain["axis"] == 1 for domain in domains)
+    assert all(domain["parallel_shape"] == ("1",) for domain in domains)
+    assert metadata["schedule"]["reduction"]["mode"] == "row-vector"
+    assert tuple(
+        candidate["num_warps"]
+        for candidate in compilation.launch_plan.tuning_candidates
+    ) == (4, 8, 1)
+    assert "tl.max(" in compilation.artifact.primary_source
+    assert "tl.sum(" in compilation.artifact.primary_source
+    assert "for v" not in compilation.artifact.primary_source
+
+    fallback = DEFAULT_COMPILER.compile(
+        CompileRequest(
+            arrangement=_square_arrangement,
+            application=_incompatible_broadcast,
+            tensors=(Tensor(2), Tensor(2)),
+            backend="triton",
+            tensor_dtypes={"x": "float32", "out": "float32"},
+        )
+    )
+    assert (
+        fallback.artifact.metadata["ssa_metadata"]["schedule"]["reduction"]["mode"]
+        == "scalar-fallback"
+    )
+
+    with pytest.raises(ValueError, match="separate kernels"):
+        DEFAULT_COMPILER.compile(
+            CompileRequest(
+                arrangement=_separate_reduction_arrangement,
+                application=_separate_reduction_outputs,
+                tensors=(Tensor(2), Tensor(1), Tensor(1)),
+                backend="triton",
+                tensor_dtypes={
+                    "x": "float32",
+                    "rows": "float32",
+                    "columns": "float32",
+                },
+            )
+        )
+
+
+@pytest.mark.parametrize("device", get_available_devices())
+def test_triton_row_vector_reduction_runtime(device):
+    normalize = make(
+        _row_arrangement,
+        _row_normalize,
+        (Tensor(2), Tensor(2)),
+        backend="triton",
+        max_num_configs=1,
+    )
+    layernorm = make(
+        _row_arrangement,
+        _row_layernorm,
+        (Tensor(2), Tensor(2)),
+        backend="triton",
+        max_num_configs=1,
+    )
+    reduce_min = make(
+        _row_reduced_arrangement,
+        _row_min,
+        (Tensor(2), Tensor(1)),
+        backend="triton",
+        max_num_configs=1,
+    )
+    column_max = make(
+        _column_arrangement,
+        _column_max_broadcast,
+        (Tensor(2), Tensor(2)),
+        backend="triton",
+        max_num_configs=1,
+    )
+    middle_sum = make(
+        _middle_axis_arrangement,
+        _middle_axis_sum,
+        (Tensor(3), Tensor(2)),
+        backend="triton",
+        max_num_configs=1,
+    )
+
+    width = 127
+    base = torch.randn((37, width * 2), device=device)
+    x = base[:, ::2]
+    normalized = torch.empty_like(x)
+    layernorm_output = torch.empty_like(x)
+    minimum = torch.empty((x.shape[0],), device=device)
+
+    normalize(x, normalized, WIDTH=width)
+    layernorm(x, layernorm_output, WIDTH=width)
+    reduce_min(x, minimum, WIDTH=width)
+
+    torch.testing.assert_close(
+        normalized,
+        torch.softmax(x, dim=1),
+        rtol=1e-5,
+        atol=1e-6,
+    )
+    torch.testing.assert_close(
+        layernorm_output,
+        torch.nn.functional.layer_norm(x, (width,)),
+        rtol=2e-4,
+        atol=2e-5,
+    )
+    torch.testing.assert_close(minimum, x.min(dim=1).values)
+
+    x = torch.randn((193, 41), device=device)
+    output = torch.empty_like(x)
+    column_max(x, output, HEIGHT=x.shape[0])
+    torch.testing.assert_close(output, x + x.max(dim=0).values, rtol=1e-5, atol=1e-6)
+
+    x = torch.randn((2, 3, 5), device=device)
+    output = torch.empty((2, 5), device=device)
+    middle_sum(x, output)
+    torch.testing.assert_close(output, x.sum(dim=1))

--- a/tests/test_triton_reduction_schedule.py
+++ b/tests/test_triton_reduction_schedule.py
@@ -2,12 +2,18 @@ import pytest
 import torch
 
 import ninetoothed.language as ntl
-from ninetoothed import Symbol, Tensor
-from ninetoothed.compiler import DEFAULT_COMPILER, CompileRequest, make
+from ninetoothed import Symbol, Tensor, float32
+from ninetoothed.compiler import (
+    DEFAULT_COMPILER,
+    CompileRequest,
+    load_built_artifact,
+    make,
+)
 from tests.utils import get_available_devices
 
 WIDTH = Symbol("WIDTH", constexpr=True)
 HEIGHT = Symbol("HEIGHT", constexpr=True)
+TOO_WIDE = (1 << 20) + 1
 
 
 def _row_arrangement(x, out, WIDTH=WIDTH):
@@ -16,6 +22,14 @@ def _row_arrangement(x, out, WIDTH=WIDTH):
 
 def _row_reduced_arrangement(x, out, WIDTH=WIDTH):
     return x.tile((1, WIDTH)), out.tile((1,))
+
+
+def _two_input_reduced_arrangement(x, y, out, WIDTH=WIDTH):
+    return x.tile((1, WIDTH)), y.tile((1, WIDTH)), out.tile((1,))
+
+
+def _fixed_row_reduced_arrangement(x, out):
+    return x.tile((1, 127)), out.tile((1,))
 
 
 def _column_arrangement(x, out, HEIGHT=HEIGHT):
@@ -32,6 +46,19 @@ def _square_arrangement(x, out):
 
 def _separate_reduction_arrangement(x, rows, columns):
     return x.tile((4, 8)), rows.tile((4,)), columns.tile((8,))
+
+
+def _mixed_outer_arrangement(x, y, out_x, out_y):
+    return (
+        x.tile((1, 7)),
+        y.tile((1, 7)),
+        out_x.tile((1,)),
+        out_y.tile((1,)),
+    )
+
+
+def _too_wide_arrangement(x, out):
+    return x.tile((1, TOO_WIDE)), out.tile((1,))
 
 
 def _row_normalize(x, out):
@@ -52,6 +79,10 @@ def _row_min(x, out):
     out = ntl.min(x, axis=1)  # noqa: F841
 
 
+def _row_product_sum(x, y, out):
+    out = ntl.sum(x * y, axis=1)  # noqa: F841
+
+
 def _column_max_broadcast(x, out):
     out = x + ntl.max(x, axis=0)[None, :]  # noqa: F841
 
@@ -67,6 +98,15 @@ def _incompatible_broadcast(x, out):
 def _separate_reduction_outputs(x, rows, columns):
     rows = ntl.sum(x, axis=1)  # noqa: F841
     columns = ntl.max(x, axis=0)  # noqa: F841
+
+
+def _mixed_outer_reductions(x, y, out_x, out_y):
+    out_x = ntl.sum(x, axis=1)  # noqa: F841
+    out_y = ntl.sum(y, axis=1)  # noqa: F841
+
+
+def _too_wide_sum(x, out):
+    out = ntl.sum(x, axis=1)  # noqa: F841
 
 
 def _request():
@@ -88,7 +128,9 @@ def test_reduction_domain_selects_triton_row_vector_schedule():
     assert {domain["operator"] for domain in domains} == {"max", "sum"}
     assert all(domain["axis"] == 1 for domain in domains)
     assert all(domain["parallel_shape"] == ("1",) for domain in domains)
+    assert all(len(domain["program_shapes"]) == 1 for domain in domains)
     assert metadata["schedule"]["reduction"]["mode"] == "row-vector"
+    assert metadata["schedule"]["reduction"]["program_shape"]
     assert tuple(
         candidate["num_warps"]
         for candidate in compilation.launch_plan.tuning_candidates
@@ -126,9 +168,34 @@ def test_reduction_domain_selects_triton_row_vector_schedule():
             )
         )
 
+    with pytest.raises(ValueError, match="separate kernels"):
+        DEFAULT_COMPILER.compile(
+            CompileRequest(
+                arrangement=_mixed_outer_arrangement,
+                application=_mixed_outer_reductions,
+                tensors=(
+                    Tensor(shape=(2, 7)),
+                    Tensor(shape=(4, 7)),
+                    Tensor(shape=(2,)),
+                    Tensor(shape=(4,)),
+                ),
+                backend="triton",
+            )
+        )
+
+    with pytest.raises(ValueError, match="exceeding the backend tensor numel limit"):
+        DEFAULT_COMPILER.compile(
+            CompileRequest(
+                arrangement=_too_wide_arrangement,
+                application=_too_wide_sum,
+                tensors=(Tensor(shape=(1, TOO_WIDE)), Tensor(shape=(1,))),
+                backend="triton",
+            )
+        )
+
 
 @pytest.mark.parametrize("device", get_available_devices())
-def test_triton_row_vector_reduction_runtime(device):
+def test_triton_row_vector_reduction_runtime(device, tmp_path):
     normalize = make(
         _row_arrangement,
         _row_normalize,
@@ -147,6 +214,13 @@ def test_triton_row_vector_reduction_runtime(device):
         _row_reduced_arrangement,
         _row_min,
         (Tensor(2), Tensor(1)),
+        backend="triton",
+        max_num_configs=1,
+    )
+    product_sum = make(
+        _two_input_reduced_arrangement,
+        _row_product_sum,
+        (Tensor(2), Tensor(2), Tensor(1)),
         backend="triton",
         max_num_configs=1,
     )
@@ -199,3 +273,47 @@ def test_triton_row_vector_reduction_runtime(device):
     output = torch.empty((2, 5), device=device)
     middle_sum(x, output)
     torch.testing.assert_close(output, x.sum(dim=1))
+
+    mismatched_output = torch.empty((4,), device=device)
+
+    with pytest.raises(ValueError, match="program domains do not match"):
+        reduce_min(x=torch.randn((2, 7), device=device), out=mismatched_output, WIDTH=7)
+
+    with pytest.raises(ValueError, match="program domains do not match"):
+        product_sum(
+            torch.randn((2, 7), device=device),
+            torch.randn((4, 7), device=device),
+            torch.empty((2,), device=device),
+            WIDTH=7,
+        )
+
+    too_wide = torch.empty((1, TOO_WIDE), device=device)
+    reduced = torch.empty((1,), device=device)
+
+    with pytest.raises(ValueError, match="tensor numel limit"):
+        reduce_min(too_wide, reduced, WIDTH=TOO_WIDE)
+
+    aot_reduce_min = make(
+        _fixed_row_reduced_arrangement,
+        _row_min,
+        (
+            Tensor(shape=(37, 127), dtype=float32),
+            Tensor(shape=(37,), dtype=float32),
+        ),
+        backend="triton",
+        caller=device,
+        kernel_name="row_min_reduction_aot",
+        output_dir=tmp_path,
+        max_num_configs=1,
+    )
+    x = torch.randn((37, 127), device=device)
+    output = torch.empty((37,), device=device)
+    aot_reduce_min(x, output)
+    torch.testing.assert_close(output, x.min(dim=1).values)
+
+    resized_x = torch.randn((38, 127), device=device)
+    resized_output = torch.empty((38,), device=device)
+
+    for launch in (aot_reduce_min, load_built_artifact(aot_reduce_min._built_artifact)):
+        with pytest.raises(TypeError, match="has shape .* expected"):
+            launch(resized_x, resized_output)


### PR DESCRIPTION
`pytest` output:
```
pytest -n 16 -x
====================================================================================== test session starts =======================================================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0                                
rootdir: /home/haojie/ntbackend/.merge-ready/reduction-domain-triton-schedule                                                                                                                     
configfile: pyproject.toml                                                                       
plugins: xdist-3.8.0, anyio-4.13.0, cov-7.1.0
16 workers [387 items]                                                                           
...................................................................................................................................................s...................................... [ 48%] 
.......................................................................................................................................................................................... [ 96%]
s..............                                                                                                                                                                            [100%]
=========================================================================== 385 passed, 2 skipped in 529.47s (0:08:49) ==========================================================================
```

## 背景

当前 SSA 编译链路对 reduction 的调度主要依赖启发式判断，缺少对归约域、并行域和结果使用关系的结构化分析。这带来两个问题：

1. Triton 可能使用 block mask 访问 scalar pointer，导致生成代码无法编译。
2. Softmax、LayerNorm 等包含归约与广播的数据流无法稳定生成高效的 row-vector kernel，性能明显低于旧版生成路径。

本 PR 从 SSA 类型、归约轴和 use-def 链中提取通用的 Reduction Domain，并据此完成调度。

## 主要修改

### 通用 Reduction Domain

新增不可变的 `ReductionDomain`，用于描述：

- reduction operand、result 和 `sum/max/min` 类型；
- 规范化后的 reduction axis；
- 输入、结果及 parallel domain shape；
- reduction extent；
- 同域 reduction 及其广播 consumer；
- row-vector 调度的合法性和拒绝原因。

分析同时覆盖：

- 正轴与负轴归一化；
- 多个同域 reduction；
- reduction 到算术、数学、条件、广播和 store 的数据流；
- `scf.if`、`scf.for`、`scf.yield` 和 loop-carried value；
- `mem.store` 与 `mem.atomic_add` 等 effect sink；
- 不同输出域、未知布局和不兼容 consumer 的 fail-closed 处理。

### Triton Row-Vector 调度

当 Reduction Domain 满足约束时，Triton 使用 row-vector 调度：

- 一个 Triton program 对应一个 parallel domain 实例；
- `tl.arange()` 覆盖 reduction axis；
- block pointer、value 和 predicate 保持相同向量域；
- 使用 `tl.sum`、`tl.max` 或 `tl.min` 完成归约；
- reduced output 使用 scalar store；
- 广播后的完整 shape output 使用 vector store；
- 支持任意单轴归约，包括 axis 0、末轴和 rank >= 3 的中间轴。

不满足条件时进入明确的 scalar fallback，无法保证语义时直接报错，不生成可疑代码。

### 调优接入

复用现有 `LaunchPlan` 和 AutoTuner，不引入第二套调优系统：

- 默认 `num_warps` 候选为 `4、8、1`；
- `num_stages=1`；
- 用户显式配置仍具有最高优先级；
- `max_num_configs=1` 使用安全的 4-warps 配置；
- winner 继续由现有运行时 benchmark 和缓存机制管理。

### 后端隔离

Row-vector value semantics 仅由 Triton 后端消费。CUDA 和 TileLang 保持原有 lowering 行为，后续 PR 再做更新。


## 正确性覆盖

新增测试集中覆盖以下高价值场景：

- Reduction Domain 的 axis、shape 和同域多归约分析；
- `sum/max/min` 生成；
- Softmax 和 LayerNorm 形式的通用 SSA 数据流；
- axis 0、末轴及 rank-3 中间轴归约；
- 非二次幂 reduction extent；
- 动态 shape、stride 和非连续输入；
- 不兼容广播及不同输出域的 fail-closed；
- tuning candidate 传播和显式配置优先级。

没有为每个内部 helper 增加独立测试，测试主要保持在 IR 契约、生成源码和公共执行路径三个层次。

## 测试结果

三个后端分别执行完整并行测试：

| 默认后端 | 结果 |
|---|---:|
| Triton | 385 passed, 2 skipped |
| CUDA | 385 passed, 2 skipped |
| TileLang | 385 passed, 2 skipped |

两个 skip 均为已有的多 GPU 测试，当前测试服务器只有一张 GPU：

- AOT multi-device test
- Triton multi-context reload test


## 性能结果

测试平台为 NVIDIA L20。基准为历史 master：

`c9ebd4950a185beed8d4c1db9ff4a1fd133934ae`

覆盖：

- Softmax：`4096 × {128, 256, 512, 1024, 2048, 4096}`
- LayerNorm：`4096 × {128, 256, 512, 1024, 2048, 4096}`
- Held-out width：`127、781、1127、4097`

共 12 个主性能点和 8 个 held-out 点，全部数值正确。

下表中的比值为：

`本 PR 延迟 / 历史 master 延迟`

因此小于 1 表示本 PR 更快。

| 指标 | 结果 |
|---|---:|
| 12 个主性能点延迟比几何平均 | 0.9659× |
| 相对历史 master 的整体提升 | 约 3.4% |
| 最差单点延迟比 | 1.0029× |
| 最差单点回归 | 约 0.29% |


所有主测试点均不超过历史 master 10%，整体性能优于历史 master。

## 改动范围


本 PR 只完成通用 Reduction Domain 和 Triton row-vector 物化。CUDA、TileLang 的并行归约物化与后端专属性能优化将通过后续独立 PR 完成。