### PR TITLE
Fix SSA dtype and scalar load masks

### DIFF
--- a/src/ninetoothed/backends/emitters/ssa.py
+++ b/src/ninetoothed/backends/emitters/ssa.py
@@ -749,7 +749,7 @@ def _emit_operation(op: ssa.Operation, ctx: _EmitContext) -> None:
         store_index = _materialize_index_expr(store_index, ctx)
 
         if op.attrs.get("source"):
-            mask = _source_bounds_mask(info, rendered, ctx)
+            mask = _source_bounds_mask(info, rendered, base_mask=ctx.mask_expr)
         else:
             mask = _store_mask(
                 ctx.target,
@@ -1631,7 +1631,7 @@ def _load_tensor_at(
     source_index = _materialize_index_expr(source_index, ctx)
     mask = _combined_mask(
         ctx.target,
-        ctx.mask_expr if ctx.target.vector_value_semantics else None,
+        _load_base_mask(source_index, ctx),
         info,
         view_index,
         ctx=ctx,
@@ -2033,14 +2033,14 @@ def _emit_scf_for(local: str, op: ssa.Operation, ctx: _EmitContext) -> str | Non
             and ctx.mask_expr is not None
             and ctx.target.needs_block_init(initial_name, value, ctx)
         ):
-            dtype = _normalize_dtype(value.type.dtype or "float32")
+            dtype = _loop_initializer_dtype(initial_name, value, ctx)
             init = ctx.target.vector_splat("(BLOCK,)", init, dtype)
         elif (
             ctx.target.vector_value_semantics
             and ctx.block_program
             and ctx.target.needs_block_init(initial_name, value, ctx)
         ):
-            dtype = _normalize_dtype(value.type.dtype or "float32")
+            dtype = _loop_initializer_dtype(initial_name, value, ctx)
             shape = ctx.target.block_shape(tuple(str(dim) for dim in value.type.shape))
             init = ctx.target.vector_splat(shape, init, dtype)
 
@@ -2108,6 +2108,32 @@ def _emit_scf_for(local: str, op: ssa.Operation, ctx: _EmitContext) -> str | Non
     if ctx.target.c_style_syntax:
         ctx.lines.append("}")
     return ctx.memo.get(result_names[0]) if result_names else None
+
+
+def _loop_initializer_dtype(
+    initial_name: str, value: ssa.Value, ctx: _EmitContext
+) -> str:
+    producer = ctx.operations.get(initial_name)
+
+    if producer is not None and producer.opcode in {
+        "tensor.zeros",
+        "tensor.empty",
+        "tensor.full",
+    }:
+        dtype_ref = producer.attrs.get("dtype_ref")
+
+        if isinstance(dtype_ref, str):
+            info = ctx.tensor_infos.get(dtype_ref)
+
+            if info is not None and info.ndim > 0:
+                return f"{dtype_ref}.dtype"
+            return value.type.dtype or "float32"
+
+        dtype = producer.attrs.get("dtype")
+
+        if isinstance(dtype, str) and dtype:
+            return dtype
+    return value.type.dtype or "float32"
 
 
 def _emit_loop_bound(name: str, ctx: _EmitContext) -> str:
@@ -2412,19 +2438,9 @@ def _load_tensor(name: str, view_index: str, ctx: _EmitContext) -> str:
         _source_index_for_value(info, view_index, ctx, level=_dtype_level(name, ctx)),
     )
     source_index = _materialize_index_expr(source_index, ctx)
-    base_mask = ctx.mask_expr if ctx.target.vector_value_semantics else None
-
-    if (
-        ctx.target.vector_value_semantics
-        and base_mask is not None
-        and ctx.target.index_name not in source_index
-        and "offsets" not in source_index
-    ):
-        base_mask = None
-
     mask = _combined_mask(
         ctx.target,
-        base_mask,
+        _load_base_mask(source_index, ctx),
         info,
         view_index,
         ctx=ctx,
@@ -2433,10 +2449,30 @@ def _load_tensor(name: str, view_index: str, ctx: _EmitContext) -> str:
     return _masked_load(name, source_index, mask, info, ctx)
 
 
+def _load_base_mask(source_index: str, ctx: _EmitContext) -> str | None:
+    if not ctx.target.vector_value_semantics:
+        return None
+
+    mask = ctx.mask_expr
+
+    if (
+        mask is not None
+        and ctx.target.index_name not in source_index
+        and "offsets" not in source_index
+    ):
+        return None
+    return mask
+
+
 def _load_source_tensor(name: str, indices: tuple[str, ...], ctx: _EmitContext) -> str:
     info = ctx.tensor_infos.get(name)
     source_index = _target_index_expr(ctx.target, _source_linear_index(info, indices))
-    mask = _source_bounds_mask(info, indices, ctx)
+    base_mask = (
+        _load_base_mask(source_index, ctx)
+        if ctx.target.vector_value_semantics
+        else ctx.mask_expr
+    )
+    mask = _source_bounds_mask(info, indices, base_mask=base_mask)
 
     return _masked_load(name, source_index, mask, info, ctx)
 
@@ -2454,12 +2490,15 @@ def _source_linear_index(info: _TensorInfo | None, indices: tuple[str, ...]) -> 
 
 
 def _source_bounds_mask(
-    info: _TensorInfo | None, indices: tuple[str, ...], ctx: _EmitContext
+    info: _TensorInfo | None,
+    indices: tuple[str, ...],
+    *,
+    base_mask: str | None,
 ) -> str | None:
     checks = []
 
-    if ctx.mask_expr:
-        checks.append(ctx.mask_expr)
+    if base_mask:
+        checks.append(base_mask)
 
     shape = () if info is None else info.source_shape
 

--- a/src/ninetoothed/backends/emitters/ssa.py
+++ b/src/ninetoothed/backends/emitters/ssa.py
@@ -2455,13 +2455,19 @@ def _load_base_mask(source_index: str, ctx: _EmitContext) -> str | None:
 
     mask = ctx.mask_expr
 
-    if (
-        mask is not None
-        and ctx.target.index_name not in source_index
-        and "offsets" not in source_index
-    ):
+    if mask is None or not _index_expr_is_vector(source_index, ctx):
         return None
     return mask
+
+
+def _index_expr_is_vector(source_index: str, ctx: _EmitContext) -> bool:
+    symbols = set(re.findall(r"\b[A-Za-z_][A-Za-z0-9_]*\b", source_index))
+
+    return bool(
+        ctx.target.index_name in symbols
+        or "offsets" in symbols
+        or "tl.arange(" in source_index
+    )
 
 
 def _load_source_tensor(name: str, indices: tuple[str, ...], ctx: _EmitContext) -> str:

--- a/src/ninetoothed/backends/emitters/triton.py
+++ b/src/ninetoothed/backends/emitters/triton.py
@@ -1,6 +1,7 @@
 """Triton syntax hooks for the common SSA emitter."""
 
 import math
+import re
 from dataclasses import dataclass
 from typing import Any
 
@@ -25,7 +26,16 @@ class TritonTarget(EmitterTarget):
         return f"tl.{operator}({operand}, axis={axis})"
 
     def vector_splat(self, shape: str, value: str, dtype: str) -> str:
-        return f"tl.full({shape}, {value}, tl.{common.normalize_dtype(dtype)})"
+        match = re.fullmatch(
+            r"([A-Za-z_][A-Za-z0-9_]*)(?:\.source)?\.dtype", dtype.strip()
+        )
+        dtype_expr = (
+            f"{match.group(1)}.dtype.element_ty"
+            if match is not None
+            else f"tl.{common.normalize_dtype(dtype)}"
+        )
+
+        return f"tl.full({shape}, {value}, {dtype_expr})"
 
     def literal(self, value: Any) -> str:
         if isinstance(value, float) and math.isinf(value):

--- a/src/ninetoothed/frontend/python.py
+++ b/src/ninetoothed/frontend/python.py
@@ -427,6 +427,7 @@ class _ApplicationSSABuilder:
         self.outputs: list[ssa.Value] = []
         self.operations: list[ssa.Operation] = []
         self.env: dict[str, ssa.Value] = {}
+        self.constructor_dtype_refs: dict[str, str] = {}
         self.temp_index = 0
         self.symbol_names = {
             name
@@ -1149,33 +1150,44 @@ class _ApplicationSSABuilder:
             else ()
         )
         dtype = _keyword_text(node, "dtype")
+        result_dtype, dtype_ref = _resolved_constructor_dtype(
+            node, env, self.constructor_dtype_refs
+        )
 
         if name in {"zeros", "empty"}:
-            return self._emit(
+            result = self._emit(
                 operations,
                 "tensor.zeros",
                 attrs={
                     "shape": _unparse(node.args[0]) if node.args else None,
                     "dtype": dtype,
+                    "dtype_ref": dtype_ref,
                 },
-                result_type=ssa.Type(kind="tensor", shape=shape, dtype=dtype),
+                result_type=ssa.Type(kind="tensor", shape=shape, dtype=result_dtype),
+            )
+        else:
+            operands = tuple(
+                self._lower_expr(argument, operations, env)
+                for argument in node.args[1:]
+            )
+            result = self._emit(
+                operations,
+                "tensor.full",
+                operands=tuple(value.name for value in operands),
+                attrs={
+                    "shape": _unparse(node.args[0]) if node.args else None,
+                    "value": (
+                        _literal_value(node.args[1]) if len(node.args) > 1 else None
+                    ),
+                    "dtype": dtype,
+                    "dtype_ref": dtype_ref,
+                },
+                result_type=ssa.Type(kind="tensor", shape=shape, dtype=result_dtype),
             )
 
-        operands = tuple(
-            self._lower_expr(argument, operations, env) for argument in node.args[1:]
-        )
-
-        return self._emit(
-            operations,
-            "tensor.full",
-            operands=tuple(value.name for value in operands),
-            attrs={
-                "shape": _unparse(node.args[0]) if node.args else None,
-                "value": _literal_value(node.args[1]) if len(node.args) > 1 else None,
-                "dtype": dtype,
-            },
-            result_type=ssa.Type(kind="tensor", shape=shape, dtype=dtype),
-        )
+        if dtype_ref is not None:
+            self.constructor_dtype_refs[result.name] = dtype_ref
+        return result
 
     def _lower_memory_call(self, name, node, operands, operations):
         if name == "load":
@@ -1739,6 +1751,32 @@ def _keyword_text(node: ast.Call, name: str) -> str | None:
         if keyword.arg == name:
             return _unparse(keyword.value)
     return None
+
+
+def _resolved_constructor_dtype(
+    node: ast.Call,
+    env: Mapping[str, ssa.Value],
+    constructor_dtype_refs: Mapping[str, str],
+) -> tuple[str | None, str | None]:
+    for keyword in node.keywords:
+        if keyword.arg != "dtype":
+            continue
+
+        value = keyword.value
+
+        if isinstance(value, ast.Attribute) and value.attr == "dtype":
+            owner = value.value
+
+            if isinstance(owner, ast.Attribute) and owner.attr == "source":
+                owner = owner.value
+
+            if isinstance(owner, ast.Name) and owner.id in env:
+                source = env[owner.id]
+                dtype_ref = constructor_dtype_refs.get(source.name, source.name)
+
+                return source.type.dtype or "float32", dtype_ref
+        return _unparse(value), None
+    return None, None
 
 
 def _literal_value(node: ast.AST) -> Any:

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -171,7 +171,7 @@ def test_non_int_constexpr(size, device):
 
 
 @pytest.mark.parametrize("device", get_available_devices())
-def test_puzzle_row_sum_ssa_compatibility(device):
+def test_loop_carried_row_sum_with_tensor_dtype(device):
     block_size = ninetoothed.Symbol("block_size", constexpr=True)
 
     def arrangement(x, y, block_size=block_size):

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 import ninetoothed
+import ninetoothed.language as ntl
 import tests.test_matmul as matmul
 from ninetoothed import Tensor
 from tests.utils import get_available_devices
@@ -167,3 +168,31 @@ def test_non_int_constexpr(size, device):
     kernel(input, other, output)
 
     assert output.shape == expected.shape and torch.allclose(output, expected)
+
+
+@pytest.mark.parametrize("device", get_available_devices())
+def test_puzzle_row_sum_ssa_compatibility(device):
+    block_size = ninetoothed.Symbol("block_size", constexpr=True)
+
+    def arrangement(x, y, block_size=block_size):
+        x_arranged = x.tile((1, block_size))
+        x_arranged = x_arranged.tile((1, -1))
+        y_arranged = y.tile((1, 1))
+
+        return x_arranged, y_arranged
+
+    def application(x, y):
+        acc = ntl.zeros(y.shape, dtype=y.dtype)
+
+        for i in range(x.shape[1]):
+            acc += ntl.sum(x[0, i], axis=-1)
+
+        y = acc  # noqa: F841
+
+    kernel = ninetoothed.make(arrangement, application, (Tensor(2, other=0), Tensor(2)))
+    x = torch.randn((17, 70), device=device)
+    y = torch.empty((17, 1), device=device)
+
+    kernel(x, y, block_size=64)
+
+    torch.testing.assert_close(y, torch.sum(x, dim=-1, keepdim=True))

--- a/tests/test_ssa_first_backend_lowering.py
+++ b/tests/test_ssa_first_backend_lowering.py
@@ -1,3 +1,5 @@
+import ast
+
 import pytest
 
 import ninetoothed.language as ntl
@@ -69,6 +71,35 @@ def helper_call_application(x, y, out):
     out = fused_affine_helper(x, y, scale=3.0)  # noqa: F841
 
 
+PUZZLE_BLOCK_SIZE = Symbol("PUZZLE_BLOCK_SIZE", constexpr=True)
+
+
+def puzzle_row_sum_arrangement(x, y, block_size=PUZZLE_BLOCK_SIZE):
+    x_arranged = x.tile((1, block_size))
+    x_arranged = x_arranged.tile((1, -1))
+    y_arranged = y.tile((1, 1))
+
+    return x_arranged, y_arranged
+
+
+def puzzle_row_sum_application(x, y):
+    acc = ntl.zeros(y.shape, dtype=y.dtype)
+
+    for i in range(x.shape[1]):
+        acc += ntl.sum(x[0, i], axis=-1)
+
+    y = acc  # noqa: F841
+
+
+def puzzle_row_sum_static_dtype_application(x, y):
+    acc = ntl.zeros(y.shape, dtype=ntl.float32)
+
+    for i in range(x.shape[1]):
+        acc += ntl.sum(x[0, i], axis=-1)
+
+    y = acc  # noqa: F841
+
+
 def _ssa_kernel(
     source: str, kernel_name: str, tensors: tuple[TensorSpec, ...]
 ) -> Kernel:
@@ -88,6 +119,22 @@ def _ssa_kernel(
 def _assert_ssa_artifact(artifact, *, route):
     assert artifact.metadata["lowering_ir"] == "ssa.Program"
     assert artifact.metadata["source_route"] == route
+
+
+def _triton_load_mask(source: str) -> ast.AST | None:
+    load = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "tl"
+        and node.func.attr == "load"
+    )
+
+    return next(
+        (keyword.value for keyword in load.keywords if keyword.arg == "mask"), None
+    )
 
 
 class TestSSAFirstBackendLowering:
@@ -865,6 +912,152 @@ def canonical_math_application(x, y, out):
 
             for source_fragment in source_fragments:
                 assert source_fragment in artifact.primary_source
+
+    def test_constructor_resolves_tensor_dtype_for_loop_carried_values(self):
+        tensors = (Tensor(2, other=0), Tensor(2))
+        artifacts = {
+            backend: lower_application(
+                puzzle_row_sum_arrangement,
+                puzzle_row_sum_application,
+                tensors,
+                backend=backend,
+                kernel_name=f"puzzle_row_sum_{backend}",
+            )
+            for backend in ("triton", "cuda", "tilelang")
+        }
+
+        triton_source = artifacts["triton"].primary_source
+        assert "y.dtype.element_ty" in triton_source
+        assert "tl.dtype" not in triton_source
+        assert "float vacc_" in artifacts["cuda"].primary_source
+        assert 'T.alloc_var("float32"' in artifacts["tilelang"].primary_source
+
+    def test_constructor_canonicalizes_aliased_and_chained_tensor_dtype(self):
+        kernel = _ssa_kernel(
+            """
+def alias_dtype_application(x, y):
+    alias = y
+    first = zeros(y.shape, dtype=alias.dtype)
+    acc = zeros(y.shape, dtype=first.dtype)
+    for _ in range(1):
+        acc += x
+    y = acc
+""",
+            "ssa_alias_dtype",
+            (
+                TensorSpec(ndim=1, shape=("rows",), name="x"),
+                TensorSpec(ndim=1, shape=("rows",), name="y"),
+            ),
+        )
+        artifact = emit_kernel(kernel, "triton")
+        source = artifact.primary_source
+        assert "y.dtype.element_ty" in source
+        assert "alias.dtype" not in source
+
+    def test_constructor_uses_static_dtype_for_scalar_dtype_source(self):
+        kernel = _ssa_kernel(
+            """
+def scalar_dtype_application(x, y, dtype_arg):
+    acc = zeros(y.shape, dtype=dtype_arg.dtype)
+    for _ in range(1):
+        acc += x
+    y = acc
+""",
+            "ssa_scalar_dtype",
+            (
+                TensorSpec(ndim=1, shape=("rows",), dtype="float16", name="x"),
+                TensorSpec(ndim=1, shape=("rows",), dtype="float16", name="y"),
+                TensorSpec(ndim=0, shape=(), dtype="float16", name="dtype_arg"),
+            ),
+        )
+        artifact = emit_kernel(kernel, "triton")
+        source = artifact.primary_source
+        assert "tl.float16" in source
+        assert "dtype_arg.dtype.element_ty" not in source
+
+    def test_constructor_does_not_propagate_dtype_ref_through_promotion(self):
+        kernel = _ssa_kernel(
+            """
+def promoted_dtype_application(x, y):
+    first = zeros(y.shape, dtype=y.dtype)
+    promoted = first + 0.5
+    acc = zeros(y.shape, dtype=promoted.dtype)
+    for _ in range(1):
+        acc += x
+    y = acc
+""",
+            "ssa_promoted_dtype",
+            (
+                TensorSpec(ndim=1, shape=("rows",), dtype="int32", name="x"),
+                TensorSpec(ndim=1, shape=("rows",), dtype="int32", name="y"),
+            ),
+        )
+        artifact = emit_kernel(kernel, "triton")
+        source = artifact.primary_source
+        assert "tl.float32" in source
+        assert "y.dtype.element_ty" not in source
+
+    def test_constructor_propagates_dtype_ref_into_nested_region(self):
+        kernel = _ssa_kernel(
+            """
+def nested_dtype_application(x, y):
+    first = zeros(y.shape, dtype=y.dtype)
+    acc = zeros(y.shape, dtype=y.dtype)
+    for i in range(1):
+        inner = zeros(y.shape, dtype=first.dtype)
+        for j in range(1):
+            inner += x
+        acc += inner
+    y = acc
+""",
+            "ssa_nested_dtype",
+            (
+                TensorSpec(ndim=1, shape=("rows",), name="x"),
+                TensorSpec(ndim=1, shape=("rows",), name="y"),
+            ),
+        )
+        source = emit_kernel(kernel, "triton").primary_source
+        assert source.count("y.dtype.element_ty") >= 2
+        assert "tl.dtype" not in source
+
+    def test_scalar_tensor_extract_load_drops_vector_mask(self):
+        artifact = lower_application(
+            puzzle_row_sum_arrangement,
+            puzzle_row_sum_static_dtype_application,
+            (Tensor(2, other=0), Tensor(2)),
+            backend="triton",
+            kernel_name="puzzle_row_sum_scalar_load",
+        )
+        mask = _triton_load_mask(artifact.primary_source)
+        assert mask is not None
+        assert not any(
+            isinstance(node, ast.Name) and node.id == "mask" for node in ast.walk(mask)
+        )
+
+    def test_scalar_source_load_drops_vector_mask(self):
+        kernel = _ssa_kernel(
+            """
+def scalar_source_load_application(x, index, y):
+    y = x.source[index]
+""",
+            "ssa_scalar_source_load",
+            (
+                TensorSpec(
+                    ndim=1,
+                    shape=("rows",),
+                    dtype="float32",
+                    name="x",
+                    attrs={"source_shape": ("rows",), "source_strides": ("1",)},
+                ),
+                TensorSpec(ndim=0, shape=(), dtype="int64", name="index"),
+                TensorSpec(ndim=1, shape=("rows",), dtype="float32", name="y"),
+            ),
+        )
+        mask = _triton_load_mask(emit_kernel(kernel, "triton").primary_source)
+        assert mask is not None
+        assert not any(
+            isinstance(node, ast.Name) and node.id == "mask" for node in ast.walk(mask)
+        )
 
     def test_from_source_generates_axis_reduction_for_native_backends(self):
         kernel = _ssa_kernel(

--- a/tests/test_ssa_first_backend_lowering.py
+++ b/tests/test_ssa_first_backend_lowering.py
@@ -121,7 +121,7 @@ def _assert_ssa_artifact(artifact, *, route):
     assert artifact.metadata["source_route"] == route
 
 
-def _triton_load_mask(source: str) -> ast.AST | None:
+def _triton_load_mask(source: str, *, tensor: str | None = None) -> ast.AST | None:
     load = next(
         node
         for node in ast.walk(ast.parse(source))
@@ -130,6 +130,16 @@ def _triton_load_mask(source: str) -> ast.AST | None:
         and isinstance(node.func.value, ast.Name)
         and node.func.value.id == "tl"
         and node.func.attr == "load"
+        and (
+            tensor is None
+            or (
+                node.args
+                and any(
+                    isinstance(argument, ast.Name) and argument.id == tensor
+                    for argument in ast.walk(node.args[0])
+                )
+            )
+        )
     )
 
     return next(
@@ -1056,6 +1066,47 @@ def scalar_source_load_application(x, index, y):
         mask = _triton_load_mask(emit_kernel(kernel, "triton").primary_source)
         assert mask is not None
         assert not any(
+            isinstance(node, ast.Name) and node.id == "mask" for node in ast.walk(mask)
+        )
+
+    def test_scalar_index_name_drops_vector_mask(self):
+        kernel = _ssa_kernel(
+            """
+def scalar_index_application(x, index_arg, y):
+    y = x[index_arg]
+""",
+            "ssa_scalar_index",
+            (
+                TensorSpec(ndim=1, shape=("rows",), dtype="float32", name="x"),
+                TensorSpec(ndim=0, shape=(), dtype="int64", name="index_arg"),
+                TensorSpec(ndim=1, shape=("rows",), dtype="float32", name="y"),
+            ),
+        )
+        mask = _triton_load_mask(
+            emit_kernel(kernel, "triton").primary_source, tensor="x"
+        )
+        assert mask is None or not any(
+            isinstance(node, ast.Name) and node.id == "mask" for node in ast.walk(mask)
+        )
+
+    def test_scalarized_vector_index_drops_vector_mask(self):
+        kernel = _ssa_kernel(
+            """
+def scalarized_index_application(x, indices, y):
+    index_value = indices - 1
+    y = sum(x[index_value], axis=0)
+""",
+            "ssa_scalarized_index",
+            (
+                TensorSpec(ndim=1, shape=("rows",), dtype="float32", name="x"),
+                TensorSpec(ndim=1, shape=("rows",), dtype="int64", name="indices"),
+                TensorSpec(ndim=0, shape=(), dtype="float32", name="y"),
+            ),
+        )
+        mask = _triton_load_mask(
+            emit_kernel(kernel, "triton").primary_source, tensor="x"
+        )
+        assert mask is None or not any(
             isinstance(node, ast.Name) and node.id == "mask" for node in ast.walk(mask)
         )
 

--- a/tests/test_ssa_first_backend_lowering.py
+++ b/tests/test_ssa_first_backend_lowering.py
@@ -71,10 +71,10 @@ def helper_call_application(x, y, out):
     out = fused_affine_helper(x, y, scale=3.0)  # noqa: F841
 
 
-PUZZLE_BLOCK_SIZE = Symbol("PUZZLE_BLOCK_SIZE", constexpr=True)
+ROW_SUM_BLOCK_SIZE = Symbol("ROW_SUM_BLOCK_SIZE", constexpr=True)
 
 
-def puzzle_row_sum_arrangement(x, y, block_size=PUZZLE_BLOCK_SIZE):
+def row_sum_arrangement(x, y, block_size=ROW_SUM_BLOCK_SIZE):
     x_arranged = x.tile((1, block_size))
     x_arranged = x_arranged.tile((1, -1))
     y_arranged = y.tile((1, 1))
@@ -82,7 +82,7 @@ def puzzle_row_sum_arrangement(x, y, block_size=PUZZLE_BLOCK_SIZE):
     return x_arranged, y_arranged
 
 
-def puzzle_row_sum_application(x, y):
+def row_sum_application(x, y):
     acc = ntl.zeros(y.shape, dtype=y.dtype)
 
     for i in range(x.shape[1]):
@@ -91,7 +91,7 @@ def puzzle_row_sum_application(x, y):
     y = acc  # noqa: F841
 
 
-def puzzle_row_sum_static_dtype_application(x, y):
+def row_sum_static_dtype_application(x, y):
     acc = ntl.zeros(y.shape, dtype=ntl.float32)
 
     for i in range(x.shape[1]):
@@ -927,11 +927,11 @@ def canonical_math_application(x, y, out):
         tensors = (Tensor(2, other=0), Tensor(2))
         artifacts = {
             backend: lower_application(
-                puzzle_row_sum_arrangement,
-                puzzle_row_sum_application,
+                row_sum_arrangement,
+                row_sum_application,
                 tensors,
                 backend=backend,
-                kernel_name=f"puzzle_row_sum_{backend}",
+                kernel_name=f"row_sum_{backend}",
             )
             for backend in ("triton", "cuda", "tilelang")
         }
@@ -1032,11 +1032,11 @@ def nested_dtype_application(x, y):
 
     def test_scalar_tensor_extract_load_drops_vector_mask(self):
         artifact = lower_application(
-            puzzle_row_sum_arrangement,
-            puzzle_row_sum_static_dtype_application,
+            row_sum_arrangement,
+            row_sum_static_dtype_application,
             (Tensor(2, other=0), Tensor(2)),
             backend="triton",
-            kernel_name="puzzle_row_sum_scalar_load",
+            kernel_name="row_sum_scalar_load",
         )
         mask = _triton_load_mask(artifact.primary_source)
         assert mask is not None


### PR DESCRIPTION
## Summary

- Preserve static constructor dtype information while retaining canonical tensor dtype provenance for Triton lowering.
- Emit runtime pointer element types for loop-carried splats and keep scalar dtype sources and promotion results static.
- Classify Triton load addresses by explicit vector lane roots so scalar-address loads drop block masks without treating names such as `index_arg` as vector values.
- Add lowering regressions and an end-to-end loop-carried row-sum GPU case covering tensor-derived dtypes and scalar-address loads.

## Root cause

The SSA frontend stored `y.dtype` as a literal result dtype. Normalization reduced it to `dtype`, so Triton emitted `tl.dtype`. Once that was corrected, extracted scalar loads still inherited the vector program mask, which Triton rejects for scalar pointers.

## Validation

- `ruff check`
- `ruff format --check`
- `python scripts/check_contributing_style.py`
- `pytest --noconftest -q tests/test_ssa_application_lowering.py tests/test_ssa_first_backend_lowering.py`
- NVIDIA A100 on implementation commit `8db92900`, before the naming-only follow-up: loop-carried row-sum end-to-end regression

`pytest` output:

```text
.......................................                                  [100%]
39 passed in 1.95s

NVIDIA A100 on implementation commit 8db92900 before the naming-only follow-up:
.                                                                        [100%]
1 passed in 4.83s
```
