### PR TITLE
Optimize Triton layout transfers

### DIFF
--- a/src/ninetoothed/backends/emitters/base.py
+++ b/src/ninetoothed/backends/emitters/base.py
@@ -1,7 +1,7 @@
 """Contracts shared by SSA backend source emitters."""
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Mapping
 
 from ninetoothed.backends.core import Target
@@ -28,6 +28,8 @@ class ModuleRenderContext:
     vector_program: bool
     block_program: bool
     scalar_program: bool
+    private_meta_parameters: tuple[tuple[str, int], ...] = ()
+    scheduled_metadata: Mapping[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -142,6 +144,9 @@ class EmitterTarget(ABC):
         del mutable
 
         return f"{name} = {value}"
+
+    def schedule_context(self, context: ModuleRenderContext) -> ModuleRenderContext:
+        return context
 
     @abstractmethod
     def literal(self, value: Any) -> str: ...

--- a/src/ninetoothed/backends/emitters/ssa.py
+++ b/src/ninetoothed/backends/emitters/ssa.py
@@ -158,6 +158,9 @@ def emit(kernel: Kernel, target: EmitterTarget) -> Artifact:
         "ssa_metadata": dict(kernel.ssa.metadata),
         "ssa_pass_trace": tuple(kernel.ssa.metadata.get("pass_trace", ())),
         "ssa_schedule": dict(kernel.ssa.metadata.get("schedule", {})),
+        "ssa_schedule_candidates": tuple(
+            kernel.ssa.metadata.get("schedule_candidates", ())
+        ),
         "ssa_pipeline_selection": dict(
             kernel.ssa.metadata.get("pipeline_selection", {})
         ),
@@ -172,6 +175,8 @@ def emit(kernel: Kernel, target: EmitterTarget) -> Artifact:
         },
         "vector_numel_limit": target.max_vector_numel,
     }
+
+    metadata.update(dict(render_context.scheduled_metadata))
 
     return Artifact(
         backend=backend,
@@ -502,6 +507,7 @@ def _render_source(
         ),
         scalar_program=vector_scalar_program,
     )
+    context = target.schedule_context(context)
 
     return target.render_module(context), context
 

--- a/src/ninetoothed/backends/emitters/triton.py
+++ b/src/ninetoothed/backends/emitters/triton.py
@@ -9,7 +9,7 @@ from ninetoothed.backends.core import Target
 from ninetoothed.backends.emitters import ssa as common
 from ninetoothed.backends.emitters.base import EmitterTarget, ModuleRenderContext
 from ninetoothed.backends.emitters.expressions import replace_symbols
-from ninetoothed.compiler.layout import LayoutTransfer
+from ninetoothed.compiler.layout import LayoutTransfer, serialize_layout_transfer
 from ninetoothed.ir import Kernel, ssa
 from ninetoothed.naming import is_meta
 
@@ -352,33 +352,12 @@ class TritonTarget(EmitterTarget):
             )
         )
         metadata = {
-            "layout_transfer": {
-                "source_binding": transfer.source_binding,
-                "destination_binding": transfer.destination_binding,
-                "permutation": transfer.permutation,
-                "requires_tiling": transfer.requires_tiling,
+            "layout_transfer": serialize_layout_transfer(transfer)
+            | {
                 "block_shape": (
                     ("TILE_M", "TILE_N")
                     if transfer.requires_tiling
                     else tuple(value.render() for value in value_shape)
-                ),
-                "value_constraints": tuple(
-                    (
-                        tuple(value.render() for value in actual),
-                        tuple(value.render() for value in expected),
-                    )
-                    for actual, expected in transfer.value_constraints
-                ),
-                "physical_constraints": tuple(
-                    (left.render(), right.render())
-                    for left, right in transfer.physical_constraints
-                ),
-                "program_constraints": tuple(
-                    (
-                        tuple(value.render() for value in actual),
-                        tuple(value.render() for value in expected),
-                    )
-                    for actual, expected in transfer.program_constraints
                 ),
                 "private_meta_parameters": tuple(name for name, _value in private_meta),
             }

--- a/src/ninetoothed/backends/emitters/triton.py
+++ b/src/ninetoothed/backends/emitters/triton.py
@@ -2,13 +2,46 @@
 
 import math
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 from ninetoothed.backends.core import Target
 from ninetoothed.backends.emitters import ssa as common
 from ninetoothed.backends.emitters.base import EmitterTarget, ModuleRenderContext
+from ninetoothed.backends.emitters.expressions import replace_symbols
+from ninetoothed.compiler.layout import LayoutTransfer
 from ninetoothed.ir import Kernel, ssa
+from ninetoothed.naming import is_meta
+
+
+def _legal_pre_tiled_block(shape, *, max_numel):
+    static_numel = 1
+
+    for extent in shape:
+        if extent.op == "constant":
+            value = int(extent.value)
+
+            if value <= 0 or value & (value - 1):
+                return False
+
+            static_numel *= value
+            continue
+
+        symbols = _index_symbols(extent)
+
+        if not symbols or any(not is_meta(symbol) for symbol in symbols):
+            return False
+
+    return max_numel is None or static_numel <= max_numel
+
+
+def _index_symbols(expression):
+    if expression.op == "symbol":
+        return frozenset({str(expression.value)})
+
+    return frozenset().union(
+        *(_index_symbols(operand) for operand in expression.operands)
+    )
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -200,10 +233,176 @@ class TritonTarget(EmitterTarget):
             "tensor.full",
         }
 
+    def schedule_context(self, context: ModuleRenderContext) -> ModuleRenderContext:
+        program = context.kernel.ssa
+        schedule = program.metadata.get("schedule", {}) if program is not None else {}
+        transfer = schedule.get("layout_transfer")
+
+        if (
+            schedule.get("granularity") != "layout-transfer"
+            or not isinstance(transfer, LayoutTransfer)
+            or not transfer.schedulable
+        ):
+            return context
+
+        value_shape = (
+            transfer.source.layout.application_shape
+            if transfer.requires_tiling
+            else transfer.destination.layout.application_shape
+        )
+
+        if len(value_shape) != 2:
+            return context
+
+        if not transfer.requires_tiling and not _legal_pre_tiled_block(
+            value_shape,
+            max_numel=self.max_vector_numel,
+        ):
+            return context
+
+        rows, columns = (_render_index_expr(value) for value in value_shape)
+        program_shape = tuple(
+            _render_index_expr(value)
+            for value in transfer.destination.layout.view_shape
+        )
+        private_meta: tuple[tuple[str, int], ...] = ()
+        lines = ["transfer_program = tl.program_id(0)"]
+
+        if transfer.requires_tiling:
+            tile = dict(schedule.get("tile", {}))
+            tile_m = int(tile.get("block_m", 16))
+            tile_n = int(tile.get("block_n", 16))
+            private_meta = (("TILE_M", tile_m), ("TILE_N", tile_n))
+            lines.extend(
+                (
+                    f"transfer_tile_columns = ({columns} + TILE_N - 1) // TILE_N",
+                    "transfer_tile_row = transfer_program // transfer_tile_columns",
+                    "transfer_tile_column = transfer_program % transfer_tile_columns",
+                    "destination_value_0 = transfer_tile_row * TILE_M + "
+                    "tl.arange(0, TILE_M)[:, None]",
+                    "destination_value_1 = transfer_tile_column * TILE_N + "
+                    "tl.arange(0, TILE_N)[None, :]",
+                    "source_value_0 = transfer_tile_row * TILE_M + "
+                    "tl.arange(0, TILE_M)[None, :]",
+                    "source_value_1 = transfer_tile_column * TILE_N + "
+                    "tl.arange(0, TILE_N)[:, None]",
+                )
+            )
+            grid_total = (
+                f"(({rows} + _ninetoothed_tile_m - 1) // "
+                f"_ninetoothed_tile_m) * (({columns} + "
+                "_ninetoothed_tile_n - 1) // _ninetoothed_tile_n)"
+            )
+        else:
+            lines.extend(
+                (
+                    f"destination_value_0 = tl.arange(0, {rows})[:, None]",
+                    f"destination_value_1 = tl.arange(0, {columns})[None, :]",
+                    f"source_value_0 = tl.arange(0, {rows})[None, :]",
+                    f"source_value_1 = tl.arange(0, {columns})[:, None]",
+                )
+            )
+            grid_total = common.product(program_shape)
+
+        destination_flat = f"(destination_value_0 * ({columns}) + destination_value_1)"
+        source_flat = f"(source_value_0 * ({columns}) + source_value_1)"
+        source_replacements = {
+            "outer_index": "transfer_program",
+            "index": source_flat,
+            "value_0": "source_value_0",
+            "value_1": "source_value_1",
+        }
+        destination_replacements = {
+            "outer_index": "transfer_program",
+            "index": destination_flat,
+            "value_0": "destination_value_0",
+            "value_1": "destination_value_1",
+        }
+        source_index = _render_access_expression(
+            transfer.source.access_map.linear_index, source_replacements
+        )
+        destination_index = _render_access_expression(
+            transfer.destination.access_map.linear_index,
+            destination_replacements,
+        )
+        source_predicate = _render_access_expression(
+            transfer.source.access_map.predicate, source_replacements
+        )
+        destination_predicate = _render_access_expression(
+            transfer.destination.access_map.predicate, destination_replacements
+        )
+        source_mask = (
+            f"({source_predicate}) & (source_value_0 < ({rows})) & "
+            f"(source_value_1 < ({columns}))"
+        )
+        destination_mask = (
+            f"({destination_predicate}) & (destination_value_0 < ({rows})) & "
+            f"(destination_value_1 < ({columns}))"
+        )
+        lines.extend(
+            (
+                f"transfer_value = {self.load(transfer.source_binding, source_index, mask=source_mask)}",
+                "transfer_value = tl.trans(transfer_value)",
+                self.store(
+                    transfer.destination_binding,
+                    destination_index,
+                    "transfer_value",
+                    mask=destination_mask,
+                ),
+            )
+        )
+        metadata = {
+            "layout_transfer": {
+                "source_binding": transfer.source_binding,
+                "destination_binding": transfer.destination_binding,
+                "permutation": transfer.permutation,
+                "requires_tiling": transfer.requires_tiling,
+                "block_shape": (
+                    ("TILE_M", "TILE_N")
+                    if transfer.requires_tiling
+                    else tuple(value.render() for value in value_shape)
+                ),
+                "value_constraints": tuple(
+                    (
+                        tuple(value.render() for value in actual),
+                        tuple(value.render() for value in expected),
+                    )
+                    for actual, expected in transfer.value_constraints
+                ),
+                "physical_constraints": tuple(
+                    (left.render(), right.render())
+                    for left, right in transfer.physical_constraints
+                ),
+                "program_constraints": tuple(
+                    (
+                        tuple(value.render() for value in actual),
+                        tuple(value.render() for value in expected),
+                    )
+                    for actual, expected in transfer.program_constraints
+                ),
+                "private_meta_parameters": tuple(name for name, _value in private_meta),
+            }
+        }
+
+        return replace(
+            context,
+            total=common.product((rows, columns)),
+            body="\n".join(lines),
+            outer_axes=program_shape,
+            grid_total=grid_total,
+            axes=(rows, columns),
+            vector_program=False,
+            block_program=True,
+            scalar_program=False,
+            private_meta_parameters=private_meta,
+            scheduled_metadata=metadata,
+        )
+
     def render_module(self, context: ModuleRenderContext) -> str:
         kernel = context.kernel
         body = common.rewrite_index_math(context.body, c_style=False)
         runtime_params = set(kernel.metadata.get("runtime_shape_params", ()))
+        private_meta = tuple(context.private_meta_parameters)
         params = ",\n    ".join(
             (
                 *context.variables,
@@ -212,6 +411,7 @@ class TritonTarget(EmitterTarget):
                     axis if axis in runtime_params else f"{axis}: tl.constexpr"
                     for axis in context.shape_params
                 ],
+                *[f"{name}: tl.constexpr" for name, _value in private_meta],
                 "BLOCK: tl.constexpr",
             )
         )
@@ -222,6 +422,9 @@ class TritonTarget(EmitterTarget):
         )
         kernel_args = ",\n        ".join(
             (*context.variables, *context.outputs, *context.shape_params)
+        )
+        private_kernel_args = "\n        ".join(
+            f"{name}=_ninetoothed_{name.lower()}," for name, _value in private_meta
         )
         offsets = (
             "0"
@@ -259,6 +462,10 @@ class TritonTarget(EmitterTarget):
         launch_params = ", ".join(
             (
                 *public_launch_params,
+                *[
+                    f"_ninetoothed_{name.lower()}={value}"
+                    for name, value in private_meta
+                ],
                 f"_ninetoothed_num_warps={num_warps}",
                 f"_ninetoothed_num_stages={num_stages}",
             )
@@ -299,12 +506,24 @@ def launch_{kernel.kernel_name}({launch_params}):
     grid = ({context.grid_total},) if {active_grid!r} else (triton.cdiv({context.grid_total}, block),)
     {kernel.kernel_name}_kernel[grid](
         {kernel_args},
+        {private_kernel_args}
         BLOCK=block,
         num_warps=_ninetoothed_num_warps,
         num_stages=_ninetoothed_num_stages,
     )
     return {result}
 '''
+
+
+def _render_index_expr(expression) -> str:
+    return common.rewrite_index_math(expression.render(), c_style=False)
+
+
+def _render_access_expression(expression, replacements) -> str:
+    return common.rewrite_index_math(
+        replace_symbols(expression.render(), replacements),
+        c_style=False,
+    )
 
 
 TARGET = TritonTarget()

--- a/src/ninetoothed/backends/materializers/triton.py
+++ b/src/ninetoothed/backends/materializers/triton.py
@@ -2,7 +2,6 @@
 
 import ctypes
 import functools
-import math
 import os
 import re
 import shutil
@@ -25,6 +24,11 @@ from ninetoothed.compiler.cache import (
     read_manifest,
     write_manifest,
     write_source,
+)
+from ninetoothed.compiler.layout_runtime import (
+    build_layout_transfer_validator,
+    memory_spans_overlap,
+    tensor_memory_span,
 )
 
 _TRITON_AOT_LAUNCHER_SCHEMA = 1
@@ -73,7 +77,7 @@ class TritonMaterializer(Materializer):
             leave,
             abi,
             specs,
-            validate_bindings=_runtime_layout_transfer_validator(
+            validate_bindings=build_layout_transfer_validator(
                 built.source.metadata,
                 abi,
             ),
@@ -388,56 +392,6 @@ def _triton_prepare_invocation(function, kernel):
     return prepare
 
 
-def _tensor_memory_span(value):
-    try:
-        device = value.device
-    except (AttributeError, RuntimeError, TypeError):
-        device = None
-
-    try:
-        shape = tuple(value.shape)
-
-        if any(size == 0 for size in shape):
-            return (device, 0, 0)
-
-        element_size = value.element_size()
-        data_ptr = value.data_ptr()
-        lower = upper = 0
-
-        for size, stride in zip(shape, value.stride()):
-            extent = (size - 1) * stride
-            lower += min(0, extent)
-            upper += max(0, extent)
-
-        return (
-            device,
-            data_ptr + lower * element_size,
-            data_ptr + (upper + 1) * element_size,
-        )
-    except (AttributeError, RuntimeError, TypeError):
-        return (device, None, None)
-
-
-def _memory_spans_overlap(first, second):
-    first_device, first_start, first_end = first
-    second_device, second_start, second_end = second
-
-    if (
-        first_device is not None
-        and second_device is not None
-        and first_device != second_device
-    ):
-        return False
-
-    if None in (first_start, first_end, second_start, second_end):
-        return True
-
-    if first_start == first_end or second_start == second_end:
-        return False
-
-    return first_start < second_end and second_start < first_end
-
-
 def _runtime_alias_signature(abi, public):
     from ninetoothed.compiler.runtime import _binding_value
 
@@ -479,7 +433,7 @@ def _runtime_alias_signature(abi, public):
             *identity,
             access,
             value,
-            _tensor_memory_span(value),
+            tensor_memory_span(value),
         )
 
     writers = tuple(
@@ -498,7 +452,7 @@ def _runtime_alias_signature(abi, public):
             overlaps = writer is reader
 
             if not overlaps:
-                overlaps = _memory_spans_overlap(writer_span, reader_span)
+                overlaps = memory_spans_overlap(writer_span, reader_span)
 
             if overlaps:
                 aliases.append((writer_name, writer_kind, reader_name, reader_kind))
@@ -741,7 +695,7 @@ def _runtime_binding_validator(compilation):
         validator
         for validator in (
             _runtime_vector_validator(compilation),
-            _runtime_layout_transfer_validator(
+            build_layout_transfer_validator(
                 getattr(compilation.artifact, "metadata", {}),
                 compilation.launch_abi,
             ),
@@ -757,166 +711,6 @@ def _runtime_binding_validator(compilation):
             validator(public)
 
     return validate
-
-
-def _runtime_layout_transfer_validator(metadata, abi):
-    transfer = dict(metadata.get("layout_transfer", {}))
-
-    if not transfer:
-        return None
-
-    import sympy
-
-    permutation = tuple(int(axis) for axis in transfer.get("permutation", ()))
-
-    physical_constraints = tuple(
-        (sympy.sympify(str(left)), sympy.sympify(str(right)))
-        for left, right in transfer.get("physical_constraints", ())
-    )
-    program_constraints = tuple(
-        (
-            tuple(sympy.sympify(str(value)) for value in actual),
-            tuple(sympy.sympify(str(value)) for value in expected),
-        )
-        for actual, expected in transfer.get("program_constraints", ())
-    )
-    value_constraints = tuple(
-        (
-            tuple(sympy.sympify(str(value)) for value in actual),
-            tuple(sympy.sympify(str(value)) for value in expected),
-        )
-        for actual, expected in transfer.get("value_constraints", ())
-    )
-    expressions = (
-        *(expression for pair in physical_constraints for expression in pair),
-        *(
-            expression
-            for constraint in value_constraints
-            for shape in constraint
-            for expression in shape
-        ),
-        *(
-            expression
-            for constraint in program_constraints
-            for shape in constraint
-            for expression in shape
-        ),
-    )
-    bindings = {binding.name: binding for binding in abi.kernel_args}
-
-    try:
-        symbols = tuple(
-            (symbol, bindings[str(symbol)])
-            for symbol in sorted(
-                set().union(*(expression.free_symbols for expression in expressions)),
-                key=str,
-            )
-        )
-        source_binding = bindings[str(transfer["source_binding"])]
-        destination_binding = bindings[str(transfer["destination_binding"])]
-    except KeyError as exc:
-        raise ValueError(
-            f"Serialized Triton layout transfer references unknown binding "
-            f"`{exc.args[0]}`."
-        ) from exc
-
-    from ninetoothed.compiler.runtime import _binding_value
-
-    def validate(public):
-        source = _binding_value(source_binding, public)
-        destination = _binding_value(destination_binding, public)
-
-        if (
-            len(permutation) != len(source.shape)
-            or len(permutation) != len(destination.shape)
-            or set(permutation) != set(range(len(permutation)))
-            or any(
-                source.shape[source_axis] != destination.shape[destination_axis]
-                for destination_axis, source_axis in enumerate(permutation)
-            )
-        ):
-            raise ValueError("Triton layout transfer physical shapes do not match.")
-
-        if not _tensor_has_non_overlapping_strides(destination):
-            raise ValueError(
-                "Triton layout transfer requires non-overlapping destination strides."
-            )
-
-        substitutions = {
-            symbol: _binding_value(binding, public) for symbol, binding in symbols
-        }
-
-        def resolve(expression):
-            resolved = expression.subs(substitutions)
-
-            if resolved.free_symbols:
-                names = ", ".join(sorted(map(str, resolved.free_symbols)))
-                raise ValueError(f"Unresolved Triton layout symbols: {names}.")
-            return int(resolved)
-
-        for left, right in physical_constraints:
-            if resolve(left) != resolve(right):
-                raise ValueError("Triton layout transfer physical shapes do not match.")
-
-        for actual, expected in value_constraints:
-            if len(actual) != len(expected) or any(
-                resolve(left) != resolve(right) for left, right in zip(actual, expected)
-            ):
-                raise ValueError("Triton layout transfer value domains do not match.")
-
-        for actual, expected in program_constraints:
-            if len(actual) != len(expected) or any(
-                resolve(left) != resolve(right) for left, right in zip(actual, expected)
-            ):
-                raise ValueError("Triton layout transfer program domains do not match.")
-
-        if source is destination or _memory_spans_overlap(
-            _tensor_memory_span(source),
-            _tensor_memory_span(destination),
-        ):
-            raise ValueError(
-                "Triton layout transfer requires non-overlapping source and "
-                "destination storage."
-            )
-
-    return validate
-
-
-def _tensor_has_non_overlapping_strides(value):
-    try:
-        shape = tuple(int(size) for size in value.shape)
-        strides = tuple(abs(int(stride)) for stride in value.stride())
-    except (AttributeError, RuntimeError, TypeError, ValueError):
-        return False
-
-    if any(size == 0 for size in shape):
-        return True
-
-    dimensions = tuple(
-        (stride, size) for size, stride in zip(shape, strides) if size > 1
-    )
-
-    if any(stride == 0 for stride, _size in dimensions):
-        return False
-
-    if len(dimensions) == 2:
-        (first_stride, first_size), (second_stride, second_size) = dimensions
-        divisor = math.gcd(first_stride, second_stride)
-
-        return not (
-            second_stride // divisor < first_size
-            and first_stride // divisor < second_size
-        )
-
-    dimensions = sorted(dimensions)
-    occupied_span = 1
-
-    for stride, size in dimensions:
-        if stride < occupied_span:
-            return False
-
-        occupied_span += (size - 1) * stride
-    return True
 
 
 def _runtime_vector_validator(compilation):
@@ -1053,7 +847,7 @@ def _aot_materialize(compilation, *, output_dir):
         leave,
         compilation.launch_abi,
         compilation.kernel.tensors,
-        validate_bindings=_runtime_layout_transfer_validator(
+        validate_bindings=build_layout_transfer_validator(
             getattr(artifact, "metadata", {}),
             compilation.launch_abi,
         ),

--- a/src/ninetoothed/backends/materializers/triton.py
+++ b/src/ninetoothed/backends/materializers/triton.py
@@ -2,6 +2,7 @@
 
 import ctypes
 import functools
+import math
 import os
 import re
 import shutil
@@ -47,11 +48,6 @@ class TritonMaterializer(Materializer):
         return _materialize(compilation)
 
     def aot_build(self, compilation, *, output_dir: str | Path):
-        if len(compilation.launch_plan.tuning_candidates) > 1:
-            raise ValueError(
-                "Triton AOT accepts one launch configuration; use build() to "
-                "benchmark and package multiple explicit configurations."
-            )
         return _aot_materialize(compilation, output_dir=output_dir)
 
     def load_built_artifact(self, built: BuiltArtifact):
@@ -69,12 +65,18 @@ class TritonMaterializer(Materializer):
         )
         specs = _runtime_specs(built.source)
 
+        abi = _launch_abi_from_dict(built.abi)
+
         return _aot_wrapper(
             function,
             enter,
             leave,
-            _launch_abi_from_dict(built.abi),
+            abi,
             specs,
+            validate_bindings=_runtime_layout_transfer_validator(
+                built.source.metadata,
+                abi,
+            ),
         )
 
 
@@ -119,7 +121,7 @@ def _materialize(compilation):
     launch = getattr(module, artifact.entrypoint)
     kernel = getattr(module, f"{artifact.kernel_name}_kernel", None)
     candidates = tuple(compilation.launch_plan.tuning_candidates)
-    validate_bindings = _runtime_vector_validator(compilation)
+    validate_bindings = _runtime_binding_validator(compilation)
     candidate_launches = tuple(
         _candidate_launch(compilation, launch, kernel, candidate, validate_bindings)
         for candidate in candidates
@@ -165,6 +167,7 @@ def _materialize(compilation):
             by_launch,
             handle,
             compilation,
+            validate_bindings,
         )
 
     return handle
@@ -178,8 +181,13 @@ def _candidate_launch(compilation, launch, kernel, candidate, validate_bindings)
         str(bindings[name].source): value
         for name, value in dict(candidate.get("meta_parameters", {})).items()
     }
+    private_meta = {
+        f"_ninetoothed_{name.lower()}": value
+        for name, value in dict(candidate.get("private_meta_parameters", {})).items()
+    }
     function = functools.partial(
         launch,
+        **private_meta,
         _ninetoothed_num_warps=int(candidate["num_warps"]),
         _ninetoothed_num_stages=int(candidate["num_stages"]),
     )
@@ -498,7 +506,13 @@ def _runtime_alias_signature(abi, public):
     return tuple(aliases)
 
 
-def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
+def _tuned_runtime_launch(
+    tuner,
+    candidates_by_launch,
+    handle,
+    compilation,
+    validate_bindings=None,
+):
     from ninetoothed.compiler.runtime import (
         _arm_prepared_runtime_launch,
         _empty_launch,
@@ -595,6 +609,9 @@ def _tuned_runtime_launch(tuner, candidates_by_launch, handle, compilation):
         )
 
         if _empty_launch(compilation.launch_abi, public):
+            if validate_bindings is not None:
+                validate_bindings(public)
+
             return _first_output(compilation.launch_abi, public)
 
         key = tuner._make_arg_key(args, kwargs)
@@ -719,6 +736,189 @@ def _runtime_validator(compilation, validate_bindings):
     return validate
 
 
+def _runtime_binding_validator(compilation):
+    validators = tuple(
+        validator
+        for validator in (
+            _runtime_vector_validator(compilation),
+            _runtime_layout_transfer_validator(
+                getattr(compilation.artifact, "metadata", {}),
+                compilation.launch_abi,
+            ),
+        )
+        if validator is not None
+    )
+
+    if not validators:
+        return None
+
+    def validate(public):
+        for validator in validators:
+            validator(public)
+
+    return validate
+
+
+def _runtime_layout_transfer_validator(metadata, abi):
+    transfer = dict(metadata.get("layout_transfer", {}))
+
+    if not transfer:
+        return None
+
+    import sympy
+
+    permutation = tuple(int(axis) for axis in transfer.get("permutation", ()))
+
+    physical_constraints = tuple(
+        (sympy.sympify(str(left)), sympy.sympify(str(right)))
+        for left, right in transfer.get("physical_constraints", ())
+    )
+    program_constraints = tuple(
+        (
+            tuple(sympy.sympify(str(value)) for value in actual),
+            tuple(sympy.sympify(str(value)) for value in expected),
+        )
+        for actual, expected in transfer.get("program_constraints", ())
+    )
+    value_constraints = tuple(
+        (
+            tuple(sympy.sympify(str(value)) for value in actual),
+            tuple(sympy.sympify(str(value)) for value in expected),
+        )
+        for actual, expected in transfer.get("value_constraints", ())
+    )
+    expressions = (
+        *(expression for pair in physical_constraints for expression in pair),
+        *(
+            expression
+            for constraint in value_constraints
+            for shape in constraint
+            for expression in shape
+        ),
+        *(
+            expression
+            for constraint in program_constraints
+            for shape in constraint
+            for expression in shape
+        ),
+    )
+    bindings = {binding.name: binding for binding in abi.kernel_args}
+
+    try:
+        symbols = tuple(
+            (symbol, bindings[str(symbol)])
+            for symbol in sorted(
+                set().union(*(expression.free_symbols for expression in expressions)),
+                key=str,
+            )
+        )
+        source_binding = bindings[str(transfer["source_binding"])]
+        destination_binding = bindings[str(transfer["destination_binding"])]
+    except KeyError as exc:
+        raise ValueError(
+            f"Serialized Triton layout transfer references unknown binding "
+            f"`{exc.args[0]}`."
+        ) from exc
+
+    from ninetoothed.compiler.runtime import _binding_value
+
+    def validate(public):
+        source = _binding_value(source_binding, public)
+        destination = _binding_value(destination_binding, public)
+
+        if (
+            len(permutation) != len(source.shape)
+            or len(permutation) != len(destination.shape)
+            or set(permutation) != set(range(len(permutation)))
+            or any(
+                source.shape[source_axis] != destination.shape[destination_axis]
+                for destination_axis, source_axis in enumerate(permutation)
+            )
+        ):
+            raise ValueError("Triton layout transfer physical shapes do not match.")
+
+        if not _tensor_has_non_overlapping_strides(destination):
+            raise ValueError(
+                "Triton layout transfer requires non-overlapping destination strides."
+            )
+
+        substitutions = {
+            symbol: _binding_value(binding, public) for symbol, binding in symbols
+        }
+
+        def resolve(expression):
+            resolved = expression.subs(substitutions)
+
+            if resolved.free_symbols:
+                names = ", ".join(sorted(map(str, resolved.free_symbols)))
+                raise ValueError(f"Unresolved Triton layout symbols: {names}.")
+            return int(resolved)
+
+        for left, right in physical_constraints:
+            if resolve(left) != resolve(right):
+                raise ValueError("Triton layout transfer physical shapes do not match.")
+
+        for actual, expected in value_constraints:
+            if len(actual) != len(expected) or any(
+                resolve(left) != resolve(right) for left, right in zip(actual, expected)
+            ):
+                raise ValueError("Triton layout transfer value domains do not match.")
+
+        for actual, expected in program_constraints:
+            if len(actual) != len(expected) or any(
+                resolve(left) != resolve(right) for left, right in zip(actual, expected)
+            ):
+                raise ValueError("Triton layout transfer program domains do not match.")
+
+        if source is destination or _memory_spans_overlap(
+            _tensor_memory_span(source),
+            _tensor_memory_span(destination),
+        ):
+            raise ValueError(
+                "Triton layout transfer requires non-overlapping source and "
+                "destination storage."
+            )
+
+    return validate
+
+
+def _tensor_has_non_overlapping_strides(value):
+    try:
+        shape = tuple(int(size) for size in value.shape)
+        strides = tuple(abs(int(stride)) for stride in value.stride())
+    except (AttributeError, RuntimeError, TypeError, ValueError):
+        return False
+
+    if any(size == 0 for size in shape):
+        return True
+
+    dimensions = tuple(
+        (stride, size) for size, stride in zip(shape, strides) if size > 1
+    )
+
+    if any(stride == 0 for stride, _size in dimensions):
+        return False
+
+    if len(dimensions) == 2:
+        (first_stride, first_size), (second_stride, second_size) = dimensions
+        divisor = math.gcd(first_stride, second_stride)
+
+        return not (
+            second_stride // divisor < first_size
+            and first_stride // divisor < second_size
+        )
+
+    dimensions = sorted(dimensions)
+    occupied_span = 1
+
+    for stride, size in dimensions:
+        if stride < occupied_span:
+            return False
+
+        occupied_span += (size - 1) * stride
+    return True
+
+
 def _runtime_vector_validator(compilation):
     metadata = getattr(compilation.artifact, "metadata", {})
     limit = metadata.get("vector_numel_limit")
@@ -819,6 +1019,7 @@ def _runtime_vector_validator(compilation):
 def _aot_materialize(compilation, *, output_dir):
     from ninetoothed.compiler.runtime import Handle, _publish_library
 
+    compilation = _select_aot_candidate(compilation)
     artifact = compilation.artifact
     cache_key = compilation_cache_key(compilation)
     source = write_source(
@@ -852,6 +1053,10 @@ def _aot_materialize(compilation, *, output_dir):
         leave,
         compilation.launch_abi,
         compilation.kernel.tensors,
+        validate_bindings=_runtime_layout_transfer_validator(
+            getattr(artifact, "metadata", {}),
+            compilation.launch_abi,
+        ),
     )
     handle = Handle(compilation, function, wrapped, source, library_path)
     write_manifest(
@@ -860,6 +1065,34 @@ def _aot_materialize(compilation, *, output_dir):
     )
 
     return handle
+
+
+def _select_aot_candidate(compilation):
+    launch_plan = getattr(compilation, "launch_plan", None)
+
+    if launch_plan is None:
+        return compilation
+
+    candidates = tuple(launch_plan.tuning_candidates)
+
+    if len(candidates) <= 1:
+        return compilation
+
+    metadata = getattr(compilation.artifact, "metadata", {})
+
+    if not metadata.get("layout_transfer"):
+        raise ValueError(
+            "Triton AOT accepts one launch configuration; use build() to "
+            "benchmark and package multiple explicit configurations."
+        )
+
+    return replace(
+        compilation,
+        launch_plan=replace(
+            compilation.launch_plan,
+            tuning_candidates=(candidates[0],),
+        ),
+    )
 
 
 def _ensure_aot_library(compilation, source: Path, library: Path) -> None:
@@ -1142,6 +1375,13 @@ def _compile_signature(compilation) -> str:
         else:
             values.append("i64")
 
+    private_meta = _private_meta_values(compilation)
+    values.extend(
+        str(private_meta[name])
+        for name in dict(compilation.artifact.metadata.get("layout_transfer", {})).get(
+            "private_meta_parameters", ()
+        )
+    )
     values.append(str(_compile_block(compilation)))
 
     return ",".join(values)
@@ -1276,14 +1516,46 @@ def _specialized_grid_total(compilation) -> str:
         for binding in compilation.launch_abi.kernel_args
         if binding.kind in {"meta", "constexpr"} and binding.value is not None
     }
+    replacements.update(
+        {
+            f"_ninetoothed_{name.lower()}": str(value)
+            for name, value in _private_meta_values(compilation).items()
+        }
+    )
 
     return replace_symbols(expression, replacements)
 
 
+def _private_meta_values(compilation) -> dict[str, int]:
+    candidates = tuple(compilation.launch_plan.tuning_candidates)
+
+    if not candidates:
+        return {}
+
+    return {
+        str(name): int(value)
+        for name, value in dict(
+            candidates[0].get("private_meta_parameters", {})
+        ).items()
+    }
+
+
 def _compile_schedule(compilation) -> tuple[int, int]:
     schedule = dict(compilation.artifact.metadata.get("ssa_schedule", {}))
-    warps = compilation.request.num_warps or schedule.get("num_warps") or 4
-    stages = compilation.request.num_stages or schedule.get("num_stages") or 3
+    candidates = tuple(compilation.launch_plan.tuning_candidates)
+    selected = dict(candidates[0]) if candidates else {}
+    warps = (
+        compilation.request.num_warps
+        or selected.get("num_warps")
+        or schedule.get("num_warps")
+        or 4
+    )
+    stages = (
+        compilation.request.num_stages
+        or selected.get("num_stages")
+        or schedule.get("num_stages")
+        or 3
+    )
 
     if isinstance(warps, tuple):
         warps = warps[0]
@@ -1293,7 +1565,15 @@ def _compile_schedule(compilation) -> tuple[int, int]:
     return int(warps), int(stages)
 
 
-def _aot_wrapper(function, enter, leave, abi, tensor_specs):
+def _aot_wrapper(
+    function,
+    enter,
+    leave,
+    abi,
+    tensor_specs,
+    *,
+    validate_bindings=None,
+):
     from ninetoothed.compiler.runtime import (
         KernelLaunchError,
         _bound_values,
@@ -1318,6 +1598,9 @@ def _aot_wrapper(function, enter, leave, abi, tensor_specs):
 
         public = _public_values(abi, args, kwargs, specs=tensor_specs)
         _validate_aot_constants(abi, public)
+
+        if validate_bindings is not None:
+            validate_bindings(public)
 
         if _empty_launch(abi, public):
             return _first_output(abi, public)

--- a/src/ninetoothed/backends/triton.py
+++ b/src/ninetoothed/backends/triton.py
@@ -14,6 +14,7 @@ from ninetoothed.backends.core import (
     Target,
 )
 from ninetoothed.backends.emitters.triton import emit
+from ninetoothed.compiler.layout import LayoutTransfer
 from ninetoothed.compiler.passes import (
     Context,
     OptimizeSchedule,
@@ -52,6 +53,32 @@ class TritonOptimizeSchedule(OptimizeSchedule):
         schedule: Mapping[str, Any],
         context: Context,
     ) -> tuple[ScheduleCandidate, ...]:
+        if schedule.get("granularity") == "layout-transfer":
+            transfer = schedule.get("layout_transfer")
+
+            if not isinstance(transfer, LayoutTransfer) or not transfer.requires_tiling:
+                return ()
+            return (
+                ScheduleCandidate(
+                    name="transpose-16x16",
+                    schedule={
+                        "tile": {"block_m": 16, "block_n": 16},
+                        "num_warps": 4,
+                        "num_stages": 1,
+                    },
+                    tags=("layout-transfer", "default"),
+                ),
+                ScheduleCandidate(
+                    name="transpose-32x32",
+                    schedule={
+                        "tile": {"block_m": 32, "block_n": 32},
+                        "num_warps": 8,
+                        "num_stages": 1,
+                    },
+                    tags=("layout-transfer", "throughput"),
+                ),
+            )
+
         del analysis, context
 
         if schedule.get("granularity") != "blocked-linalg":
@@ -100,6 +127,17 @@ class TritonOptimizeSchedule(OptimizeSchedule):
             return {
                 "schedule": {"num_warps": 4, "num_stages": 2},
             }
+
+        if granularity == "layout-transfer":
+            defaults = {}
+
+            if "num_warps" not in schedule:
+                defaults["num_warps"] = 4
+
+            if "num_stages" not in schedule:
+                defaults["num_stages"] = 1
+
+            return {"schedule": defaults}
 
         if granularity == "blocked-linalg":
             preserve_linalg = bool(

--- a/src/ninetoothed/compiler/driver.py
+++ b/src/ninetoothed/compiler/driver.py
@@ -662,6 +662,16 @@ def _triton_tuning_candidates(
     arranged,
 ) -> tuple[Mapping[str, Any], ...]:
     schedule = dict(metadata.get("ssa_schedule", {}))
+
+    if schedule.get("granularity") == "layout-transfer" and metadata.get(
+        "layout_transfer"
+    ):
+        return _triton_layout_transfer_candidates(
+            metadata,
+            request,
+            arranged,
+        )
+
     warps = _configuration_values(
         request.num_warps,
         schedule.get("num_warps"),
@@ -707,6 +717,119 @@ def _triton_tuning_candidates(
             candidates[index * len(candidates) // limit] for index in range(limit)
         ]
     return tuple(candidates)
+
+
+def _triton_layout_transfer_candidates(
+    metadata: Mapping[str, Any],
+    request: CompileRequest,
+    arranged,
+) -> tuple[Mapping[str, Any], ...]:
+    schedule_candidates = tuple(metadata.get("ssa_schedule_candidates", ()))
+    layout_transfer = dict(metadata.get("layout_transfer", {}))
+
+    if not schedule_candidates:
+        schedule_candidates = (
+            {
+                "name": "transpose-default",
+                "schedule": dict(metadata.get("ssa_schedule", {})),
+            },
+        )
+
+    candidates = []
+
+    for scheduled in schedule_candidates:
+        candidate_schedule = dict(scheduled.get("schedule", {}))
+        tile = dict(candidate_schedule.get("tile", {}))
+        private_meta = {}
+
+        if layout_transfer.get("requires_tiling"):
+            private_meta = {
+                "TILE_M": int(tile.get("block_m", 16)),
+                "TILE_N": int(tile.get("block_n", 16)),
+            }
+
+        warps = _configuration_values(
+            request.num_warps,
+            candidate_schedule.get("num_warps"),
+            default=4,
+        )
+        stages = _configuration_values(
+            request.num_stages,
+            candidate_schedule.get("num_stages"),
+            default=1,
+        )
+
+        for meta, num_warps, num_stages in itertools.product(
+            _meta_parameter_configurations(arranged), warps, stages
+        ):
+            parts = [
+                str(scheduled.get("name", "layout-transfer-default")),
+                *(f"{remove_prefixes(name)}-{value}" for name, value in meta.items()),
+                f"warps-{num_warps}",
+                f"stages-{num_stages}",
+            ]
+            candidate = {
+                "id": "_".join(parts),
+                "num_warps": num_warps,
+                "num_stages": num_stages,
+            }
+
+            if meta:
+                candidate["meta_parameters"] = meta
+
+            if private_meta:
+                candidate["private_meta_parameters"] = private_meta
+
+            if (
+                _layout_transfer_candidate_is_legal(
+                    layout_transfer,
+                    meta,
+                    private_meta,
+                )
+                and candidate not in candidates
+            ):
+                candidates.append(candidate)
+
+    if not candidates:
+        raise ValueError(
+            "No legal Triton layout-transfer configuration satisfies the block "
+            "shape and tensor-size constraints."
+        )
+
+    limit = request.max_num_configs
+
+    if limit is not None and len(candidates) > limit:
+        candidates = [
+            candidates[index * len(candidates) // limit] for index in range(limit)
+        ]
+    return tuple(candidates)
+
+
+def _layout_transfer_candidate_is_legal(layout_transfer, meta, private_meta):
+    import sympy
+
+    block_shape = tuple(layout_transfer.get("block_shape", ()))
+
+    if len(block_shape) != 2:
+        return False
+
+    substitutions = dict(meta) | dict(private_meta)
+    numel = 1
+
+    for extent in block_shape:
+        specialized = sympy.sympify(str(extent)).subs(substitutions)
+
+        if specialized.free_symbols or not specialized.is_integer:
+            return False
+
+        value = int(specialized)
+
+        if value <= 0 or value & (value - 1):
+            return False
+
+        numel *= value
+
+    return numel <= 1 << 20
 
 
 def _meta_parameter_configurations(arranged) -> tuple[dict[str, int], ...]:

--- a/src/ninetoothed/compiler/layout.py
+++ b/src/ninetoothed/compiler/layout.py
@@ -51,6 +51,34 @@ class LayoutTransfer:
         return self.failure_reason is None
 
 
+def serialize_layout_transfer(transfer: LayoutTransfer) -> dict[str, object]:
+    """Serialize a proven transfer without adding backend scheduling details."""
+    return {
+        "source_binding": transfer.source_binding,
+        "destination_binding": transfer.destination_binding,
+        "permutation": transfer.permutation,
+        "requires_tiling": transfer.requires_tiling,
+        "value_constraints": tuple(
+            (
+                tuple(value.render() for value in actual),
+                tuple(value.render() for value in expected),
+            )
+            for actual, expected in transfer.value_constraints
+        ),
+        "physical_constraints": tuple(
+            (left.render(), right.render())
+            for left, right in transfer.physical_constraints
+        ),
+        "program_constraints": tuple(
+            (
+                tuple(value.render() for value in actual),
+                tuple(value.render() for value in expected),
+            )
+            for actual, expected in transfer.program_constraints
+        ),
+    }
+
+
 def analyze_layout_transfer(program: ssa.Program, tensors=()) -> LayoutTransfer | None:
     """Return the unique proven direct rank-2 permutation in the program."""
     store = _sole_top_level_store(program)

--- a/src/ninetoothed/compiler/layout.py
+++ b/src/ninetoothed/compiler/layout.py
@@ -1,0 +1,809 @@
+"""Backend-neutral analysis of rank-2 layout transfers."""
+
+from dataclasses import dataclass
+
+import sympy
+
+from ninetoothed.ir import AccessMap, IndexExpr, TensorLayout, ssa
+
+
+@dataclass(frozen=True, kw_only=True)
+class TensorTransfer:
+    """Structured physical access for one side of a layout transfer."""
+
+    layout: TensorLayout
+    access_map: AccessMap
+    axis_mapping: tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "axis_mapping", tuple(self.axis_mapping))
+
+
+@dataclass(frozen=True, kw_only=True)
+class LayoutTransfer:
+    """A proven direct rank-2 permutation between physical tensor bindings."""
+
+    source_binding: str
+    destination_binding: str
+    source: TensorTransfer
+    destination: TensorTransfer
+    value_constraints: tuple[tuple[tuple[IndexExpr, ...], tuple[IndexExpr, ...]], ...]
+    physical_constraints: tuple[tuple[IndexExpr, IndexExpr], ...]
+    program_constraints: tuple[tuple[tuple[IndexExpr, ...], tuple[IndexExpr, ...]], ...]
+    requires_tiling: bool
+    failure_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        for name in (
+            "value_constraints",
+            "physical_constraints",
+            "program_constraints",
+        ):
+            object.__setattr__(self, name, tuple(getattr(self, name)))
+
+    @property
+    def permutation(self) -> tuple[int, ...]:
+        """Map destination physical axes to source physical axes."""
+        return self.source.axis_mapping
+
+    @property
+    def schedulable(self) -> bool:
+        return self.failure_reason is None
+
+
+def analyze_layout_transfer(program: ssa.Program, tensors=()) -> LayoutTransfer | None:
+    """Return the unique proven direct rank-2 permutation in the program."""
+    store = _sole_top_level_store(program)
+
+    if store is None:
+        return None
+
+    if any(name in store.attrs for name in ("indices", "source", "subscript")):
+        return None
+
+    value_types = _value_types(program)
+    definitions = _definitions(program)
+    users = _users(program)
+    tensor_specs = {tensor.name: tensor for tensor in tensors}
+    inputs = {value.name for value in program.inputs}
+    stored_value, destination_binding = store.operands[:2]
+    traced = _trace_source(stored_value, definitions, users, store)
+
+    if traced is None:
+        return None
+
+    source_binding, explicit_transpose = traced
+
+    if source_binding not in inputs or destination_binding not in inputs:
+        return None
+
+    source_type = value_types.get(source_binding)
+    stored_type = value_types.get(stored_value)
+    destination_type = value_types.get(destination_binding)
+
+    if (
+        not _rank_two_tensor(source_type)
+        or not _rank_two_tensor(stored_type)
+        or not _rank_two_tensor(destination_type)
+    ):
+        return None
+
+    source_spec = tensor_specs.get(source_binding)
+    destination_spec = tensor_specs.get(destination_binding)
+
+    if explicit_transpose:
+        return _explicit_transfer(
+            source_binding,
+            destination_binding,
+            source_type,
+            stored_type,
+            destination_type,
+            source_spec,
+            destination_spec,
+        )
+
+    return _arrangement_transfer(
+        source_binding,
+        destination_binding,
+        source_type,
+        destination_type,
+        source_spec,
+        destination_spec,
+    )
+
+
+def _explicit_transfer(
+    source_binding,
+    destination_binding,
+    source_type,
+    stored_type,
+    destination_type,
+    source_spec,
+    destination_spec,
+):
+    if any(
+        spec is not None and spec.layout is not None
+        for spec in (source_spec, destination_spec)
+    ):
+        return None
+
+    requires_tiling = True
+
+    source_shape = _physical_shape(source_spec, source_type)
+    destination_shape = _physical_shape(destination_spec, destination_type)
+    logical_shape = _type_shape(stored_type)
+
+    if len(source_shape) != 2 or len(destination_shape) != 2:
+        return None
+
+    source_strides = _physical_strides(source_spec, source_shape)
+    destination_strides = _physical_strides(destination_spec, destination_shape)
+    source_program_shape = _program_shape(source_spec, logical_shape)
+    destination_program_shape = _program_shape(destination_spec, logical_shape)
+    destination_value_shape = _application_shape(destination_spec, destination_type)
+    logical_indices = _logical_indices()
+    source_access = _normalized_source_access(
+        source_spec,
+        logical_indices,
+        source_strides,
+    )
+    destination_access = _destination_access(
+        destination_spec,
+        logical_indices,
+        destination_strides,
+    )
+    source_layout = _normalized_layout(
+        source_shape,
+        source_strides,
+        logical_shape,
+        source_program_shape,
+        source_access,
+    )
+    destination_layout = _normalized_layout(
+        destination_shape,
+        destination_strides,
+        destination_value_shape,
+        destination_program_shape,
+        destination_access,
+    )
+
+    if not _renderable_access(source_layout, source_access) or not _renderable_access(
+        destination_layout,
+        destination_access,
+    ):
+        return None
+
+    if _relative_axis_mapping(source_access, destination_access) != (1, 0):
+        return None
+
+    return _contract(
+        source_binding,
+        destination_binding,
+        TensorTransfer(
+            layout=source_layout,
+            access_map=source_access,
+            axis_mapping=(1, 0),
+        ),
+        TensorTransfer(
+            layout=destination_layout,
+            access_map=destination_access,
+            axis_mapping=(0, 1),
+        ),
+        requires_tiling=requires_tiling,
+    )
+
+
+def _arrangement_transfer(
+    source_binding,
+    destination_binding,
+    source_type,
+    destination_type,
+    source_spec,
+    destination_spec,
+):
+    if source_spec is None or destination_spec is None:
+        return None
+
+    source_layout = source_spec.layout
+    destination_layout = destination_spec.layout
+
+    if (
+        not _rank_two_layout(source_layout)
+        or not _rank_two_layout(destination_layout)
+        or not source_layout.value_accesses
+        or not destination_layout.value_accesses
+    ):
+        return None
+
+    if _type_shape(source_type) != _type_shape(destination_type):
+        return None
+
+    source_access = _layout_access(source_layout)
+    destination_access = _layout_access(destination_layout)
+
+    if not _renderable_access(
+        source_layout,
+        source_access,
+    ) or not _renderable_access(destination_layout, destination_access):
+        return None
+
+    if not _outer_domain_is_mapped(
+        source_layout,
+        source_access,
+    ) or not _outer_domain_is_mapped(destination_layout, destination_access):
+        return None
+
+    permutation = _relative_axis_mapping(
+        source_access,
+        destination_access,
+    )
+
+    if permutation != (1, 0):
+        return None
+
+    if not _access_coordinates_match(
+        source_layout,
+        source_access,
+        destination_layout,
+        destination_access,
+        permutation,
+    ):
+        return None
+
+    source = _tensor_transfer(source_layout, source_access, permutation)
+    destination = _tensor_transfer(destination_layout, destination_access, (0, 1))
+
+    return _contract(
+        source_binding,
+        destination_binding,
+        source,
+        destination,
+        requires_tiling=False,
+    )
+
+
+def _contract(
+    source_binding,
+    destination_binding,
+    source,
+    destination,
+    *,
+    requires_tiling,
+):
+    source_layout = source.layout
+    destination_layout = destination.layout
+    value_constraints = (
+        (source_layout.application_shape, destination_layout.application_shape),
+    )
+    physical_constraints = tuple(
+        (
+            source_layout.source_shape[source_axis],
+            destination_layout.source_shape[destination_axis],
+        )
+        for destination_axis, source_axis in enumerate(source.axis_mapping)
+    )
+    program_constraints = ((source_layout.view_shape, destination_layout.view_shape),)
+    physical_compatible, physical_reason = _constraint_compatibility(
+        physical_constraints,
+        "physical shapes",
+    )
+    program_compatible, program_reason = _program_compatibility(
+        source_layout.view_shape,
+        destination_layout.view_shape,
+    )
+
+    if (
+        len(source_layout.application_shape) != 2
+        or len(destination_layout.application_shape) != 2
+    ):
+        return None
+
+    value_compatible, value_reason = _static_shape_compatibility(
+        source_layout.application_shape,
+        destination_layout.application_shape,
+        "logical value shapes",
+    )
+
+    if not value_compatible:
+        failure_reason = value_reason
+    elif not program_compatible:
+        failure_reason = program_reason
+    elif not physical_compatible:
+        failure_reason = physical_reason
+    else:
+        failure_reason = None
+
+    return LayoutTransfer(
+        source_binding=source_binding,
+        destination_binding=destination_binding,
+        source=source,
+        destination=destination,
+        value_constraints=value_constraints,
+        physical_constraints=physical_constraints,
+        program_constraints=program_constraints,
+        requires_tiling=requires_tiling,
+        failure_reason=failure_reason,
+    )
+
+
+def _tensor_transfer(layout, access, axis_mapping):
+    return TensorTransfer(
+        layout=layout,
+        access_map=access,
+        axis_mapping=axis_mapping,
+    )
+
+
+def _sole_top_level_store(program):
+    if len(program.blocks) != 1:
+        return None
+
+    effects = tuple(
+        operation
+        for operation in _walk_program(program)
+        if operation.opcode in {"mem.atomic_add", "mem.store"}
+    )
+
+    if (
+        len(effects) != 1
+        or effects[0].opcode != "mem.store"
+        or len(effects[0].operands) != 2
+        or not any(
+            effects[0] is operation for operation in program.blocks[0].operations
+        )
+    ):
+        return None
+
+    return effects[0]
+
+
+def _trace_source(value, definitions, users, store):
+    operation = definitions.get(value)
+
+    if operation is None:
+        return value, False
+
+    if (
+        operation.opcode != "linalg.transpose"
+        or len(operation.operands) != 1
+        or len(operation.results) != 1
+        or operation.regions
+        or tuple(operation.attrs.get("permutation", (1, 0))) != (1, 0)
+        or users.get(value, ()) != (store,)
+        or operation.operands[0] in definitions
+    ):
+        return None
+
+    return operation.operands[0], True
+
+
+def _relative_axis_mapping(source_access, destination_access):
+    source_indices = source_access.source_indices
+    destination_indices = destination_access.source_indices
+
+    if len(source_indices) != 2 or len(destination_indices) != 2:
+        return None
+
+    source_axes = tuple(_value_axis(index) for index in source_indices)
+    destination_axes = tuple(_value_axis(index) for index in destination_indices)
+
+    if set(source_axes) == {0, 1} and set(destination_axes) == {0, 1}:
+        return tuple(source_axes.index(axis) for axis in destination_axes)
+
+    return None
+
+
+def _access_coordinates_match(
+    source_layout,
+    source_access,
+    destination_layout,
+    destination_access,
+    permutation,
+):
+    source_substitutions = {}
+    destination_substitutions = {}
+
+    for destination_axis, source_axis in enumerate(permutation):
+        canonical = sympy.Symbol(f"_physical_{destination_axis}")
+        source_extent = sympy.sympify(source_layout.source_shape[source_axis].render())
+        destination_extent = sympy.sympify(
+            destination_layout.source_shape[destination_axis].render()
+        )
+
+        if (
+            source_extent in source_substitutions
+            and source_substitutions[source_extent] != canonical
+        ) or (
+            destination_extent in destination_substitutions
+            and destination_substitutions[destination_extent] != canonical
+        ):
+            return False
+
+        source_substitutions[source_extent] = canonical
+        destination_substitutions[destination_extent] = canonical
+
+    try:
+        return all(
+            sympy.simplify(
+                sympy.sympify(source_access.source_indices[source_axis].render()).subs(
+                    source_substitutions
+                )
+                - sympy.sympify(
+                    destination_access.source_indices[destination_axis].render()
+                ).subs(destination_substitutions)
+            )
+            == 0
+            for destination_axis, source_axis in enumerate(permutation)
+        )
+    except (SyntaxError, TypeError, ValueError):
+        return False
+
+
+def _renderable_access(layout, access):
+    if access is None:
+        return False
+
+    axes = tuple(_value_axis(index) for index in access.source_indices)
+
+    if set(axes) != {0, 1}:
+        return False
+
+    expected_linear_index = _linear_index(
+        access.source_indices,
+        layout.source_strides,
+    )
+
+    if not _equivalent_index_expr(access.linear_index, expected_linear_index):
+        return False
+
+    layout_expressions = (
+        *layout.source_shape,
+        *layout.source_strides,
+        *layout.view_shape,
+        *layout.application_shape,
+    )
+    allowed = {
+        "index",
+        "outer_index",
+        "value_0",
+        "value_1",
+        *(
+            symbol
+            for expression in layout_expressions
+            for symbol in _symbols(expression)
+        ),
+    }
+    access_expressions = (
+        *access.source_indices,
+        access.linear_index,
+        access.predicate,
+    )
+
+    return all(_symbols(expression) <= allowed for expression in access_expressions)
+
+
+def _outer_domain_is_mapped(layout, access):
+    single_program = all(_static_integer(extent) == 1 for extent in layout.view_shape)
+
+    return single_program or any(
+        "outer_index" in _symbols(index) for index in access.source_indices
+    )
+
+
+def _symbols(expression):
+    if expression.op == "symbol":
+        return frozenset({str(expression.value)})
+
+    return frozenset().union(*(_symbols(operand) for operand in expression.operands))
+
+
+def _value_axis(expression):
+    try:
+        rendered = sympy.sympify(expression.render())
+    except (SyntaxError, TypeError, ValueError):
+        return None
+
+    value_symbols = tuple(sympy.Symbol(f"value_{axis}") for axis in range(2))
+    coefficients = tuple(sympy.diff(rendered, symbol) for symbol in value_symbols)
+
+    if coefficients.count(sympy.Integer(1)) != 1 or any(
+        coefficient not in {sympy.Integer(0), sympy.Integer(1)}
+        for coefficient in coefficients
+    ):
+        return None
+
+    axis = coefficients.index(sympy.Integer(1))
+    remainder = sympy.simplify(rendered - value_symbols[axis])
+
+    if remainder == 0:
+        return axis
+
+    if sympy.Symbol("outer_index") in remainder.free_symbols and not any(
+        symbol in remainder.free_symbols for symbol in value_symbols
+    ):
+        return axis
+    return None
+
+
+def _linear_index(indices, strides):
+    terms = tuple(
+        IndexExpr(op="mul", operands=(index, stride))
+        for index, stride in zip(indices, strides)
+    )
+
+    if not terms:
+        return IndexExpr.parse(0)
+
+    result = terms[0]
+
+    for term in terms[1:]:
+        result = IndexExpr(op="add", operands=(result, term))
+    return result
+
+
+def _equivalent_index_expr(left, right):
+    try:
+        difference = sympy.sympify(left.render()) - sympy.sympify(right.render())
+    except (SyntaxError, TypeError, ValueError):
+        return False
+    return sympy.simplify(difference) == 0
+
+
+def _program_compatibility(source_shape, destination_shape):
+    return _static_shape_compatibility(
+        source_shape,
+        destination_shape,
+        "program shapes",
+    )
+
+
+def _constraint_compatibility(constraints, label):
+    for left, right in constraints:
+        left_value = _static_integer(left)
+        right_value = _static_integer(right)
+
+        if (
+            left_value is not None
+            and right_value is not None
+            and left_value != right_value
+        ):
+            return False, f"{label} are statically incompatible"
+
+    return True, None
+
+
+def _static_shape_compatibility(left, right, label):
+    if len(left) != len(right):
+        return False, f"{label} have different ranks"
+
+    for left_dim, right_dim in zip(left, right):
+        left_value = _static_integer(left_dim)
+        right_value = _static_integer(right_dim)
+
+        if (
+            left_value is not None
+            and right_value is not None
+            and left_value != right_value
+        ):
+            return False, f"{label} are statically incompatible"
+
+    return True, None
+
+
+def _static_integer(expression):
+    if expression.op == "constant":
+        value = expression.value
+
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+
+    return None
+
+
+def _normalized_layout(
+    source_shape,
+    source_strides,
+    value_shape,
+    program_shape,
+    access,
+):
+    return TensorLayout(
+        source_shape=source_shape,
+        source_strides=source_strides,
+        view_shape=program_shape,
+        application_shape=value_shape,
+        view_access=access,
+        value_accesses=(access,),
+    )
+
+
+def _access_map(indices, strides, predicate):
+    linear = IndexExpr(op="constant", value=0)
+
+    for index, stride in zip(indices, strides):
+        linear = IndexExpr(
+            op="add",
+            operands=(
+                linear,
+                IndexExpr(op="mul", operands=(index, stride)),
+            ),
+        )
+
+    return AccessMap(
+        source_indices=indices,
+        linear_index=linear,
+        predicate=predicate,
+    )
+
+
+def _logical_indices():
+    return (IndexExpr.parse("value_0"), IndexExpr.parse("value_1"))
+
+
+def _normalized_source_access(spec, logical_indices, source_strides):
+    if spec is not None and spec.layout is not None:
+        access = _layout_access(spec.layout)
+
+        if access is not None:
+            return _permute_access(access, (1, 0))
+
+    return _access_map(
+        (logical_indices[1], logical_indices[0]),
+        source_strides,
+        IndexExpr.parse(True),
+    )
+
+
+def _destination_access(spec, logical_indices, destination_strides):
+    if spec is not None and spec.layout is not None:
+        access = _layout_access(spec.layout)
+
+        if access is not None:
+            return access
+
+    return _access_map(
+        logical_indices,
+        destination_strides,
+        IndexExpr.parse(True),
+    )
+
+
+def _permute_access(access, permutation):
+    return AccessMap(
+        source_indices=tuple(
+            _substitute_value_axes(expression, permutation)
+            for expression in access.source_indices
+        ),
+        linear_index=_substitute_value_axes(access.linear_index, permutation),
+        predicate=_substitute_value_axes(access.predicate, permutation),
+    )
+
+
+def _substitute_value_axes(expression, permutation):
+    if expression.op == "symbol":
+        name = str(expression.value)
+        suffix = name.removeprefix("value_")
+
+        if name.startswith("value_") and suffix.isdigit():
+            axis = int(suffix)
+
+            if axis < len(permutation):
+                return IndexExpr(op="symbol", value=f"value_{permutation[axis]}")
+
+    return IndexExpr(
+        op=expression.op,
+        operands=tuple(
+            _substitute_value_axes(operand, permutation)
+            for operand in expression.operands
+        ),
+        value=expression.value,
+    )
+
+
+def _layout_access(layout):
+    if layout is None:
+        return None
+
+    if layout.value_accesses:
+        return layout.value_accesses[-1]
+
+    return layout.view_access
+
+
+def _physical_shape(spec, type_):
+    if spec is not None and spec.layout is not None:
+        return spec.layout.source_shape
+
+    return _type_shape(type_)
+
+
+def _physical_strides(spec, source_shape):
+    if spec is not None and spec.layout is not None:
+        return spec.layout.source_strides
+
+    return (source_shape[1], IndexExpr.parse(1))
+
+
+def _program_shape(spec, fallback):
+    if spec is not None and spec.layout is not None:
+        return spec.layout.view_shape
+
+    return fallback
+
+
+def _application_shape(spec, type_):
+    if spec is not None and spec.layout is not None:
+        return spec.layout.application_shape
+
+    return _type_shape(type_)
+
+
+def _type_shape(type_):
+    return tuple(IndexExpr.parse(dim) for dim in type_.shape)
+
+
+def _rank_two_layout(layout: TensorLayout | None) -> bool:
+    access = _layout_access(layout)
+
+    return bool(
+        layout is not None
+        and len(layout.source_shape) == 2
+        and len(layout.source_strides) == 2
+        and len(layout.application_shape) == 2
+        and access is not None
+        and len(access.source_indices) == 2
+    )
+
+
+def _rank_two_tensor(type_):
+    return bool(type_ is not None and type_.kind == "tensor" and len(type_.shape) == 2)
+
+
+def _value_types(program):
+    result = {value.name: value.type for value in (*program.inputs, *program.outputs)}
+
+    def visit_block(block):
+        result.update({argument.name: argument.type for argument in block.args})
+
+        for operation in block.operations:
+            result.update({value.name: value.type for value in operation.results})
+
+            for region in operation.regions:
+                visit_block(region)
+
+    for block in program.blocks:
+        visit_block(block)
+    return result
+
+
+def _definitions(program):
+    return {
+        result.name: operation
+        for operation in _walk_program(program)
+        for result in operation.results
+    }
+
+
+def _users(program):
+    result = {}
+
+    for operation in _walk_program(program):
+        for operand in operation.operands:
+            result.setdefault(operand, []).append(operation)
+
+    return {value: tuple(operations) for value, operations in result.items()}
+
+
+def _walk_program(program):
+    def visit_block(block):
+        for operation in block.operations:
+            yield operation
+
+            for region in operation.regions:
+                yield from visit_block(region)
+
+    for block in program.blocks:
+        yield from visit_block(block)
+
+
+__all__ = ["LayoutTransfer", "TensorTransfer", "analyze_layout_transfer"]

--- a/src/ninetoothed/compiler/layout_runtime.py
+++ b/src/ninetoothed/compiler/layout_runtime.py
@@ -1,0 +1,214 @@
+"""Runtime validation helpers for backend-neutral layout transfers."""
+
+import math
+
+import sympy
+
+
+def tensor_memory_span(value):
+    """Return the conservative byte span occupied by a tensor-like value."""
+    try:
+        device = value.device
+    except (AttributeError, RuntimeError, TypeError):
+        device = None
+
+    try:
+        shape = tuple(value.shape)
+
+        if any(size == 0 for size in shape):
+            return (device, 0, 0)
+
+        element_size = value.element_size()
+        data_ptr = value.data_ptr()
+        lower = upper = 0
+
+        for size, stride in zip(shape, value.stride()):
+            extent = (size - 1) * stride
+            lower += min(0, extent)
+            upper += max(0, extent)
+
+        return (
+            device,
+            data_ptr + lower * element_size,
+            data_ptr + (upper + 1) * element_size,
+        )
+    except (AttributeError, RuntimeError, TypeError):
+        return (device, None, None)
+
+
+def memory_spans_overlap(first, second):
+    """Conservatively determine whether two tensor byte spans overlap."""
+    first_device, first_start, first_end = first
+    second_device, second_start, second_end = second
+
+    if (
+        first_device is not None
+        and second_device is not None
+        and first_device != second_device
+    ):
+        return False
+
+    if None in (first_start, first_end, second_start, second_end):
+        return True
+
+    if first_start == first_end or second_start == second_end:
+        return False
+
+    return first_start < second_end and second_start < first_end
+
+
+def build_layout_transfer_validator(metadata, abi):
+    """Build a runtime validator from serialized layout-transfer metadata."""
+    transfer = dict(metadata.get("layout_transfer", {}))
+
+    if not transfer:
+        return None
+
+    permutation = tuple(int(axis) for axis in transfer.get("permutation", ()))
+    physical_constraints = tuple(
+        (sympy.sympify(str(left)), sympy.sympify(str(right)))
+        for left, right in transfer.get("physical_constraints", ())
+    )
+    program_constraints = tuple(
+        (
+            tuple(sympy.sympify(str(value)) for value in actual),
+            tuple(sympy.sympify(str(value)) for value in expected),
+        )
+        for actual, expected in transfer.get("program_constraints", ())
+    )
+    value_constraints = tuple(
+        (
+            tuple(sympy.sympify(str(value)) for value in actual),
+            tuple(sympy.sympify(str(value)) for value in expected),
+        )
+        for actual, expected in transfer.get("value_constraints", ())
+    )
+    expressions = (
+        *(expression for pair in physical_constraints for expression in pair),
+        *(
+            expression
+            for constraint in value_constraints
+            for shape in constraint
+            for expression in shape
+        ),
+        *(
+            expression
+            for constraint in program_constraints
+            for shape in constraint
+            for expression in shape
+        ),
+    )
+    bindings = {binding.name: binding for binding in abi.kernel_args}
+
+    try:
+        symbols = tuple(
+            (symbol, bindings[str(symbol)])
+            for symbol in sorted(
+                set().union(*(expression.free_symbols for expression in expressions)),
+                key=str,
+            )
+        )
+        source_binding = bindings[str(transfer["source_binding"])]
+        destination_binding = bindings[str(transfer["destination_binding"])]
+    except KeyError as exc:
+        raise ValueError(
+            f"Serialized layout transfer references unknown binding `{exc.args[0]}`."
+        ) from exc
+
+    from ninetoothed.compiler.runtime import _binding_value
+
+    def validate(public):
+        source = _binding_value(source_binding, public)
+        destination = _binding_value(destination_binding, public)
+
+        if (
+            len(permutation) != len(source.shape)
+            or len(permutation) != len(destination.shape)
+            or set(permutation) != set(range(len(permutation)))
+            or any(
+                source.shape[source_axis] != destination.shape[destination_axis]
+                for destination_axis, source_axis in enumerate(permutation)
+            )
+        ):
+            raise ValueError("Layout transfer physical shapes do not match.")
+
+        if not _tensor_has_non_overlapping_strides(destination):
+            raise ValueError(
+                "Layout transfer requires non-overlapping destination strides."
+            )
+
+        substitutions = {
+            symbol: _binding_value(binding, public) for symbol, binding in symbols
+        }
+
+        def resolve(expression):
+            resolved = expression.subs(substitutions)
+
+            if resolved.free_symbols:
+                names = ", ".join(sorted(map(str, resolved.free_symbols)))
+                raise ValueError(f"Unresolved layout transfer symbols: {names}.")
+            return int(resolved)
+
+        for left, right in physical_constraints:
+            if resolve(left) != resolve(right):
+                raise ValueError("Layout transfer physical shapes do not match.")
+
+        for actual, expected in value_constraints:
+            if len(actual) != len(expected) or any(
+                resolve(left) != resolve(right) for left, right in zip(actual, expected)
+            ):
+                raise ValueError("Layout transfer value domains do not match.")
+
+        for actual, expected in program_constraints:
+            if len(actual) != len(expected) or any(
+                resolve(left) != resolve(right) for left, right in zip(actual, expected)
+            ):
+                raise ValueError("Layout transfer program domains do not match.")
+
+        if source is destination or memory_spans_overlap(
+            tensor_memory_span(source),
+            tensor_memory_span(destination),
+        ):
+            raise ValueError(
+                "Layout transfer requires non-overlapping source and destination "
+                "storage."
+            )
+
+    return validate
+
+
+def _tensor_has_non_overlapping_strides(value):
+    try:
+        shape = tuple(int(size) for size in value.shape)
+        strides = tuple(abs(int(stride)) for stride in value.stride())
+    except (AttributeError, RuntimeError, TypeError, ValueError):
+        return False
+
+    if any(size == 0 for size in shape):
+        return True
+
+    dimensions = tuple(
+        (stride, size) for size, stride in zip(shape, strides) if size > 1
+    )
+
+    if any(stride == 0 for stride, _size in dimensions):
+        return False
+
+    if len(dimensions) == 2:
+        (first_stride, first_size), (second_stride, second_size) = dimensions
+        divisor = math.gcd(first_stride, second_stride)
+
+        return not (
+            second_stride // divisor < first_size
+            and first_stride // divisor < second_size
+        )
+
+    dimensions = sorted(dimensions)
+    occupied_span = 1
+
+    for stride, size in dimensions:
+        if stride < occupied_span:
+            return False
+
+        occupied_span += (size - 1) * stride
+    return True

--- a/src/ninetoothed/compiler/passes.py
+++ b/src/ninetoothed/compiler/passes.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass, field
 from typing import Any, Mapping
 
 from ninetoothed.backends.core import Target, normalize_target
+from ninetoothed.compiler.layout import LayoutTransfer, analyze_layout_transfer
 from ninetoothed.compiler.reductions import analyze_reductions
 from ninetoothed.ir import ssa
 
@@ -279,6 +280,7 @@ class AnalyzeEffects(Pass):
         loops = sum(1 for opcode in opcodes if opcode == "scf.for")
         dot_input_dtypes = _linalg_input_dtypes(program)
         reduction_analysis = analyze_reductions(program, context.tensors)
+        layout_transfer = analyze_layout_transfer(program, context.tensors)
 
         return _with_metadata(
             program,
@@ -294,6 +296,7 @@ class AnalyzeEffects(Pass):
                 "has_exp_reduction_dot_pattern": _has_exp_reduction_dot_pattern(
                     opcodes
                 ),
+                "layout_transfer": layout_transfer,
                 **reduction_analysis,
             },
         )
@@ -349,6 +352,7 @@ class SelectSchedule(Pass):
             "parallelism": "program-blocks",
         }
         reduction = analysis.get("reduction_schedule")
+        layout_transfer = analysis.get("layout_transfer")
 
         if "reduction" in options:
             raise ValueError(
@@ -360,6 +364,13 @@ class SelectSchedule(Pass):
 
         if isinstance(reduction, Mapping):
             schedule["reduction"] = dict(reduction)
+
+        if (
+            schedule.get("granularity") == "layout-transfer"
+            and isinstance(layout_transfer, LayoutTransfer)
+            and layout_transfer.schedulable
+        ):
+            schedule["layout_transfer"] = layout_transfer
 
         return _with_metadata(program, schedule=schedule)
 
@@ -388,6 +399,12 @@ class OptimizeSchedule(Pass):
             else:
                 rejected.append(candidate.as_metadata() | {"reason": reason})
 
+        selected = self.select_candidate(tuple(legal), context)
+
+        if selected is not None:
+            legal.remove(selected)
+            legal.insert(0, selected)
+
         max_num_configs = context.compiler_options.get("max_num_configs")
 
         if max_num_configs is not None:
@@ -401,7 +418,6 @@ class OptimizeSchedule(Pass):
 
         candidates = tuple(legal)
         rejected = tuple(rejected)
-        selected = self.select_candidate(candidates, context)
 
         if selected is not None:
             schedule = _merge_nested(schedule, selected.schedule)
@@ -895,6 +911,11 @@ def _has_exp_reduction_dot_pattern(opcodes: tuple[str, ...]) -> bool:
 
 
 def _schedule_granularity(analysis: Mapping[str, Any]) -> str:
+    layout_transfer = analysis.get("layout_transfer")
+
+    if isinstance(layout_transfer, LayoutTransfer) and layout_transfer.schedulable:
+        return "layout-transfer"
+
     if analysis.get("has_exp_reduction_dot_pattern"):
         return "exp-reduction-dot-region"
 

--- a/src/ninetoothed/compiler/runtime.py
+++ b/src/ninetoothed/compiler/runtime.py
@@ -991,6 +991,9 @@ def _runtime_wrapper(
 
         bound_public = dict(public) | overrides
 
+        if validate_bindings is not None:
+            validate_bindings(bound_public)
+
         if _empty_launch(abi, public):
             return _PreparedRuntimeLaunch(
                 guard=_VerifiedRuntimeCall.from_call(abi, args, kwargs),
@@ -998,9 +1001,6 @@ def _runtime_wrapper(
                 owner_refs=_runtime_owner_refs(args, kwargs),
                 empty=True,
             )
-
-        if validate_bindings is not None:
-            validate_bindings(bound_public)
 
         values, _keepalive = _bound_values(abi, bound_public, scalar_mode="value")
         bindings = abi.kernel_args
@@ -1087,14 +1087,13 @@ def _runtime_wrapper(
 
     def launch(*args, **kwargs):
         public = _public_values(abi, args, kwargs, specs=specs)
-
-        if _empty_launch(abi, public):
-            return _first_output(abi, public)
-
         bound_public = dict(public) | overrides
 
         if validate_bindings is not None:
             validate_bindings(bound_public)
+
+        if _empty_launch(abi, public):
+            return _first_output(abi, public)
 
         values, keepalive = _bound_values(
             abi,

--- a/tests/test_layout_transfer_analysis.py
+++ b/tests/test_layout_transfer_analysis.py
@@ -1,0 +1,332 @@
+import pytest
+
+from ninetoothed import Tensor
+from ninetoothed.backends.core import Target
+from ninetoothed.compiler.layout import LayoutTransfer, analyze_layout_transfer
+from ninetoothed.compiler.passes import lower_for_target
+from ninetoothed.frontend.layout import tensor_specs
+from ninetoothed.frontend.python import from_source
+from ninetoothed.ir import AccessMap, IndexExpr, TensorLayout, TensorSpec
+
+_COPY_SOURCE = "\ndef copy(x, out):\n    out = x\n"
+
+
+def _expr(value):
+    return IndexExpr.parse(value)
+
+
+def _access(indices, strides, predicate=True, linear_index=None):
+    indices = tuple(_expr(index) for index in indices)
+    strides = tuple(_expr(stride) for stride in strides)
+
+    return AccessMap(
+        source_indices=indices,
+        linear_index=(
+            _expr(linear_index)
+            if linear_index is not None
+            else IndexExpr(
+                op="add",
+                operands=(
+                    IndexExpr(op="mul", operands=(indices[0], strides[0])),
+                    IndexExpr(op="mul", operands=(indices[1], strides[1])),
+                ),
+            )
+        ),
+        predicate=_expr(predicate),
+    )
+
+
+def _spec(
+    name,
+    *,
+    source_shape,
+    value_shape=("m", "n"),
+    program_shape=("p", "q"),
+    indices=("value_0", "value_1"),
+    strides=("ld", 1),
+    predicate=True,
+    tiled=True,
+    linear_index=None,
+):
+    access = _access(indices, strides, predicate, linear_index)
+    layout = TensorLayout(
+        source_shape=tuple(_expr(dim) for dim in source_shape),
+        source_strides=tuple(_expr(stride) for stride in strides),
+        view_shape=tuple(_expr(dim) for dim in program_shape),
+        application_shape=tuple(_expr(dim) for dim in value_shape),
+        view_access=access,
+        value_accesses=(access,) if tiled else (),
+    )
+
+    return TensorSpec(
+        ndim=2,
+        shape=tuple(value_shape),
+        dtype="float32",
+        name=name,
+        layout=layout,
+    )
+
+
+def _permuted_specs(
+    *,
+    source_program=("p", "q"),
+    destination_program=("p", "q"),
+    source_indices=("outer_index + value_1", "value_0"),
+    destination_indices=("value_0", "outer_index + value_1"),
+    source_strides=("ld", 1),
+    source_predicate=True,
+    source_linear_index=None,
+    source_tiled=True,
+    destination_tiled=True,
+    names=("x", "out"),
+):
+    return (
+        _spec(
+            names[0],
+            source_shape=("n", "m"),
+            program_shape=source_program,
+            indices=source_indices,
+            strides=source_strides,
+            predicate=source_predicate,
+            linear_index=source_linear_index,
+            tiled=source_tiled,
+        ),
+        _spec(
+            names[1],
+            source_shape=("m", "n"),
+            program_shape=destination_program,
+            indices=destination_indices,
+            tiled=destination_tiled,
+        ),
+    )
+
+
+def _program(source, tensors, kind="layout_transfer"):
+    program = from_source(source, tensors, kind=kind)
+    assert program is not None
+
+    return program
+
+
+def _analyze_copy(specs):
+    return analyze_layout_transfer(_program(_COPY_SOURCE, specs), specs)
+
+
+def _assert_copy_rejected(specs):
+    assert _analyze_copy(specs) is None
+
+
+def test_explicit_transpose_builds_structured_immutable_access_contract():
+    program = _program(
+        "\ndef transpose(x, out):\n    out = x.T\n",
+        (
+            TensorSpec(ndim=2, shape=("m", "n"), dtype="float32", name="x"),
+            TensorSpec(
+                ndim=2,
+                shape=("output_rows", "output_columns"),
+                dtype="float32",
+                name="out",
+            ),
+        ),
+    )
+
+    transfer = analyze_layout_transfer(program)
+
+    assert isinstance(transfer, LayoutTransfer)
+    assert transfer.source_binding == "x"
+    assert transfer.destination_binding == "out"
+    assert transfer.permutation == (1, 0)
+    assert transfer.source.access_map.source_indices == (
+        _expr("value_1"),
+        _expr("value_0"),
+    )
+    assert transfer.source.layout.application_shape == (_expr("n"), _expr("m"))
+    assert transfer.value_constraints == (
+        (
+            (_expr("n"), _expr("m")),
+            (_expr("output_rows"), _expr("output_columns")),
+        ),
+    )
+    assert transfer.physical_constraints == (
+        (_expr("n"), _expr("output_rows")),
+        (_expr("m"), _expr("output_columns")),
+    )
+    assert transfer.requires_tiling
+    assert transfer.schedulable
+
+
+def test_dynamic_constraints_and_structured_contract_reach_schedule():
+    specs = _permuted_specs(
+        source_program=("source_p", "source_q"),
+        destination_program=("destination_p", "destination_q"),
+    )
+    program = _program(_COPY_SOURCE, specs)
+
+    lowered = lower_for_target(program, backend=Target.TRITON, tensors=specs)
+    transfer = lowered.metadata["analysis"]["layout_transfer"]
+
+    assert transfer.schedulable
+    assert transfer.failure_reason is None
+    assert transfer.program_constraints == (
+        (
+            (_expr("source_p"), _expr("source_q")),
+            (_expr("destination_p"), _expr("destination_q")),
+        ),
+    )
+    assert transfer.value_constraints == (
+        (
+            (_expr("m"), _expr("n")),
+            (_expr("m"), _expr("n")),
+        ),
+    )
+    assert transfer.physical_constraints == (
+        (_expr("m"), _expr("m")),
+        (_expr("n"), _expr("n")),
+    )
+    assert lowered.metadata["schedule"]["granularity"] == "layout-transfer"
+    assert lowered.metadata["schedule"]["layout_transfer"] is transfer
+
+    overridden = lower_for_target(
+        program,
+        backend=Target.TRITON,
+        tensors=specs,
+        pass_options={
+            "ssa.select_schedule": {"granularity": "elementwise-grid"},
+        },
+    )
+
+    assert "layout_transfer" not in overridden.metadata["schedule"]
+
+
+@pytest.mark.parametrize(
+    ("specs", "source", "reason"),
+    (
+        (
+            _permuted_specs(source_program=(2, 3), destination_program=(3, 2)),
+            "\ndef copy(x, out):\n    out = x\n",
+            "program shapes are statically incompatible",
+        ),
+        (
+            (
+                TensorSpec(ndim=2, shape=(2, 3), dtype="float32", name="x"),
+                TensorSpec(ndim=2, shape=(3, 4), dtype="float32", name="out"),
+            ),
+            "\ndef transpose(x, out):\n    out = x.T\n",
+            "logical value shapes are statically incompatible",
+        ),
+    ),
+)
+def test_static_mismatch_is_rejected_from_layout_schedule(specs, source, reason):
+    program = _program(source, specs)
+
+    lowered = lower_for_target(program, backend=Target.TRITON, tensors=specs)
+    transfer = lowered.metadata["analysis"]["layout_transfer"]
+
+    assert not transfer.schedulable
+    assert transfer.failure_reason == reason
+    assert lowered.metadata["schedule"]["granularity"] == "elementwise-grid"
+    assert "layout_transfer" not in lowered.metadata["schedule"]
+
+
+def test_real_tiled_permute_uses_value_axis_contributions():
+    source = Tensor(shape=(8, 12)).permute((1, 0)).tile((3, 2))
+    destination = Tensor(shape=(12, 8)).tile((3, 2))
+    specs = tensor_specs(("x", "out"), (source, destination))
+    transfer = analyze_layout_transfer(
+        _program(_COPY_SOURCE, specs),
+        specs,
+    )
+
+    assert transfer.permutation == (1, 0)
+    assert transfer.source.access_map is specs[0].layout.value_accesses[-1]
+    assert transfer.destination.access_map is specs[1].layout.value_accesses[-1]
+    assert not transfer.requires_tiling
+    assert transfer.schedulable
+
+
+def test_original_non_contiguous_stride_and_predicate_are_preserved():
+    specs = _permuted_specs(
+        source_strides=("row_stride", "column_stride"),
+        source_predicate="value_1 < n",
+    )
+    transfer = _analyze_copy(specs)
+
+    assert transfer.source.layout is specs[0].layout
+    assert transfer.source.access_map is specs[0].layout.value_accesses[-1]
+    assert transfer.source.layout.source_strides == (
+        _expr("row_stride"),
+        _expr("column_stride"),
+    )
+    assert transfer.source.access_map.predicate == _expr("value_1 < n")
+
+
+def test_multiple_live_layout_transfers_are_ambiguous():
+    first = _permuted_specs(names=("x0", "out0"))
+    second = _permuted_specs(names=("x1", "out1"))
+    specs = (*first, *second)
+    program = _program(
+        "\ndef two(x0, out0, x1, out1):\n    out0 = x0\n    out1 = x1\n",
+        specs,
+    )
+
+    assert analyze_layout_transfer(program, specs) is None
+
+
+def test_unproven_effect_or_coordinate_contract_is_rejected():
+    specs = _permuted_specs()
+    conditional = _program(
+        "\ndef conditional(x, out):\n    if x > 0:\n        out = x\n",
+        specs,
+    )
+    unknown_axes = _permuted_specs(
+        source_indices=("j", "i"),
+        destination_indices=("i", "j"),
+    )
+    mixed_specs = tensor_specs(
+        ("x", "out"),
+        (
+            Tensor(shape=(8, 12)).permute((1, 0)).tile((3, 2)),
+            Tensor(shape=(12, 8)),
+        ),
+    )
+    scaled_axes = _permuted_specs(
+        source_indices=("value_1", "2 * value_0"),
+        destination_indices=("value_0", "value_1"),
+    )
+    inconsistent_index = _permuted_specs(
+        source_indices=("value_1", "value_0"),
+        destination_indices=("value_0", "value_1"),
+        source_linear_index="value_0 + value_1",
+    )
+    inconsistent_outer_mapping = _permuted_specs(
+        destination_indices=("value_0", "2 * outer_index + value_1"),
+    )
+    unmapped_outer_domain = _permuted_specs(
+        source_indices=("value_1", "value_0"),
+        destination_indices=("value_0", "value_1"),
+    )
+    missing_value_access = _permuted_specs(
+        source_tiled=False,
+        destination_tiled=False,
+    )
+    indexed_store = _program(
+        """
+def indexed(x, out):
+    out.source[out.offsets(0), out.offsets(1)] = x
+""",
+        specs,
+    )
+
+    assert analyze_layout_transfer(conditional, specs) is None
+    assert analyze_layout_transfer(indexed_store, specs) is None
+
+    for rejected_specs in (
+        inconsistent_index,
+        inconsistent_outer_mapping,
+        missing_value_access,
+        mixed_specs,
+        scaled_axes,
+        unknown_axes,
+        unmapped_outer_domain,
+    ):
+        _assert_copy_rejected(rejected_specs)

--- a/tests/test_ssa_first_backend_lowering.py
+++ b/tests/test_ssa_first_backend_lowering.py
@@ -1182,19 +1182,26 @@ def scalarized_index_application(x, indices, y):
             assert transpose.operands == ("x",)
 
         expected = {
-            "triton": (
-                "ssa-unified-triton-emitter",
-                "tl.load(x + (v2) * (cols) + (v1)",
-            ),
             "cuda": ("ssa-unified-cuda-emitter", "x[(v2) * (cols) + (v1)]"),
             "tilelang": ("ssa-unified-tilelang-emitter", "x_buf[(v2) * (cols) + (v1)]"),
         }
 
-        for backend, (route, source_fragment) in expected.items():
-            artifact = emit_kernel(kernel, backend)
-            _assert_ssa_artifact(artifact, route=route)
+        for frontend_kernel in (kernel, attribute_kernel):
+            artifact = emit_kernel(frontend_kernel, "triton")
+            _assert_ssa_artifact(
+                artifact,
+                route="ssa-unified-triton-emitter",
+            )
             assert "linalg.transpose" not in str(artifact.metadata["ssa"])
-            assert source_fragment in artifact.primary_source
+            assert (
+                "transfer_value = tl.trans(transfer_value)" in artifact.primary_source
+            )
+
+            for backend, (route, source_fragment) in expected.items():
+                artifact = emit_kernel(frontend_kernel, backend)
+                _assert_ssa_artifact(artifact, route=route)
+                assert "linalg.transpose" not in str(artifact.metadata["ssa"])
+                assert source_fragment in artifact.primary_source
 
     def test_from_source_emits_store_inside_scf_for_without_operator_dispatch(self):
         kernel = _ssa_kernel(

--- a/tests/test_triton_layout_transfer.py
+++ b/tests/test_triton_layout_transfer.py
@@ -1,0 +1,150 @@
+from ninetoothed import Tensor
+from ninetoothed.backends import Target, emit
+from ninetoothed.frontend.layout import tensor_specs
+from ninetoothed.frontend.python import from_source
+from ninetoothed.ir import Kernel, TensorSpec
+
+
+def _transpose_kernel(*, compiler_options=None) -> Kernel:
+    source = "\ndef arbitrary_name(x, out):\n    out = x.T\n"
+    tensors = (
+        TensorSpec(ndim=2, shape=("m", "n"), dtype="float32", name="x"),
+        TensorSpec(ndim=2, shape=("n", "m"), dtype="float32", name="out"),
+    )
+    program = from_source(source, tensors, kind="layout_transfer_test")
+    assert program is not None
+
+    return Kernel(
+        kernel_name="layout_transfer_test",
+        source=source,
+        source_language="ninetoothed-python",
+        entrypoint="layout_transfer_test",
+        tensors=tensors,
+        compiler_options=compiler_options or {},
+        ssa=program,
+    )
+
+
+def test_triton_layout_transfer_emits_tiled_transpose_with_independent_tails():
+    artifact = emit(_transpose_kernel(), Target.TRITON)
+    source = artifact.primary_source
+
+    compile(source, "layout_transfer_test.triton.py", "exec")
+
+    for fragment in (
+        "TILE_M: tl.constexpr",
+        "TILE_N: tl.constexpr",
+        "_ninetoothed_tile_m=16",
+        "_ninetoothed_tile_n=16",
+        "grid = (((n + _ninetoothed_tile_m - 1) // _ninetoothed_tile_m) * "
+        "((m + _ninetoothed_tile_n - 1) // _ninetoothed_tile_n),)",
+        "source_value_0 = transfer_tile_row * TILE_M + tl.arange(0, TILE_M)[None, :]",
+        "source_value_1 = transfer_tile_column * TILE_N + "
+        "tl.arange(0, TILE_N)[:, None]",
+        "transfer_value = tl.trans(transfer_value)",
+    ):
+        assert fragment in source
+
+    assert "triton.cdiv(n, _ninetoothed_tile_m)" not in source
+
+    load = next(
+        line for line in source.splitlines() if "transfer_value = tl.load" in line
+    )
+    store = next(line for line in source.splitlines() if "tl.store(out +" in line)
+    assert "source_value_0 < (n)" in load
+    assert "source_value_1 < (m)" in load
+    assert "destination_value_0" not in load
+    assert "destination_value_0 < (n)" in store
+    assert "destination_value_1 < (m)" in store
+    assert "source_value_0" not in store
+
+
+def test_triton_layout_transfer_exposes_legal_schedule_candidates():
+    artifact = emit(_transpose_kernel(), Target.TRITON)
+    candidates = artifact.metadata["ssa_schedule_candidates"]
+
+    assert tuple(candidate["name"] for candidate in candidates) == (
+        "transpose-16x16",
+        "transpose-32x32",
+    )
+    assert tuple(
+        (
+            candidate["schedule"]["tile"],
+            candidate["schedule"]["num_warps"],
+            candidate["schedule"]["num_stages"],
+        )
+        for candidate in candidates
+    ) == (
+        ({"block_m": 16, "block_n": 16}, 4, 1),
+        ({"block_m": 32, "block_n": 32}, 8, 1),
+    )
+    assert artifact.metadata["ssa_schedule"]["tile"] == {
+        "block_m": 16,
+        "block_n": 16,
+    }
+    assert artifact.metadata["layout_transfer"]["private_meta_parameters"] == (
+        "TILE_M",
+        "TILE_N",
+    )
+    assert artifact.metadata["layout_transfer"]["value_constraints"] == (
+        (("n", "m"), ("n", "m")),
+    )
+    assert artifact.metadata["layout_transfer"]["physical_constraints"] == (
+        ("n", "n"),
+        ("m", "m"),
+    )
+    assert artifact.metadata["layout_transfer"]["program_constraints"] == (
+        (("n", "m"), ("n", "m")),
+    )
+
+
+def test_explicit_candidate_survives_single_config_limit_with_selected_warps():
+    artifact = emit(
+        _transpose_kernel(
+            compiler_options={
+                "max_num_configs": 1,
+                "ssa_pass_options": {
+                    "ssa.triton.optimize_schedule": {"candidate": "transpose-32x32"}
+                },
+            }
+        ),
+        Target.TRITON,
+    )
+
+    (candidate,) = artifact.metadata["ssa_schedule_candidates"]
+    assert candidate["name"] == "transpose-32x32"
+    assert candidate["schedule"] == {
+        "tile": {"block_m": 32, "block_n": 32},
+        "num_warps": 8,
+        "num_stages": 1,
+    }
+    assert artifact.metadata["ssa_schedule"]["num_warps"] == 8
+    assert "_ninetoothed_num_warps=8" in artifact.primary_source
+
+
+def test_non_power_of_two_pre_tiled_transfer_uses_generic_emission():
+    tensors = tensor_specs(
+        ("x", "out"),
+        (
+            Tensor(shape=(8, 12)).permute((1, 0)).tile((3, 2)),
+            Tensor(shape=(12, 8)).tile((3, 2)),
+        ),
+    )
+    source = "\ndef copy(x, out):\n    out = x\n"
+    program = from_source(source, tensors, kind="layout_transfer_test")
+    assert program is not None
+    artifact = emit(
+        Kernel(
+            kernel_name="layout_transfer_test",
+            source=source,
+            source_language="ninetoothed-python",
+            entrypoint="layout_transfer_test",
+            tensors=tensors,
+            ssa=program,
+        ),
+        Target.TRITON,
+    )
+
+    assert "transfer_value = tl.trans(transfer_value)" not in artifact.primary_source
+    assert "tl.arange(0, 3)" not in artifact.primary_source
+    assert "layout_transfer" not in artifact.metadata

--- a/tests/test_triton_layout_transfer_runtime.py
+++ b/tests/test_triton_layout_transfer_runtime.py
@@ -6,11 +6,9 @@ import torch
 
 import ninetoothed
 from ninetoothed import Tensor, block_size
-from ninetoothed.backends.materializers.triton import (
-    _aot_wrapper,
-    _runtime_layout_transfer_validator,
-)
+from ninetoothed.backends.materializers.triton import _aot_wrapper
 from ninetoothed.compiler import load_built_artifact
+from ninetoothed.compiler.layout_runtime import build_layout_transfer_validator
 from ninetoothed.ir import LaunchABI, LaunchBinding
 from tests.utils import get_available_devices
 
@@ -62,7 +60,7 @@ def test_layout_transfer_runtime_contract_and_aot_wiring():
     metadata = _metadata()
     x = torch.empty((2, 3))
     out = torch.empty((3, 2))
-    validate = _runtime_layout_transfer_validator(metadata, abi)
+    validate = build_layout_transfer_validator(metadata, abi)
 
     validate({"x": x, "out": out})
 
@@ -73,7 +71,7 @@ def test_layout_transfer_runtime_contract_and_aot_wiring():
     )
 
     with pytest.raises(ValueError, match="physical shapes"):
-        _runtime_layout_transfer_validator(provenance_only, abi)(
+        build_layout_transfer_validator(provenance_only, abi)(
             {"x": x, "out": torch.empty((2, 3))}
         )
 
@@ -96,7 +94,7 @@ def test_layout_transfer_runtime_contract_and_aot_wiring():
         ),
     ):
         with pytest.raises(ValueError, match=expected):
-            _runtime_layout_transfer_validator(
+            build_layout_transfer_validator(
                 _metadata(**{constraint: replacement}), abi
             )({"x": x, "out": out})
 
@@ -123,7 +121,7 @@ def test_layout_transfer_runtime_contract_and_aot_wiring():
         lambda: None,
         abi,
         (),
-        validate_bindings=_runtime_layout_transfer_validator(
+        validate_bindings=build_layout_transfer_validator(
             _metadata(program_constraints=((("sx0",), ("dy0",)),)), abi
         ),
     )

--- a/tests/test_triton_layout_transfer_runtime.py
+++ b/tests/test_triton_layout_transfer_runtime.py
@@ -1,0 +1,205 @@
+import json
+from pathlib import Path
+
+import pytest
+import torch
+
+import ninetoothed
+from ninetoothed import Tensor, block_size
+from ninetoothed.backends.materializers.triton import (
+    _aot_wrapper,
+    _runtime_layout_transfer_validator,
+)
+from ninetoothed.compiler import load_built_artifact
+from ninetoothed.ir import LaunchABI, LaunchBinding
+from tests.utils import get_available_devices
+
+BLOCK_SIZE = block_size(16, 32)
+
+
+def _permutation_arrangement(input, output, BLOCK_SIZE=BLOCK_SIZE):
+    return (
+        input.tile((BLOCK_SIZE, BLOCK_SIZE)),
+        output.permute((1, 0)).tile((BLOCK_SIZE, BLOCK_SIZE)),
+    )
+
+
+def _copy_application(input, output):
+    output = input  # noqa: F841
+
+
+def _abi():
+    return LaunchABI(
+        public_args=("x", "out"),
+        kernel_args=(
+            LaunchBinding(name="x", kind="tensor", source="x"),
+            LaunchBinding(name="out", kind="tensor", source="out"),
+            LaunchBinding(name="sx0", kind="shape", source="x", dim=0),
+            LaunchBinding(name="sx1", kind="shape", source="x", dim=1),
+            LaunchBinding(name="dy0", kind="shape", source="out", dim=0),
+            LaunchBinding(name="dy1", kind="shape", source="out", dim=1),
+        ),
+        outputs=("out",),
+    )
+
+
+def _metadata(**overrides):
+    transfer = {
+        "source_binding": "x",
+        "destination_binding": "out",
+        "permutation": (1, 0),
+        "physical_constraints": (("sx0", "dy1"), ("sx1", "dy0")),
+        "value_constraints": ((("sx1", "sx0"), ("dy0", "dy1")),),
+        "program_constraints": ((("sx1", "sx0"), ("dy0", "dy1")),),
+    }
+    transfer.update(overrides)
+
+    return {"layout_transfer": transfer}
+
+
+def test_layout_transfer_runtime_contract_and_aot_wiring():
+    abi = _abi()
+    metadata = _metadata()
+    x = torch.empty((2, 3))
+    out = torch.empty((3, 2))
+    validate = _runtime_layout_transfer_validator(metadata, abi)
+
+    validate({"x": x, "out": out})
+
+    provenance_only = _metadata(
+        physical_constraints=(),
+        value_constraints=(),
+        program_constraints=(),
+    )
+
+    with pytest.raises(ValueError, match="physical shapes"):
+        _runtime_layout_transfer_validator(provenance_only, abi)(
+            {"x": x, "out": torch.empty((2, 3))}
+        )
+
+    with pytest.raises(ValueError, match="destination strides"):
+        validate({"x": x, "out": torch.empty_strided((3, 2), (0, 1))})
+
+    validate({"x": x, "out": torch.empty_strided((3, 2), (3, 4))})
+
+    for constraint, replacement, expected in (
+        ("physical_constraints", (("sx0", "dy0"),), "physical shapes"),
+        (
+            "value_constraints",
+            ((("sx0",), ("dy0",)),),
+            "value domains",
+        ),
+        (
+            "program_constraints",
+            ((("sx0",), ("dy0",)),),
+            "program domains",
+        ),
+    ):
+        with pytest.raises(ValueError, match=expected):
+            _runtime_layout_transfer_validator(
+                _metadata(**{constraint: replacement}), abi
+            )({"x": x, "out": out})
+
+    storage = torch.empty(7)
+    overlapping_x = storage[:6].view(2, 3)
+    overlapping_out = storage[1:7].view(3, 2)
+
+    with pytest.raises(ValueError, match="non-overlapping"):
+        validate({"x": overlapping_x, "out": overlapping_out})
+
+    class Function:
+        argtypes = None
+        called = False
+
+        def __call__(self, *_args):
+            self.called = True
+
+            return 0
+
+    function = Function()
+    wrapped = _aot_wrapper(
+        function,
+        lambda: 0,
+        lambda: None,
+        abi,
+        (),
+        validate_bindings=_runtime_layout_transfer_validator(
+            _metadata(program_constraints=((("sx0",), ("dy0",)),)), abi
+        ),
+    )
+
+    with pytest.raises(ValueError, match="program domains"):
+        wrapped(x, out)
+
+    assert not function.called
+
+    empty_wrapped = _aot_wrapper(
+        function,
+        lambda: 0,
+        lambda: None,
+        abi,
+        (),
+        validate_bindings=validate,
+    )
+
+    with pytest.raises(ValueError, match="physical shapes"):
+        empty_wrapped(torch.empty((0, 3)), torch.empty((0, 2)))
+
+    assert not function.called
+
+
+@pytest.mark.parametrize("device", get_available_devices())
+def test_layout_transfer_jit_aot_reload_with_dynamic_strides(device, tmp_path):
+    rows, columns = 127, 79
+    input = torch.empty_strided(
+        (rows, columns),
+        (columns + 7, 1),
+        dtype=torch.float16,
+        device=device,
+    )
+    input.copy_(torch.randn_like(input))
+    output = torch.empty_strided(
+        (columns, rows),
+        (rows + 5, 1),
+        dtype=torch.float16,
+        device=device,
+    )
+    jit_kernel = ninetoothed.make(
+        _permutation_arrangement,
+        _copy_application,
+        (Tensor(2), Tensor(2)),
+        backend="triton",
+    )
+
+    jit_kernel(input, output)
+    torch.testing.assert_close(output, input.T, rtol=0, atol=0)
+
+    shared = torch.randn((64, 64), dtype=torch.float16, device=device)
+
+    with pytest.raises(ValueError, match="non-overlapping"):
+        jit_kernel(shared, shared.T)
+
+    aot_kernel = ninetoothed.make(
+        _permutation_arrangement,
+        _copy_application,
+        (
+            Tensor(2, dtype=ninetoothed.float16),
+            Tensor(2, dtype=ninetoothed.float16),
+        ),
+        backend="triton",
+        caller=device,
+        output_dir=tmp_path,
+    )
+    manifest = json.loads(
+        Path(aot_kernel._built_artifact.manifest_path).read_text(encoding="utf-8")
+    )
+
+    assert len(manifest["launch_plan"]["tuning_candidates"]) == 1
+
+    for launch in (aot_kernel, load_built_artifact(aot_kernel._built_artifact)):
+        output.zero_()
+        launch(input, output)
+        torch.testing.assert_close(output, input.T, rtol=0, atol=0)
+
+        with pytest.raises(ValueError, match="non-overlapping"):
+            launch(shared, shared.T)


### PR DESCRIPTION
`pytest` output:
```
$ PYTHONPATH="$PWD/src" pytest -n 16                     
========================================================= test session starts =========================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0                                                                            
rootdir: /home/haojie/ntbackend/.merge-ready/triton-layout-transfer-schedule                                                           
configfile: pyproject.toml                                                                                                             
plugins: xdist-3.8.0, anyio-4.13.0, cov-7.1.0                      
16 workers [413 items]                                                                                                                 
............................................................................................................................... [ 30%] 
................................................................s.............................................................. [ 61%] 
...................................................................s........................................................... [ 92%] 
................................                                                                                                [100%]
=================================================== 411 passed, 2 skipped in 17.46s ===================================================
```


## 修改说明

## 背景

SSA 编译链路已经能够正确生成二维 transpose，但此前 Triton 后端仍将其作为普通逐元素访问处理。

这种生成方式虽然数值正确，但没有显式利用二维布局变换的结构：

- program 与线性输出元素绑定；
- 输入地址通过 div/mod 重新计算；
- global load/store 无法同时保持合并访问；
- 没有构造二维 block，也没有使用 `tl.trans`；
- 对大规模矩阵只能达到约 300–340 GB/s 的有效带宽。

在 NVIDIA L20 上，PR #208 基线中的部分结果为：

| Shape | 端到端延迟 | 有效带宽 |
|---|---:|---:|
| 2048 × 2048 | 51.51 μs | 325.7 GB/s |
| 4096 × 4096 | 206.06 μs | 325.7 GB/s |
| 8192 × 8192 | 787.35 μs | 340.9 GB/s |
| 4097 × 1023 | 56.19 μs | 298.4 GB/s |

历史 Triton 生成路径 `c9ebd495` 在相同场景中明显更快。因此，本 PR 的目标是：

1. 在 SSA/Layout IR 上识别通用二维 layout transfer；
2. 通过标准分析和调度 pass 选择 tiled transfer；
3. 在 Triton 后端物化二维 block load、`tl.trans` 和 block store；
4. 恢复并提升 transpose 性能；
5. 为 CUDA、TileLang 后续复用相同分析和运行时约束建立公共基础设施。

本实现不根据 kernel 名称识别 transpose，也不使用固定 shape 或算子模板。

---

## 修改说明

### 1. 增加结构化 LayoutTransfer 分析

新增后端无关的 `TensorTransfer` 和 `LayoutTransfer`。

`TensorTransfer` 描述传输一侧的物理访问信息：

- `TensorLayout`
- `AccessMap`
- 物理轴映射

`LayoutTransfer` 描述输入到输出之间已经被编译器证明的布局关系：

- source/destination binding
- source/destination physical access
- permutation
- value-domain constraints
- physical shape/stride constraints
- outer program-domain constraints
- 是否需要重新 tiled
- 无法调度时的原因

这些对象为 immutable、keyword-only dataclass，避免 pass 之间意外修改分析结果。

### 2. 从 SSA 数据流推导布局变换

`analyze_layout_transfer()` 从 SSA 和 Layout IR 推导 layout transfer：

1. 找到唯一顶层 `mem.store`；
2. 沿 use-def 链追踪 stored value；
3. 判断数据是否直接来自输入 binding；
4. 读取 `linalg.transpose` 或 arrangement 中的 `AccessMap`；
5. 比较 source/destination 坐标表达式；
6. 推导 destination physical axis 到 source physical axis 的 permutation；
7. 构造动态 value、physical 和 program-domain constraints。

该分析只依赖：

- SSA operation；
- Tensor type；
- Layout IR；
- AccessMap；
- use-def；
- shape、stride 和 predicate。

当前能够识别：

- `x.T` 形成的 `linalg.transpose`；
- frontend 生成的显式二维 transpose；
- arrangement/Layout IR 中表达的二维 axis permutation；
- 已经在 arrangement 中完成分块的直接 layout transfer。

### 3. 严格限制可调度范围

只有能够证明为直接二维 permutation 的数据流才会进入 LayoutTransfer 调度。

以下情况不会使用新的 tiled 路径：

- 存在多个有副作用的 store；
- 存在 atomic operation；
- transpose 结果存在多个不兼容使用者；
- source 或 destination 不是 rank-2；
- permutation 不是完整双射；
- source/destination 坐标无法证明等价；
- outer program domain 不兼容；
- predicate 或动态约束无法表达；
- 输入输出涉及无法验证的融合数据流。

无法证明时保留现有通用 lowering，不会根据代码形状猜测布局关系。

### 4. 接入标准 Pass Pipeline

LayoutTransfer 分析接入现有编译流程：

`Python frontend -> SSA/Layout IR -> analysis -> schedule selection -> backend schedule -> emitter -> materializer`

通用 analysis pass 将 `LayoutTransfer` 写入 analysis metadata。

schedule selection 只有在以下条件同时成立时才选择 `layout-transfer`：

- 分析结果存在；
- transfer 可调度；
- value、physical 和 program-domain contract 完整；
- 当前程序没有与该调度冲突的其他效果。


### 5. 增加 Triton layout-transfer 调度候选

Triton 后端为需要重新 tiled 的 LayoutTransfer 提供两组候选：

| Candidate | Tile | Warps | Stages |
|---|---:|---:|---:|
| `transpose-16x16` | 16 × 16 | 4 | 1 |
| `transpose-32x32` | 32 × 32 | 8 | 1 |

候选进入现有 `LaunchPlan.tuning_candidates`，继续复用当前 Triton AutoTuner：

- 不增加第二套 tuner；
- `max_num_configs` 继续生效；
- 用户显式配置优先；
- winner 使用现有 specialization/cache 机制；
- JIT、AOT 和 reload 使用一致的候选信息。

候选根据 block numel、dtype 和已有后端约束进行合法性过滤。

### 6. 生成二维 Triton block transfer

Triton emitter 根据 LayoutTransfer 生成二维坐标：

- `tl.program_id(0)` 对应二维 tile；
- source 和 destination 分别构造二维 value coordinate；
- source/destination 使用独立 tail predicate；
- 使用 block-valued pointer 执行 `tl.load`；
- 使用 `tl.trans` 完成寄存器内转置；
- 使用 block-valued pointer 执行 `tl.store`。

核心生成结构为：

    destination_value_0 = tile_row * TILE_M + tl.arange(0, TILE_M)[:, None]
    destination_value_1 = tile_column * TILE_N + tl.arange(0, TILE_N)[None, :]

    source_value_0 = tile_row * TILE_M + tl.arange(0, TILE_M)[None, :]
    source_value_1 = tile_column * TILE_N + tl.arange(0, TILE_N)[:, None]

    transfer_value = tl.load(source_pointer, mask=source_mask)
    transfer_value = tl.trans(transfer_value)
    tl.store(destination_pointer, transfer_value, mask=destination_mask)

source 与 destination 的 mask 分开构造，因此矩形矩阵、非二次幂 shape 和尾块不会错误共享 predicate。

对于 arrangement 已经完成合法分块的 transfer，emitter 可以直接消费现有 value shape；无法使用合法 Triton block 表示时继续走通用生成路径。

### 7. 动态布局运行时校验

编译期无法确定的 shape、stride 和 program-domain 关系会序列化到 artifact metadata，并在运行时校验。

新增公共 `compiler.layout_runtime`，负责：

- 动态 source/destination shape 对应关系；
- permutation 后的 physical extent；
- program-domain constraints；
- 输出 Tensor stride 是否可能产生重叠写入；
- 输入输出 storage span 是否重叠；
- view、offset 和负 stride 的保守地址区间计算。

例如二维 transpose 要求：

    source.shape      = (M, N)
    permutation       = (1, 0)
    destination.shape = (N, M)

动态参数不满足该关系时，会在 kernel launch 前给出明确错误，而不是启动错误配置的 kernel。

### 8. 防止不安全的原地布局变换

tiled transpose 不支持输入输出 storage overlap。

运行时根据以下信息计算 Tensor 可能访问的字节区间：

- device
- data pointer
- shape
- stride
- element size

因此即使输入输出是不同的 Python wrapper，只要底层 storage 区间重叠，也会被识别。

对于无法准确计算地址范围的 tensor-like 对象，采用 fail-closed 策略，不假设其安全。

### 9. 公共能力从 Triton 下沉到 compiler

最新调整将后端无关能力从 Triton emitter/materializer 移入 compiler 公共层。

`compiler.layout.serialize_layout_transfer()` 统一序列化：

- source/destination binding
- permutation
- value constraints
- physical constraints
- program constraints
- requires_tiling

Triton emitter 只追加自身调度信息：

- `block_shape`
- private meta parameters

`compiler.layout_runtime.build_layout_transfer_validator()` 统一构造运行时 validator。

Triton JIT、AOT 和跨进程 reload 均复用该公共实现。

storage span 和 overlap 判断也由公共模块提供，并同时供 Triton autotune alias 检查使用。

该重构不改变生成源码、调度候选、Launch ABI、缓存键或性能结果，但使未来 CUDA、TileLang 可以直接复用同一套 LayoutTransfer 语义与安全校验。

### 10. JIT、AOT、build 和 reload 接入

LayoutTransfer metadata 和 runtime validator 已接入：

- Triton JIT；
- `make()`；
- AOT build；
- built artifact reload；
- 跨进程 reload；
- autotune candidate materialization。

所有路径使用相同的：

- LayoutTransfer contract；
- Launch ABI；
- runtime binding；
- shape/stride validator；
- storage overlap 规则。

---


## 性能结果

### 测试环境

- GPU：NVIDIA L20
- Compute Capability：8.9
- 数据类型：FP16
- 每个 case 预热 20 次
- 使用 4 组轮换 buffer
- 每轮累计测试时间约 200 ms
- 共测试 5 轮
- 记录 endpoint 与 kernel-only 延迟
- 每个性能点均执行完整输出正确性验证

对比版本：

- **PR #208 基线**：`c12bf3311ef5d8ce5b8db894697bcb715be870d1`
- **本 PR**：LayoutTransfer tiled Triton 实现
- **历史 Triton master**：`c9ebd4950a185beed8d4c1db9ff4a1fd133934ae`

表中延迟越低越好；Speedup 大于 `1.0×` 表示本 PR 更快。

| Shape | 类型 | PR #208 | 本 PR | 相对 PR #208 | 历史 master | 相对历史 master |
|---|---|---:|---:|---:|---:|---:|
| 512 × 512 | contiguous | 13.67 μs | 14.06 μs | 0.97× | 18.30 μs | 1.30× |
| 1024 × 1024 | contiguous | 14.51 μs | 14.03 μs | 1.03× | 18.14 μs | 1.29× |
| 2048 × 2048 | contiguous | 51.51 μs | 16.49 μs | 3.12× | 18.14 μs | 1.10× |
| 4096 × 4096 | contiguous | 206.06 μs | 104.94 μs | 1.96× | 103.09 μs | 0.98× |
| 6144 × 6144 | contiguous | 462.49 μs | 257.69 μs | 1.79× | 252.47 μs | 0.98× |
| 8192 × 8192 | contiguous | 787.35 μs | 462.86 μs | 1.70× | 450.55 μs | 0.97× |
| 4096 × 1024 | contiguous | 53.73 μs | 14.11 μs | 3.81× | 18.02 μs | 1.28× |
| 1024 × 4096 | contiguous | 53.14 μs | 16.49 μs | 3.22× | 17.98 μs | 1.09× |
| 8192 × 2048 | contiguous | 211.99 μs | 102.18 μs | 2.07× | 100.51 μs | 0.98× |
| 2048 × 8192 | contiguous | 194.52 μs | 107.33 μs | 1.81× | 106.73 μs | 0.99× |
| 1000 × 1537 | held-out | 20.56 μs | 14.10 μs | 1.46× | 18.19 μs | 1.29× |
| 4097 × 1023 | held-out | 56.19 μs | 16.74 μs | 3.36× | 17.99 μs | 1.08× |
| 1127 × 781 | dynamic stride | 24.79 μs | 14.31 μs | 1.73× | 18.04 μs | 1.26× |

汇总：

- 相对 PR #208，13 个性能点的端到端几何平均提升约 **1.98×**。
- 相对历史 Triton master `c9ebd495`，几何平均提升约 **1.12×**。
- 最大提升为 `4096 × 1024`：约 **3.81×**。
- held-out `4097 × 1023` 提升约 **3.36×**。
- 动态 stride 场景提升约 **1.73×**。
- 大规模连续 transpose 达到约 **580–640 GB/s**。
- 部分矩形和非规则 shape 达到约 **1.0–1.19 TB/s** 有效带宽。
- 相对历史 master 的最差单点回归低于 3%。
- `512 × 512` 相对 PR #208 有约 2.9% 波动，但仍比历史 master 快约 30%。

最新公共 LayoutTransfer 重构只移动序列化和运行时校验代码，没有改变 emitter 输出和调度候选，因此上述性能结果仍适用于当前 PR。

---

## 能力边界

本 PR 当前只优化已经证明的直接 rank-2 layout permutation。

暂不包括：

- 三维及更高维 permute；
- 多个 layout transfer 的 kernel 拆分；
- transpose 与复杂计算的任意融合；
- matmul 中隐式 transpose 的 contraction layout 选择；
- im2col 等复合数据搬运；
- CUDA layout-transfer emitter；
- TileLang layout-transfer emitter；
- 原地 transpose；
- 无法证明 storage/layout 安全时的激进调度。

这些能力可以在现有 `TensorTransfer`、`LayoutTransfer`、AccessMap、公共 serializer 和 runtime validator 基础上继续扩展，不需要重新设计整套基础设施。


默认后端行为、Launch ABI 和 artifact 加载方式保持不变。

普通 elementwise、reduction、matmul、attention、CUDA 和 TileLang 路径不受影响。