### PR TITLE
Optimize CUDA row reductions cooperatively

### DIFF
--- a/src/ninetoothed/backends/cuda.py
+++ b/src/ninetoothed/backends/cuda.py
@@ -84,6 +84,34 @@ class CudaOptimizeSchedule(OptimizeSchedule):
     ) -> tuple[ScheduleCandidate, ...]:
         del context
 
+        reduction = schedule.get("reduction", {})
+
+        if (
+            schedule.get("granularity") == "parallel-reduction"
+            and isinstance(reduction, Mapping)
+            and reduction.get("mode") == "row-vector"
+        ):
+            extent = _static_extent(reduction.get("extent"))
+
+            if extent is not None and extent <= 32:
+                thread_counts = (32, 128, 256)
+            elif extent is not None and extent <= 128:
+                thread_counts = (128, 256, 32)
+            else:
+                thread_counts = (256, 128, 32)
+
+            return tuple(
+                ScheduleCandidate(
+                    name=f"cooperative-reduction-{threads}",
+                    schedule={
+                        "cuda_cooperative_reduction": True,
+                        "threads": threads,
+                    },
+                    tags=("cooperative-reduction",),
+                )
+                for threads in thread_counts
+            )
+
         if schedule.get("granularity") != "blocked-linalg" or not analysis.get(
             "dot_supports_low_precision_intrinsic", False
         ):
@@ -124,6 +152,13 @@ class CudaOptimizeSchedule(OptimizeSchedule):
 
             return {"preserve_linalg": preserve_linalg}
         return {}
+
+
+def _static_extent(value: Any) -> int | None:
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return None
 
 
 def register_ssa_passes(registry: "Registry") -> None:

--- a/src/ninetoothed/backends/emitters/base.py
+++ b/src/ninetoothed/backends/emitters/base.py
@@ -28,6 +28,7 @@ class ModuleRenderContext:
     vector_program: bool
     block_program: bool
     scalar_program: bool
+    cooperative_reduction_program: bool = False
     private_meta_parameters: tuple[tuple[str, int], ...] = ()
     scheduled_metadata: Mapping[str, Any] = field(default_factory=dict)
 
@@ -104,6 +105,26 @@ class EmitterTarget(ABC):
         return None
 
     def emit_reduction_loop(self, local, operation, context):
+        del local, operation, context
+
+        return None
+
+    def supports_cooperative_reduction(self, schedule: Mapping[str, Any]) -> bool:
+        del schedule
+
+        return False
+
+    def thread_id(self) -> str:
+        raise NotImplementedError(
+            f"Emitter {type(self).__name__} has no thread-id expression."
+        )
+
+    def thread_count(self) -> str:
+        raise NotImplementedError(
+            f"Emitter {type(self).__name__} has no thread-count expression."
+        )
+
+    def emit_cooperative_reduction(self, local, operation, context):
         del local, operation, context
 
         return None

--- a/src/ninetoothed/backends/emitters/context.py
+++ b/src/ninetoothed/backends/emitters/context.py
@@ -66,7 +66,9 @@ class EmitContext:
     layout_contiguous: bool = False
     vector_program: bool = False
     reduction_lane: str | None = None
+    cooperative_reduction_program: bool = False
     scheduled_reductions: frozenset[str] = frozenset()
+    reduction_schedule: Mapping[str, Any] | None = None
 
     def child(
         self,
@@ -107,7 +109,9 @@ class EmitContext:
             "layout_contiguous": self.layout_contiguous,
             "vector_program": self.vector_program,
             "reduction_lane": self.reduction_lane,
+            "cooperative_reduction_program": self.cooperative_reduction_program,
             "scheduled_reductions": self.scheduled_reductions,
+            "reduction_schedule": self.reduction_schedule,
         }
         data.update(kwargs)
 

--- a/src/ninetoothed/backends/emitters/cuda.py
+++ b/src/ninetoothed/backends/emitters/cuda.py
@@ -18,13 +18,16 @@ _dtype_level = common.dtype_level
 _emit_element = common.emit_element
 _emit_loop_bound = common.emit_loop_bound
 _emit_value = common.emit_value
+_fresh_temp = common.fresh_temp
 _indent_lines = common.indent_lines
 _linearized_index = common.linearized_index
 _load_other = common.load_other
 _local_symbol = common.local_symbol
 _materialize_bool_expr = common.materialize_bool_expr
 _materialize_index_expr = common.materialize_index_expr
+_nested_local_suffix = common.nested_local_suffix
 _normalize_dtype = common.normalize_dtype
+_reduction_identity = common.reduction_identity
 _source_index_for_value = common.source_index_for_value
 _target_index_expr = common.target_index_expr
 _value_axes = common.value_axes
@@ -134,6 +137,32 @@ class CudaTarget(EmitterTarget):
         function = functions.get(name, name)
 
         return f"{function}({', '.join(args)})"
+
+    def supports_cooperative_reduction(self, schedule):
+        try:
+            threads = int(schedule.get("threads", 256))
+        except (TypeError, ValueError):
+            return False
+
+        return bool(
+            schedule.get("cuda_cooperative_reduction")
+            and 32 <= threads <= 256
+            and threads % 32 == 0
+        )
+
+    def program_id(self, axis=0):
+        if axis != 0:
+            raise ValueError("CUDA cooperative reduction uses a one-dimensional grid.")
+        return "static_cast<int64_t>(blockIdx.x)"
+
+    def thread_id(self):
+        return "static_cast<int64_t>(threadIdx.x)"
+
+    def thread_count(self):
+        return "static_cast<int64_t>(blockDim.x)"
+
+    def emit_cooperative_reduction(self, local, operation, context):
+        return _emit_cuda_cooperative_reduction(local, operation, context)
 
     def local_decl(self, type_: ssa.Type, name: str, expr: str) -> str:
         if type_.kind == "pointer":
@@ -252,6 +281,9 @@ class CudaTarget(EmitterTarget):
     bool nt_matrix_active = nt_matrix_row < ({context.axes[0]}) && nt_matrix_col < ({context.axes[1]});
 {common.indent_block(body, "    ")}"""
             blocks_expr = grid_total
+        elif context.cooperative_reduction_program:
+            kernel_prelude = body
+            blocks_expr = grid_total
         else:
             kernel_prelude = f"""    int64_t {self.index_name} = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
     if ({self.index_name} < {total}) {{
@@ -297,6 +329,145 @@ extern "C" int launch_{kernel.kernel_name}(
     return static_cast<int>(cudaGetLastError());
 }}
 """
+
+
+def _emit_cuda_cooperative_reduction(
+    local: str, operation: ssa.Operation, ctx: _EmitContext
+) -> str:
+    schedule = dict(ctx.reduction_schedule or {})
+    axis = int(schedule["axis"]) if "axis" in schedule else None
+
+    if axis is None or not operation.operands or not operation.results:
+        raise ValueError("Malformed CUDA cooperative reduction operation.")
+
+    operator = operation.opcode[len("reduce.") :]
+    operand = operation.operands[0]
+    operand_axes = _value_axes(operand, ctx)
+    extent = str(schedule.get("extent", operand_axes[axis]))
+    operand_type = ctx.value_types.get(operand)
+    result_dtype = _normalize_dtype(operation.results[0].type.dtype or "float32")
+    operand_dtype = _normalize_dtype(
+        operand_type.dtype if operand_type is not None else result_dtype
+    )
+    accumulator_dtype = _cuda_reduction_accumulator_dtype(operand_dtype, result_dtype)
+    accumulator_type = ssa.Type(kind="scalar", dtype=accumulator_dtype)
+    accumulator = _fresh_temp(ctx, "nt_reduce_acc")
+    reduction_index = _fresh_temp(ctx, "nt_reduce_index")
+    shuffle_offset = _fresh_temp(ctx, "nt_reduce_offset")
+    shared = _fresh_temp(ctx, "nt_reduce_shared")
+    identity = _reduction_identity(operator, accumulator_type, ctx.target)
+    coordinates = list(ctx.coordinate_exprs)
+    coordinates[axis] = reduction_index
+    coordinates = tuple(coordinates)
+    linear = _target_index_expr(
+        ctx.target, _linearized_index(coordinates, operand_axes)
+    )
+    body_lines: list[str] = []
+    body = ctx.child(
+        lines=body_lines,
+        memo=dict(ctx.memo),
+        coordinate_exprs=coordinates,
+        index_expr=linear,
+        inner_index_expr=linear,
+        reduce_axis=axis,
+        reduce_index=reduction_index,
+        mask_expr=None,
+        local_suffix=_nested_local_suffix(ctx, accumulator),
+    )
+    term = _emit_element(operand, coordinates, body)
+    term = ctx.target.cast(accumulator_dtype, term)
+    body_lines.append(
+        f"{accumulator} = "
+        f"{_cuda_reduction_update(operator, accumulator, term, accumulator_dtype)};"
+    )
+
+    ctx.lines.append(ctx.target.local_decl(accumulator_type, accumulator, identity))
+    ctx.lines.append(
+        ctx.target.loop_header(
+            reduction_index,
+            ctx.target.thread_id(),
+            extent,
+            ctx.target.thread_count(),
+        )
+    )
+    ctx.lines.extend(_indent_lines(body_lines, ctx.target))
+    ctx.lines.append("}")
+    ctx.lines.append(
+        f"for (int {shuffle_offset} = 16; {shuffle_offset} > 0; "
+        f"{shuffle_offset} >>= 1) {{"
+    )
+    shuffle = f"__shfl_down_sync(0xffffffffu, {accumulator}, {shuffle_offset})"
+    ctx.lines.append(
+        f"    {accumulator} = "
+        f"{_cuda_reduction_update(operator, accumulator, shuffle, accumulator_dtype)};"
+    )
+    ctx.lines.append("}")
+    ctx.lines.append(
+        f"__shared__ {ctx.target.type_name(accumulator_dtype)} {shared}[8];"
+    )
+    ctx.lines.append(
+        f"if ((threadIdx.x & 31) == 0) {{ "
+        f"{shared}[threadIdx.x >> 5] = {accumulator}; }}"
+    )
+    ctx.lines.append("__syncthreads();")
+    ctx.lines.append("if (threadIdx.x < 32) {")
+    ctx.lines.append(
+        f"    {accumulator} = threadIdx.x < ((blockDim.x + 31) / 32) "
+        f"? {shared}[threadIdx.x] : {identity};"
+    )
+    ctx.lines.append(
+        f"    for (int {shuffle_offset} = 16; {shuffle_offset} > 0; "
+        f"{shuffle_offset} >>= 1) {{"
+    )
+    shuffle = f"__shfl_down_sync(0xffffffffu, {accumulator}, {shuffle_offset})"
+    ctx.lines.append(
+        f"        {accumulator} = "
+        f"{_cuda_reduction_update(operator, accumulator, shuffle, accumulator_dtype)};"
+    )
+    ctx.lines.append("    }")
+    ctx.lines.append(f"    if (threadIdx.x == 0) {{ {shared}[0] = {accumulator}; }}")
+    ctx.lines.append("}")
+    ctx.lines.append("__syncthreads();")
+    result_type = ssa.Type(kind="scalar", dtype=result_dtype)
+    ctx.lines.append(
+        ctx.target.local_decl(
+            result_type,
+            local,
+            ctx.target.cast(result_dtype, f"{shared}[0]"),
+        )
+    )
+
+    return local
+
+
+def _cuda_reduction_accumulator_dtype(operand_dtype: str, result_dtype: str) -> str:
+    if operand_dtype in {
+        "float8_e4m3fn",
+        "float8_e5m2",
+        "float16",
+        "bfloat16",
+    }:
+        return "float32"
+
+    if operand_dtype == "bool":
+        return "int32"
+    return result_dtype
+
+
+def _cuda_reduction_update(operator: str, lhs: str, rhs: str, dtype: str) -> str:
+    if operator == "sum":
+        return f"({lhs}) + ({rhs})"
+
+    if dtype == "float32":
+        function = "fmaxf" if operator == "max" else "fminf"
+        return f"{function}({lhs}, {rhs})"
+
+    if dtype == "float64":
+        function = "fmax" if operator == "max" else "fmin"
+        return f"{function}({lhs}, {rhs})"
+
+    comparison = ">" if operator == "max" else "<"
+    return f"(({lhs}) {comparison} ({rhs}) ? ({lhs}) : ({rhs}))"
 
 
 def _curand_support(context: ModuleRenderContext) -> tuple[str, str]:

--- a/src/ninetoothed/backends/emitters/cuda.py
+++ b/src/ninetoothed/backends/emitters/cuda.py
@@ -460,13 +460,16 @@ def _cuda_reduction_update(operator: str, lhs: str, rhs: str, dtype: str) -> str
 
     if dtype == "float32":
         function = "fmaxf" if operator == "max" else "fminf"
+
         return f"{function}({lhs}, {rhs})"
 
     if dtype == "float64":
         function = "fmax" if operator == "max" else "fmin"
+
         return f"{function}({lhs}, {rhs})"
 
     comparison = ">" if operator == "max" else "<"
+
     return f"(({lhs}) {comparison} ({rhs}) ? ({lhs}) : ({rhs}))"
 
 

--- a/src/ninetoothed/backends/emitters/ssa.py
+++ b/src/ninetoothed/backends/emitters/ssa.py
@@ -170,6 +170,7 @@ def emit(kernel: Kernel, target: EmitterTarget) -> Artifact:
         "launch_block": _launch_block(kernel),
         "program_mode": {
             "block": render_context.block_program,
+            "cooperative_reduction": render_context.cooperative_reduction_program,
             "scalar": render_context.scalar_program,
             "vector": render_context.vector_program,
         },
@@ -235,6 +236,71 @@ def _static_integer(value) -> int | None:
         return int(str(value))
     except (TypeError, ValueError):
         return None
+
+
+def _reduction_program_domain(schedule, target, reduction_coordinate):
+    axes = tuple(str(axis) for axis in schedule.get("value_shape", ()))
+    reduction_axis = int(schedule["axis"])
+    parallel_shape = tuple(str(axis) for axis in schedule.get("parallel_shape", ()))
+    parallel_total = _product(parallel_shape)
+    program_index = target.program_id(0)
+    parallel_index = (
+        "0"
+        if _is_one_expr(parallel_total)
+        else _target_index_expr(target, f"({program_index}) % ({parallel_total})")
+    )
+    coordinates = []
+    parallel_dim = 0
+
+    for dim in range(len(axes)):
+        if dim == reduction_axis:
+            coordinates.append(reduction_coordinate)
+            continue
+
+        coordinates.append(
+            _axis_offset_expr(parallel_shape, parallel_dim, parallel_index, target)
+        )
+        parallel_dim += 1
+
+    coordinates = tuple(coordinates)
+    outer_shape = tuple(str(axis) for axis in schedule.get("program_shape", ()))
+    outer_index = (
+        "0"
+        if not outer_shape
+        else program_index
+        if _is_one_expr(parallel_total)
+        else _target_index_expr(target, f"floor(({program_index})/({parallel_total}))")
+    )
+
+    return (
+        axes,
+        _target_index_expr(target, str(schedule["extent"])),
+        _target_index_expr(target, _product((*outer_shape, *parallel_shape))),
+        outer_index,
+        _linearized_index(coordinates, axes),
+        coordinates,
+    )
+
+
+def _cooperative_program_supported(operations, schedule, value_types):
+    value_shape = tuple(str(dim) for dim in schedule.get("value_shape", ()))
+    result_shape = tuple(str(dim) for dim in schedule.get("result_shape", ()))
+
+    if not value_shape:
+        return False
+
+    for operation in operations:
+        if not _is_top_level_effect(operation):
+            continue
+
+        if operation.opcode != "mem.store" or not operation.operands:
+            return False
+
+        value_axes = _value_type_axes(value_types.get(operation.operands[0]))
+
+        if value_axes not in {value_shape, result_shape}:
+            return False
+    return True
 
 
 def _render_source(
@@ -345,10 +411,18 @@ def _render_source(
     vector_scalar_program = bool(
         target.vector_value_semantics and primary_atomic is not None and not value_axes
     )
+    cooperative_reduction_program = bool(
+        reduction_schedule is not None
+        and target.supports_cooperative_reduction(program.metadata.get("schedule", {}))
+        and _cooperative_program_supported(
+            block.operations, reduction_schedule, value_types
+        )
+    )
     vector_reduction_program = bool(
         target.vector_value_semantics
         and reduction_schedule is not None
         and not vector_block_program
+        and not cooperative_reduction_program
     )
     native_block_program = bool(
         target.native_block_matmul
@@ -370,56 +444,19 @@ def _render_source(
         grid_total = _target_index_expr(target, _product(outer_axes))
         outer_index_expr = target.program_id(0)
         inner_index_expr = "0"
-    elif vector_reduction_program:
-        axes = value_axes
-        reduction_axis = int(reduction_schedule["axis"])
-        parallel_shape = tuple(
-            str(axis) for axis in reduction_schedule.get("parallel_shape", ())
-        )
-        parallel_total = _product(parallel_shape)
-        program_index = target.program_id(0)
-        parallel_index = (
-            "0"
-            if _is_one_expr(parallel_total)
-            else _target_index_expr(target, f"({program_index}) % ({parallel_total})")
-        )
-        coordinate_exprs = []
-        parallel_dim = 0
-
-        for dim in range(len(value_axes)):
-            if dim == reduction_axis:
-                coordinate_exprs.append("offsets")
-                continue
-
-            coordinate_exprs.append(
-                _axis_offset_expr(
-                    parallel_shape,
-                    parallel_dim,
-                    parallel_index,
-                    target,
-                )
-            )
-            parallel_dim += 1
-
-        coordinate_exprs = tuple(coordinate_exprs)
-        total = _target_index_expr(target, str(reduction_schedule["extent"]))
-        outer_program_shape = tuple(
-            str(axis) for axis in reduction_schedule.get("program_shape", ())
-        )
-        grid_total = _target_index_expr(
+    elif vector_reduction_program or cooperative_reduction_program:
+        (
+            axes,
+            total,
+            grid_total,
+            outer_index_expr,
+            inner_index_expr,
+            coordinate_exprs,
+        ) = _reduction_program_domain(
+            reduction_schedule,
             target,
-            _product((*outer_program_shape, *parallel_shape)),
+            "offsets" if vector_reduction_program else "0",
         )
-        outer_index_expr = (
-            "0"
-            if not outer_program_shape
-            else program_index
-            if _is_one_expr(parallel_total)
-            else _target_index_expr(
-                target, f"floor(({program_index})/({parallel_total}))"
-            )
-        )
-        inner_index_expr = _linearized_index(coordinate_exprs, value_axes)
     elif native_block_program:
         axes = value_axes
         total = _target_index_expr(target, _product(value_axes))
@@ -465,8 +502,17 @@ def _render_source(
         block_program=vector_block_program,
         native_block_program=native_block_program,
         vector_program=vector_reduction_program,
-        coordinate_exprs=(coordinate_exprs if vector_reduction_program else ()),
-        reduction_schedule=(reduction_schedule if vector_reduction_program else None),
+        coordinate_exprs=(
+            coordinate_exprs
+            if vector_reduction_program or cooperative_reduction_program
+            else ()
+        ),
+        reduction_schedule=(
+            reduction_schedule
+            if vector_reduction_program or cooperative_reduction_program
+            else None
+        ),
+        cooperative_reduction_program=cooperative_reduction_program,
     )
     body = _with_contiguous_1d_fast_path(
         kernel,
@@ -483,6 +529,7 @@ def _render_source(
         block_program=vector_block_program,
         native_block_program=native_block_program,
         vector_program=vector_reduction_program,
+        cooperative_reduction_program=cooperative_reduction_program,
     )
 
     context = ModuleRenderContext(
@@ -506,6 +553,7 @@ def _render_source(
             else native_block_program
         ),
         scalar_program=vector_scalar_program,
+        cooperative_reduction_program=cooperative_reduction_program,
     )
     context = target.schedule_context(context)
 
@@ -542,10 +590,11 @@ def _with_contiguous_1d_fast_path(
     block_program: bool,
     native_block_program: bool,
     vector_program: bool,
+    cooperative_reduction_program: bool,
 ) -> str:
     logical_infos = tuple(tensor_infos[tensor.name] for tensor in kernel.tensors)
 
-    if vector_program:
+    if vector_program or cooperative_reduction_program:
         return generic_body
 
     if not logical_infos or any(
@@ -666,11 +715,14 @@ def _render_body(
     vector_program: bool = False,
     coordinate_exprs: tuple[str, ...] = (),
     reduction_schedule: Mapping[str, Any] | None = None,
+    cooperative_reduction_program: bool = False,
 ) -> str:
     output = outputs[0] if outputs else "out"
     lines: list[str] = []
     enable_index_cse = (
-        not target.vector_value_semantics and outer_index_expr != inner_index_expr
+        not target.vector_value_semantics
+        and not cooperative_reduction_program
+        and outer_index_expr != inner_index_expr
     )
 
     if block_program:
@@ -747,10 +799,19 @@ def _render_body(
         layout_contiguous=layout_contiguous,
         vector_program=vector_program,
         reduction_lane="offsets" if reduction_schedule is not None else None,
+        cooperative_reduction_program=cooperative_reduction_program,
         scheduled_reductions=frozenset(
             str(result) for result in (reduction_schedule or {}).get("reductions", ())
         ),
+        reduction_schedule=reduction_schedule,
     )
+
+    if cooperative_reduction_program:
+        _emit_cooperative_reduction_program(operations, ctx)
+
+        if not ctx.lines:
+            ctx.lines.append("/* no-op */")
+        return "\n".join(ctx.lines)
 
     for op in operations:
         if _is_top_level_effect(op):
@@ -759,6 +820,104 @@ def _render_body(
     if not ctx.lines:
         ctx.lines.append("pass" if not target.c_style_syntax else "/* no-op */")
     return "\n".join(ctx.lines)
+
+
+def _emit_cooperative_reduction_program(
+    operations: tuple[ssa.Operation, ...], ctx: _EmitContext
+) -> None:
+    schedule = dict(ctx.reduction_schedule or {})
+    value_shape = tuple(str(dim) for dim in schedule.get("value_shape", ()))
+    result_shape = tuple(str(dim) for dim in schedule.get("result_shape", ()))
+    axis = int(schedule["axis"]) if "axis" in schedule else None
+
+    if axis is None or not value_shape:
+        raise ValueError("Cooperative reduction requires a row-vector domain.")
+
+    for result in schedule.get("reductions", ()):
+        _emit_value(str(result), ctx)
+
+    for operation in operations:
+        if not _is_top_level_effect(operation):
+            continue
+
+        if operation.opcode != "mem.store":
+            raise ValueError(
+                "Cooperative reduction only supports SSA programs whose "
+                "top-level effects are stores."
+            )
+
+        value_axes = _value_axes(operation.operands[0], ctx)
+
+        if value_axes == value_shape:
+            _emit_cooperative_full_store(operation, value_shape, axis, ctx)
+        elif value_axes == result_shape:
+            _emit_cooperative_scalar_store(operation, result_shape, axis, ctx)
+        else:
+            raise ValueError(
+                "Cooperative reduction store domain must match either the "
+                "reduction input or result domain."
+            )
+
+
+def _emit_cooperative_full_store(
+    operation: ssa.Operation,
+    value_shape: tuple[str, ...],
+    axis: int,
+    ctx: _EmitContext,
+) -> None:
+    lane = _fresh_temp(ctx, "nt_lane")
+    coordinates = list(ctx.coordinate_exprs)
+    coordinates[axis] = lane
+    coordinates = tuple(coordinates)
+    linear = _target_index_expr(ctx.target, _linearized_index(coordinates, value_shape))
+    body_lines: list[str] = []
+    body = ctx.child(
+        lines=body_lines,
+        memo=dict(ctx.memo),
+        coordinate_exprs=coordinates,
+        index_expr=linear,
+        inner_index_expr=linear,
+        row_expr=coordinates[0] if coordinates else None,
+        col_expr=coordinates[1] if len(coordinates) > 1 else None,
+        local_suffix=_nested_local_suffix(ctx, lane),
+    )
+    _emit_operation(operation, body)
+    ctx.lines.append(
+        ctx.target.loop_header(
+            lane,
+            ctx.target.thread_id(),
+            value_shape[axis],
+            ctx.target.thread_count(),
+        )
+    )
+    ctx.lines.extend(_indent_lines(body_lines, ctx.target))
+    ctx.lines.append("}")
+
+
+def _emit_cooperative_scalar_store(
+    operation: ssa.Operation,
+    result_shape: tuple[str, ...],
+    axis: int,
+    ctx: _EmitContext,
+) -> None:
+    coordinates = tuple(
+        coordinate for dim, coordinate in enumerate(ctx.coordinate_exprs) if dim != axis
+    )
+    linear = _target_index_expr(
+        ctx.target, _linearized_index(coordinates, result_shape)
+    )
+    body_lines: list[str] = []
+    body = ctx.child(
+        lines=body_lines,
+        memo=dict(ctx.memo),
+        index_expr=linear,
+        inner_index_expr=linear,
+        local_suffix=_nested_local_suffix(ctx, "reduced_store"),
+    )
+    _emit_operation(operation, body)
+    ctx.lines.append(f"if ({ctx.target.thread_id()} == 0) {{")
+    ctx.lines.extend(_indent_lines(body_lines, ctx.target))
+    ctx.lines.append("}")
 
 
 def _is_top_level_effect(op: ssa.Operation) -> bool:
@@ -946,6 +1105,19 @@ def _emit_value(name: str, ctx: _EmitContext) -> str:
             ctx.memo[name] = operand
 
             return operand
+
+        if ctx.cooperative_reduction_program and name in ctx.scheduled_reductions:
+            result = ctx.target.emit_cooperative_reduction(local, op, ctx)
+
+            if result is None:
+                raise ValueError(
+                    f"Backend `{ctx.target.backend.value}` selected cooperative "
+                    f"reduction but did not consume `{name}`."
+                )
+
+            ctx.memo[name] = result
+
+            return result
 
         if ctx.vector_program and name in ctx.scheduled_reductions:
             operator = op.opcode[len("reduce.") :]
@@ -1473,7 +1645,7 @@ def _emit_element(name: str, coords: tuple[str, ...], ctx: _EmitContext) -> str:
         )
 
     if op.opcode.startswith("reduce."):
-        if ctx.block_program or ctx.vector_program:
+        if ctx.block_program or ctx.vector_program or ctx.cooperative_reduction_program:
             return _emit_value(name, ctx)
         return _emit_reduce_element(op, coords, ctx)
 
@@ -1958,9 +2130,11 @@ def _current_coords(axes: tuple[str, ...], ctx: _EmitContext) -> tuple[str, ...]
             _axis_offset_expr(output_axes, dim, ctx.inner_index_expr, ctx.target)
             for dim in range(len(output_axes))
         )
-        vector_reduction_axis = (
+        scheduled_reduction_axis = (
             output_coords.index(ctx.reduction_lane)
             if ctx.vector_program and ctx.reduction_lane in output_coords
+            else int(ctx.reduction_schedule["axis"])
+            if ctx.cooperative_reduction_program and ctx.reduction_schedule is not None
             else None
         )
         coords: tuple[str, ...] | None = None
@@ -1970,11 +2144,11 @@ def _current_coords(axes: tuple[str, ...], ctx: _EmitContext) -> tuple[str, ...]
                 "0" if axis == "1" else output_coords[index]
                 for index, axis in enumerate(axes)
             )
-        elif vector_reduction_axis is not None and len(axes) == len(output_axes) - 1:
+        elif scheduled_reduction_axis is not None and len(axes) == len(output_axes) - 1:
             parallel_dims = tuple(
                 index
                 for index in range(len(output_axes))
-                if index != vector_reduction_axis
+                if index != scheduled_reduction_axis
             )
 
             if axes == tuple(output_axes[index] for index in parallel_dims):
@@ -3808,6 +3982,7 @@ emit_element = _emit_element
 emit_loop_bound = _emit_loop_bound
 emit_operation = _emit_operation
 emit_value = _emit_value
+fresh_temp = _fresh_temp
 indent_block = _indent_block
 indent_lines = _indent_lines
 linearized_index = _linearized_index
@@ -3816,8 +3991,10 @@ local_symbol = _local_symbol
 logical_ssa_audit = _logical_ssa_audit
 materialize_bool_expr = _materialize_bool_expr
 materialize_index_expr = _materialize_index_expr
+nested_local_suffix = _nested_local_suffix
 normalize_dtype = _normalize_dtype
 product = _product
+reduction_identity = _reduction_identity
 resolved_dot_operand_dtype = _resolved_dot_operand_dtype
 rewrite_index_math = _rewrite_index_math
 schedule_int = _schedule_int
@@ -3841,6 +4018,7 @@ __all__ = [
     "emit_loop_bound",
     "emit_operation",
     "emit_value",
+    "fresh_temp",
     "indent_block",
     "indent_lines",
     "linearized_index",
@@ -3849,8 +4027,10 @@ __all__ = [
     "logical_ssa_audit",
     "materialize_bool_expr",
     "materialize_index_expr",
+    "nested_local_suffix",
     "normalize_dtype",
     "product",
+    "reduction_identity",
     "resolved_dot_operand_dtype",
     "rewrite_index_math",
     "schedule_int",

--- a/src/ninetoothed/compiler/driver.py
+++ b/src/ninetoothed/compiler/driver.py
@@ -295,6 +295,7 @@ def _compile_kernel(request: CompileRequest) -> Compilation:
             "ssa_ir_source": "application_ast",
             "ssa_tensor_ir_source": "arrangement_views",
             "runtime_shape_params": _runtime_shape_params(specs),
+            "specialization_values": specialization_values,
             "generation_py_fallback": False,
             "meta_defaults": meta_defaults,
         },

--- a/src/ninetoothed/compiler/specialization.py
+++ b/src/ninetoothed/compiler/specialization.py
@@ -50,18 +50,21 @@ def scheduled_meta_defaults(
 
 
 def specialize_schedule_tiles(kernel: Kernel) -> Kernel:
-    """Materialize deterministic backend tile choices before source emission."""
+    """Materialize runtime symbols and backend tile choices before emission."""
     if kernel.ssa is None:
         return kernel
 
     schedule = dict(kernel.ssa.metadata.get("schedule", {}))
     defaults = dict(kernel.metadata.get("meta_defaults", {}))
     tile = dict(schedule.get("tile", {}))
-    values = {
-        name: int(tile[schedule_name])
-        for name in defaults
-        if (schedule_name := _schedule_tile_name(name)) in tile
-    }
+    values = dict(kernel.metadata.get("specialization_values", {}))
+    values.update(
+        {
+            name: int(tile[schedule_name])
+            for name in defaults
+            if (schedule_name := _schedule_tile_name(name)) in tile
+        }
+    )
 
     if not values:
         return kernel

--- a/tests/test_cuda_reduction_schedule.py
+++ b/tests/test_cuda_reduction_schedule.py
@@ -1,0 +1,219 @@
+import re
+from pathlib import Path
+
+import pytest
+import torch
+
+import ninetoothed.language as ntl
+from ninetoothed import Tensor, bfloat16, float16, float32
+from ninetoothed.backends.core import Target
+from ninetoothed.backends.cuda import CudaOptimizeSchedule
+from ninetoothed.compiler import (
+    DEFAULT_COMPILER,
+    CompileRequest,
+    load_built_artifact,
+    make,
+)
+from ninetoothed.compiler.passes import Context
+from tests import test_triton_reduction_schedule as reduction
+
+
+def _row_sum(x, out):
+    out = ntl.sum(x, axis=1)  # noqa: F841
+
+
+def _row_atomic_arrangement(x, out, total, WIDTH=reduction.WIDTH):
+    x = x.tile((1, WIDTH))
+
+    return x, out.tile((1,)), total.tile((-1,)).expand(x.shape)
+
+
+def _row_sum_with_atomic(x, out, total):
+    out = ntl.sum(x, axis=1)  # noqa: F841
+    ntl.atomic_add(total.source.data_ptr(), 1.0)
+
+
+def _candidate_names(extent):
+    candidates = CudaOptimizeSchedule().schedule_candidates(
+        {},
+        {
+            "granularity": "parallel-reduction",
+            "reduction": {"mode": "row-vector", "extent": extent},
+        },
+        Context(backend=Target.CUDA, compiler_options={}, kernel_metadata={}),
+    )
+
+    return tuple(candidate.name for candidate in candidates)
+
+
+def test_cuda_cooperative_reduction_schedule_and_source():
+    assert _candidate_names(31)[0] == "cooperative-reduction-32"
+    assert _candidate_names(127)[0] == "cooperative-reduction-128"
+    assert _candidate_names(781)[0] == "cooperative-reduction-256"
+
+    compilation = DEFAULT_COMPILER.compile(
+        CompileRequest(
+            arrangement=reduction._row_arrangement,
+            application=reduction._row_normalize,
+            tensors=(Tensor(2), Tensor(2)),
+            backend="cuda",
+            max_num_configs=1,
+            pass_options={
+                "ssa.cuda.optimize_schedule": {"candidate": "cooperative-reduction-128"}
+            },
+        )
+    )
+    source = compilation.artifact.primary_source
+    schedule = compilation.artifact.metadata["ssa_schedule"]
+
+    assert schedule["cuda_cooperative_reduction"] is True
+    assert schedule["threads"] == 128
+    assert tuple(value.render() for value in compilation.launch_plan.block) == ("128",)
+    assert "__shfl_down_sync" in source
+    assert "__shared__ float" in source
+    assert "__syncthreads()" in source
+    assert "static_cast<int64_t>(threadIdx.x)" in source
+    assert "+= static_cast<int64_t>(blockDim.x)" in source
+    assert "blocks =" in source
+    assert "(WIDTH + threads - 1) / threads" not in source
+
+    assert not re.search(r"\bv\d+_elem\b", source)
+
+    fallback = DEFAULT_COMPILER.compile(
+        CompileRequest(
+            arrangement=reduction._row_arrangement,
+            application=reduction._row_normalize,
+            tensors=(Tensor(2), Tensor(2)),
+            backend="cuda",
+            max_num_configs=1,
+            pass_options={"ssa.cuda.optimize_schedule": {"schedule": {"threads": 48}}},
+        )
+    )
+    fallback_schedule = fallback.artifact.metadata["ssa_schedule"]
+    assert fallback_schedule["cuda_cooperative_reduction"] is True
+    assert fallback_schedule["threads"] == 48
+    assert "__shfl_down_sync" not in fallback.artifact.primary_source
+
+    effect_fallback = DEFAULT_COMPILER.compile(
+        CompileRequest(
+            arrangement=_row_atomic_arrangement,
+            application=_row_sum_with_atomic,
+            tensors=(Tensor(2), Tensor(1), Tensor(1)),
+            backend="cuda",
+            max_num_configs=1,
+        )
+    )
+    assert (
+        effect_fallback.artifact.metadata["ssa_schedule"]["cuda_cooperative_reduction"]
+        is True
+    )
+    assert "__shfl_down_sync" not in effect_fallback.artifact.primary_source
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_cuda_cooperative_reduction_runtime():
+    device = "cuda"
+    reduce_min = make(
+        reduction._row_reduced_arrangement,
+        reduction._row_min,
+        (Tensor(2, dtype=float32), Tensor(1, dtype=float32)),
+        backend="cuda",
+        max_num_configs=1,
+    )
+    normalize = make(
+        reduction._row_arrangement,
+        reduction._row_normalize,
+        (Tensor(2, dtype=float16), Tensor(2, dtype=float16)),
+        backend="cuda",
+        max_num_configs=1,
+    )
+    layernorm = make(
+        reduction._row_arrangement,
+        reduction._row_layernorm,
+        (Tensor(2, dtype=bfloat16), Tensor(2, dtype=bfloat16)),
+        backend="cuda",
+        max_num_configs=1,
+    )
+    reduce_sum = make(
+        reduction._row_reduced_arrangement,
+        _row_sum,
+        (Tensor(2, dtype=float32), Tensor(1, dtype=float32)),
+        backend="cuda",
+        max_num_configs=1,
+    )
+    column_max = make(
+        reduction._column_arrangement,
+        reduction._column_max_broadcast,
+        (Tensor(2, dtype=float32), Tensor(2, dtype=float32)),
+        backend="cuda",
+        max_num_configs=1,
+    )
+
+    base = torch.randn((37, 254), device=device)
+    x = base[:, ::2]
+    output = torch.empty((37,), device=device)
+    reduce_min(x, output, WIDTH=127)
+    torch.testing.assert_close(output, x.min(dim=1).values)
+
+    x = torch.randn((41, 781), device=device, dtype=torch.float16)
+    output = torch.empty_like(x)
+    normalize(x, output, WIDTH=781)
+    torch.testing.assert_close(output, torch.softmax(x, dim=1), rtol=2e-3, atol=2e-3)
+
+    x = torch.randn((29, 1127), device=device, dtype=torch.bfloat16)
+    output = torch.empty_like(x)
+    layernorm(x, output, WIDTH=1127)
+    torch.testing.assert_close(
+        output,
+        torch.nn.functional.layer_norm(x, (1127,)),
+        rtol=2e-2,
+        atol=2e-2,
+    )
+
+    x = torch.randn((17, 4097), device=device)
+    output = torch.empty((17,), device=device)
+    reduce_sum(x, output, WIDTH=4097)
+    torch.testing.assert_close(output, x.sum(dim=1), rtol=1e-4, atol=1e-4)
+
+    x = torch.randn((193, 41), device=device)
+    output = torch.empty_like(x)
+    column_max(x, output, HEIGHT=193)
+    torch.testing.assert_close(output, x + x.max(dim=0).values)
+
+    x = torch.empty((0, 127), device=device, dtype=torch.float16)
+    output = torch.empty_like(x)
+    normalize(x, output, WIDTH=127)
+    assert output.numel() == 0
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_cuda_cooperative_reduction_aot_reload(tmp_path):
+    device = "cuda"
+    tensors = (
+        Tensor(shape=(37, 127), dtype=float32),
+        Tensor(shape=(37,), dtype=float32),
+    )
+    compilation = DEFAULT_COMPILER.compile(
+        CompileRequest(
+            arrangement=reduction._fixed_row_reduced_arrangement,
+            application=reduction._row_min,
+            tensors=tensors,
+            backend="cuda",
+            kernel_name="cuda_cooperative_row_min",
+            max_num_configs=1,
+        )
+    )
+    handle = DEFAULT_COMPILER.materialize(
+        compilation,
+        output_dir=tmp_path,
+        mode="aot",
+    )
+    x = torch.randn((37, 127), device=device)
+
+    for launch in (handle, load_built_artifact(handle._built_artifact)):
+        output = torch.empty((37,), device=device)
+        launch(x, output)
+        torch.testing.assert_close(output, x.min(dim=1).values)
+
+    assert Path(handle._built_artifact.binary_path).is_file()
+    assert "__shfl_down_sync" in compilation.artifact.primary_source

--- a/tests/test_ssa_first_backend_lowering.py
+++ b/tests/test_ssa_first_backend_lowering.py
@@ -1125,7 +1125,7 @@ def scalarized_index_application(x, indices, y):
             "triton": ("ssa-unified-triton-emitter", "tl.sum("),
             "cuda": (
                 "ssa-unified-cuda-emitter",
-                "a[(index) * (cols) + (v1_i)] * x[v1_i]",
+                "__shfl_down_sync",
             ),
             "tilelang": ("ssa-unified-tilelang-emitter", "for v1_i in T.serial(cols):"),
         }


### PR DESCRIPTION
`pytest` output:

```
$ PYTHONPATH="$PWD/src" pytest -n 16
========================================================= test session starts =========================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/haojie/ntbackend/.merge-ready/cuda-cooperative-row-reduction
configfile: pyproject.tomlplugins: xdist-3.8.0, anyio-4.13.0, cov-7.1.0
16 workers [416 items]    
............................................................................................................................... [ 30%]
...........................................................................................................................s... [ 61%]
........................................................................................................s...................... [ 91%]
...................................                                                                                             [100%]
============================================= 414 passed, 2 skipped in 131.66s (0:02:11) ==============================================
```

## 修改说明

CUDA 后端此前使用逐输出元素的串行循环执行单轴归约。对于较长的归约轴，每个线程都需要独立遍历完整输入，导致大量重复读取和计算。

这一问题对以下计算影响明显：

- row sum、row max、row min；
- reduction 结果参与后续广播计算的场景；
- 包含多次归约的数据流，例如 Softmax 和 LayerNorm。

此外，复杂归约表达式在生成 CUDA 代码时可能产生重复的局部变量名，导致 LayerNorm 无法通过 NVCC 编译。

本次修改在已有 `ReductionDomain` 分析基础上，为 CUDA 增加 CTA 协作式单轴归约调度。

---

## 主要修改

### 1. 增加 CUDA row-vector reduction 调度

`CudaOptimizeSchedule` 根据 `ReductionDomain` 中的归约模式和 extent 生成协作式归约候选。

默认线程配置为：

| Reduction extent | 首选线程数 | 备用候选 |
|---:|---:|---|
| `<= 32` | 32 | 128、256 |
| `<= 128` | 128 | 256、32 |
| 其他或动态 extent | 256 | 128、32 |

选中的配置写入 schedule：

```python
{
    "cuda_cooperative_reduction": True,
    "threads": threads,
}
```

线程数必须满足：

```text
32 <= threads <= 256
threads % 32 == 0
```

不满足约束的配置继续使用原有 CUDA 生成路径。

---

### 2. 扩展共享 SSA emitter 接口

共享 emitter 增加了协作式归约所需的最小后端接口：

- 判断当前 schedule 是否支持协作式归约；
- 获取 thread ID；
- 获取 block thread count；
- 生成后端归约代码。

共享层负责组织计算域和执行顺序：

1. 计算 outer/program domain；
2. 计算 parallel domain 坐标；
3. 按 SSA 顺序生成归约结果；
4. 为完整 shape 输出生成 thread-stride store；
5. 为 reduced shape 输出生成单线程 store。

CUDA emitter 负责具体的 shuffle、shared memory 和同步指令。

---

### 3. 实现两级 CUDA 协作式归约

每个 CTA 处理一个 parallel-domain 实例。

首先，每个线程以 `blockDim.x` 为步长遍历归约轴：

```cpp
for (
    int64_t index = threadIdx.x;
    index < reduction_extent;
    index += blockDim.x
) {
    accumulator = reduce(accumulator, input[index]);
}
```

线程局部归约完成后，执行两级归约：

1. 使用 `__shfl_down_sync` 完成 warp 内归约；
2. 每个 warp 将 partial result 写入 shared memory；
3. 第一个 warp 对所有 partial result 再次归约；
4. 通过 barrier 将最终结果发布给整个 CTA。

生成代码的核心结构为：

```cpp
for (int offset = 16; offset > 0; offset >>= 1) {
    accumulator = reduce(
        accumulator,
        __shfl_down_sync(0xffffffffu, accumulator, offset)
    );
}

__shared__ float partials[8];

if ((threadIdx.x & 31) == 0) {
    partials[threadIdx.x >> 5] = accumulator;
}

__syncthreads();
```

固定的 `partials[8]` 可以覆盖最多 256 个线程产生的 8 个 warp partial。

---

### 4. 支持 sum、max 和 min

当前协作式路径支持：

- `reduce.sum`
- `reduce.max`
- `reduce.min`

每种归约使用对应的 identity 和 update 表达式。

低精度输入使用 FP32 accumulator：

| 输入类型 | Accumulator |
|---|---|
| FP8 | FP32 |
| FP16 | FP32 |
| BF16 | FP32 |
| FP32 | FP32 |
| FP64 | FP64 |

这样可以降低长归约轴上的累计误差。

---

### 5. 支持归约后的广播与逐元素计算

归约结果仍然是普通 SSA value，可以继续参与后续算术、数学函数和广播计算。

例如 Softmax 数据流：

```text
max
 -> subtract
 -> exp
 -> sum
 -> divide
 -> store
```

以及 LayerNorm 数据流：

```text
sum / square-sum
 -> mean / variance
 -> normalize
 -> store
```

多个归约按照 SSA 依赖顺序生成。后一级归约可以使用前一级归约的结果，barrier 保证结果在 CTA 内可见。

---

### 6. 分别处理完整输出和归约输出

对于与输入具有相同 shape 的输出，所有线程共同写回：

```cpp
for (
    int64_t lane = threadIdx.x;
    lane < reduction_extent;
    lane += blockDim.x
) {
    output[lane] = value;
}
```

对于删除归约轴后的输出，只由 thread 0 写回：

```cpp
if (threadIdx.x == 0) {
    reduced_output[index] = reduction_result;
}
```

因此同一套生成逻辑可以处理：

- 只输出 reduction result；
- reduction result 广播回原 shape；
- 同时输出完整结果和 reduced result。

---

### 7. 增加协作路径的适用性检查

启用协作式归约前会检查顶层 effect 和输出 domain。

当前支持：

- 顶层 effect 为普通 `mem.store`；
- stored value 属于 reduction input domain；
- 或 stored value 属于 reduction result domain。

以下情况继续使用原有 CUDA 路径：

- atomic operation；
- 输出 domain 与归约域不兼容；
- 无法统一的顶层 effect；
- 非 row-vector reduction；
- 非法线程配置。

这样可以保证调度选择与最终 emitter 能力保持一致。

---

### 8. 修复归约代码中的局部变量重名

复杂归约表达式可能在不同循环作用域中生成相同的局部变量名，例如：

```cpp
v_elem
```

LayerNorm 数据流会因此出现重复声明并导致 NVCC 编译失败。

修改后，以下临时变量统一通过 `_fresh_temp()` 分配：

- thread-local accumulator；
- reduction index；
- shuffle offset；
- shared partial；
- 嵌套逐元素表达式。

嵌套 emission scope 同时使用独立的 local suffix，确保生成的 CUDA 标识符唯一。

---

### 9. 修正调度后的动态 specialization

动态 shape 在 frontend 阶段完成首次 specialization，而 CUDA thread schedule 在后续 pass 中确定。

此前两者之间缺少一次统一更新，可能出现：

- kernel body 使用已经特化的 shape；
- launch metadata 仍保留旧的符号表达式。

现在会在 backend schedule 确定后，将运行时 specialization value 和 schedule tile value统一应用到最终 SSA：

```text
runtime specialization
+ backend schedule values
-> specialized SSA metadata
-> CUDA source
-> LaunchPlan
```

动态 shape、launch grid 和生成代码因此使用同一组最终参数。

---

## 编译流程

修改后的 CUDA reduction 编译路径为：

```text
NineToothed Python
    -> SSA / Layout IR
    -> ReductionDomain analysis
    -> schedule selection
    -> CudaOptimizeSchedule
    -> shared SSA emitter
    -> CUDA cooperative reduction emission
    -> NVCC
    -> LaunchPlan
```

---

## 性能结果

### 测试环境

- GPU：NVIDIA L20
- 对比基线：PR #210 head `d2e778ac98df2899944fdef3abefe047303e1223`

表中延迟越低越好，Speedup 大于 `1.0×` 表示优化后更快。

### Row Sum

| Shape | PR #210 | 优化后 | Speedup |
|---|---:|---:|---:|
| 4096 × 128 | 24.739 μs | 25.161 μs | 0.98× |
| 8192 × 1024 | 188.029 μs | 46.624 μs | 4.03× |
| 2048 × 4096 | 420.302 μs | 47.309 μs | 8.88× |

三个规模的端到端几何平均提升约 `3.28×`。

`4096 × 128` 为启动开销占比较高的小规模场景，延迟变化约 `1.7%`。

### Softmax 优化效果

| Shape | PR #210 | 优化后 | Speedup |
|---|---:|---:|---:|
| 4096 × 128 | 130.161 μs | 26.393 μs | 4.93× |
| 8192 × 1024 | 14700.067 μs | 113.612 μs | 129.39× |
| 2048 × 4096 | 58332.458 μs | 112.792 μs | 517.16× |

### LayerNorm 优化效果

| Shape | PR #210 | 优化后 |
|---|---|---:|
| 4096 × 128 | NVCC 编译失败 | 26.293 μs |
| 8192 × 1024 | NVCC 编译失败 | 112.664 μs |
| 2048 × 4096 | NVCC 编译失败 | 115.926 μs |

LayerNorm 在修复局部变量重名后已经可以正常编译和执行。

---

## 当前能力边界

以下优化待后续 PR 加入：

- CUDA runtime autotuning；
- hierarchical multi-CTA reduction；
- 跨 reduction global-load CSE；
- shared-memory input promotion；
- async copy；
- `prod/mean/any/all` 的协作式归约；
- Triton 和 TileLang 的对应调度调整。

其他 reduction 和不满足 row-vector 条件的程序继续使用现有生成路径。
